### PR TITLE
[BENTO-21] Sudo preserves SSH_AUTH_SOCK on Debian and Ubuntu

### DIFF
--- a/definitions/.debian/sudoers.sh
+++ b/definitions/.debian/sudoers.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -eux
 
 sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=sudo' /etc/sudoers
+sed -i -e '/Defaults\s\+exempt_group/a Defaults\tenv_keep += "SSH_AUTH_SOCK"' /etc/sudoers
 sed -i -e 's/%sudo ALL=(ALL) ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers

--- a/definitions/.ubuntu/sudoers.sh
+++ b/definitions/.ubuntu/sudoers.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -eux
 
 sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=admin' /etc/sudoers
+sed -i -e '/Defaults\s\+exempt_group/a Defaults\tenv_keep += "SSH_AUTH_SOCK"' /etc/sudoers
 sed -i -e 's/%admin ALL=(ALL) ALL/%admin ALL=NOPASSWD:ALL/g' /etc/sudoers


### PR DESCRIPTION
This is a fix for http://tickets.opscode.com/browse/BENTO-21
