### PR TITLE
[BENTO-2] Update Ubuntu iso filenames, md5sums.

### DIFF
--- a/definitions/ubuntu-12.04-i386/definition.rb
+++ b/definitions/ubuntu-12.04-i386/definition.rb
@@ -1,11 +1,11 @@
 require File.dirname(__FILE__) + "/../.ubuntu/session.rb"
 
-iso = "ubuntu-12.04-server-i386.iso"
+iso = "ubuntu-12.04.1-server-i386.iso"
 
 session =
   UBUNTU_SESSION.merge( :os_type_id => 'Ubuntu',
                         :iso_file => iso,
-                        :iso_md5 => "32184a83c8b5e6031e1264e5c499bc03",
+                        :iso_md5 => "3daaa312833a7da1e85e2a02787e4b66",
                         :iso_src => "http://releases.ubuntu.com/12.04/#{iso}" )
 
 Veewee::Session.declare session

--- a/definitions/ubuntu-12.04/definition.rb
+++ b/definitions/ubuntu-12.04/definition.rb
@@ -1,10 +1,10 @@
 require File.dirname(__FILE__) + "/../.ubuntu/session.rb"
 
-iso = "ubuntu-12.04-server-amd64.iso"
+iso = "ubuntu-12.04.1-server-amd64.iso"
 
 session =
   UBUNTU_SESSION.merge( :iso_file => iso,
-                        :iso_md5 => "f2e921788d35bbdf0336d05d228136eb",
+                        :iso_md5 => "a8c667e871f48f3a662f3fbf1c3ddb17",
                         :iso_src => "http://releases.ubuntu.com/12.04/#{iso}" )
 
 Veewee::Session.declare session


### PR DESCRIPTION
Update Ubuntu iso filenames, md5sums for 12.04.1. (fixes 404 when building basebox)
