### PR TITLE
Fix ubuntu iso url for ubuntu 12.04.1

### DIFF
--- a/definitions/ubuntu-12.04-i386/definition.rb
+++ b/definitions/ubuntu-12.04-i386/definition.rb
@@ -1,6 +1,6 @@
 require File.dirname(__FILE__) + "/../.ubuntu/session.rb"
 
-iso = "ubuntu-12.04-server-i386.iso"
+iso = "ubuntu-12.04.1-server-i386.iso"
 
 session =
   UBUNTU_SESSION.merge( :iso_file => iso,

--- a/definitions/ubuntu-12.04/definition.rb
+++ b/definitions/ubuntu-12.04/definition.rb
@@ -1,6 +1,6 @@
 require File.dirname(__FILE__) + "/../.ubuntu/session.rb"
 
-iso = "ubuntu-12.04-server-amd64.iso"
+iso = "ubuntu-12.04.1-server-amd64.iso"
 
 session =
   UBUNTU_SESSION.merge( :iso_file => iso,


### PR DESCRIPTION
Change in the iso name of ubuntu 12.04 definitions file (x86 and amd64), the new version came out in August 23 2012.
