### PR TITLE
Fix 404 when downloading Ubuntu 12.04 ISO

### DIFF
--- a/definitions/ubuntu-12.04/definition.rb
+++ b/definitions/ubuntu-12.04/definition.rb
@@ -1,10 +1,10 @@
 require File.dirname(__FILE__) + "/../.ubuntu/session.rb"
 
-iso = "ubuntu-12.04.1-server-amd64.iso"
+iso = "ubuntu-12.04.2-server-amd64.iso"
 
 session =
   UBUNTU_SESSION.merge( :iso_file => iso,
-                        :iso_md5 => "a8c667e871f48f3a662f3fbf1c3ddb17",
+                        :iso_md5 => "af5f788aee1b32c4b2634734309cc9e9",
                         :iso_src => "http://releases.ubuntu.com/12.04/#{iso}" )
 
 Veewee::Session.declare session


### PR DESCRIPTION
12.04.1 has been taken out of the FTP server, replacing with the newer 12.04.2.
