### PR TITLE
[BENTO-24] "#" is not a valid comment character for Windows batch files

### DIFF
--- a/definitions/.windows/install-vbox.bat
+++ b/definitions/.windows/install-vbox.bat
@@ -1,5 +1,5 @@
-# with this, we can open the iso, and extract the VBoxWindowsAdditions.exe!
-# http://downloads.sourceforge.net/sevenzip/7z920.exe
+REM with this, we can open the iso, and extract the VBoxWindowsAdditions.exe!
+REM http://downloads.sourceforge.net/sevenzip/7z920.exe
 cmd /c certutil -addstore -f "TrustedPublisher" a:oracle-cert.cer
 cmd /c e:\VBoxWindowsAdditions-amd64.exe /S
 cmd /c shutdown.exe /r /t 0 /d p:2:4 /c "Vagrant reboot for VBoxWindowsAdditions"

--- a/definitions/.windows/mount-validation.bat
+++ b/definitions/.windows/mount-validation.bat
@@ -1,3 +1,3 @@
-# This is so we can pass the validation test
+REM This is so we can pass the validation test
 cmd /c net use z: \\vboxsrv\veewee-validation
 


### PR DESCRIPTION
Use "REM" to avoid (admittedly harmless) errors.
