### PR TITLE
Add nfs-common package to the Ubuntu and Debian definitions

### DIFF
--- a/definitions/.debian/preseed.cfg
+++ b/definitions/.debian/preseed.cfg
@@ -28,7 +28,7 @@ d-i passwd/user-uid string 900
 d-i passwd/user-password password vagrant
 d-i passwd/user-password-again password vagrant
 d-i passwd/username string vagrant
-d-i pkgsel/include string openssh-server sudo bzip2 acpid cryptsetup zlib1g-dev wget curl
+d-i pkgsel/include string openssh-server sudo bzip2 acpid cryptsetup zlib1g-dev wget curl nfs-common
 d-i pkgsel/install-language-support boolean false
 d-i pkgsel/update-policy select unattended-upgrades
 d-i pkgsel/upgrade select full-upgrade

--- a/definitions/.ubuntu/preseed.cfg
+++ b/definitions/.ubuntu/preseed.cfg
@@ -21,7 +21,7 @@ d-i passwd/user-uid string 900
 d-i passwd/user-password password vagrant
 d-i passwd/user-password-again password vagrant
 d-i passwd/username string vagrant
-d-i pkgsel/include string openssh-server cryptsetup build-essential libssl-dev libreadline-dev zlib1g-dev linux-source dkms
+d-i pkgsel/include string openssh-server cryptsetup build-essential libssl-dev libreadline-dev zlib1g-dev linux-source dkms nfs-common
 d-i pkgsel/install-language-support boolean false
 d-i pkgsel/update-policy select unattended-upgrades
 d-i pkgsel/upgrade select full-upgrade


### PR DESCRIPTION
I like the Opscode boxes and I use them a lot, but I've had troubles lately because for some projects I need better shared directories' perfomance. With the NFS shared disrectories it is much better but the Opscode boxes (unlike the original Veewee ones) miss of the nfs client.

I've noticed that there is already a ticket for this, [BENTO-5](http://tickets.opscode.com/browse/BENTO-5), but the pull-request just cover the CENTOS boxes. This will cover the Debian and Ubuntu ones.

I would love to see this merged too.

Thanks
