### PR TITLE
[BENTO-5] added nfs client support for the box so that vagrant nfs shares work

### DIFF
--- a/definitions/.centos/ks.cfg
+++ b/definitions/.centos/ks.cfg
@@ -37,3 +37,4 @@ echo "vagrant" | passwd --stdin vagrant
 # sudo
 echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+yum -y install nfs-utils nfs-utils-lib


### PR DESCRIPTION
This enables using the vagrant box config to make nfs shares, see http://vagrantup.com/v1/docs/nfs.html
