### PR TITLE
Added defs for CentOS 5.9 and 6.4 boxes. Bugfix CentOS 5.8 x86_64 box.

### DIFF
--- a/definitions/centos-5.8/definition.rb
+++ b/definitions/centos-5.8/definition.rb
@@ -3,7 +3,7 @@ require File.dirname(__FILE__) + "/../.centos/session.rb"
 iso = "CentOS-5.8-x86_64-bin-DVD-1of2.iso"
 
 session =
-  CENTOS_SESSION.merge({ :os_type_id => 'RedHat',
+  CENTOS_SESSION.merge({ :os_type_id => 'RedHat_64',
                          :iso_file => iso,
                          :iso_md5 => "8a3bf0030f192022943f83fe6b2cf373",
                          :iso_src => "http://mirror.stanford.edu/yum/pub/centos/5.8/isos/x86_64/#{iso}" })

--- a/definitions/centos-5.9-i386/chef-client.sh
+++ b/definitions/centos-5.9-i386/chef-client.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -eux
+
+wget -O - http://opscode.com/chef/install.sh | sudo bash

--- a/definitions/centos-5.9-i386/cleanup.sh
+++ b/definitions/centos-5.9-i386/cleanup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -eux
+yum -y erase gtk2 libX11 hicolor-icon-theme avahi freetype bitstream-vera-fonts
+yum -y clean all
+rm -rf VBoxGuestAdditions_*.iso VBoxGuestAdditions_*.iso.?
+rm -f /tmp/chef*rpm

--- a/definitions/centos-5.9-i386/definition.rb
+++ b/definitions/centos-5.9-i386/definition.rb
@@ -1,0 +1,11 @@
+require File.dirname(__FILE__) + "/../.centos/session.rb"
+
+iso = "CentOS-5.9-i386-bin-DVD-1of2.iso"
+
+session =
+  CENTOS_SESSION.merge({ :os_type_id => 'RedHat',
+                         :iso_file => iso,
+                         :iso_md5 => "c8caaa18400dfde2065d8ef58eb9e9bf",
+                         :iso_src => "http://mirror.stanford.edu/yum/pub/centos/5.9/isos/i386/#{iso}" })
+
+Veewee::Session.declare session

--- a/definitions/centos-5.9-i386/ks.cfg
+++ b/definitions/centos-5.9-i386/ks.cfg
@@ -1,0 +1,39 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw --iscrypted $1$damlkd,f$UC/u5pUts5QiU3ow.CSso/
+firewall --disabled
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+text
+skipx
+zerombr
+clearpart --all --initlabel
+autopart
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot
+
+%packages --ignoremissing
+@Base
+@Core
+@Development Tools
+openssl-devel
+readline-devel
+zlib-devel
+kernel-devel
+
+%post
+# update root certs
+wget -O/etc/pki/tls/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem
+# vagrant
+groupadd vagrant -g 999
+useradd vagrant -g vagrant -G wheel -u 900
+echo "vagrant" | passwd --stdin vagrant
+# sudo
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers

--- a/definitions/centos-5.9-i386/minimize.sh
+++ b/definitions/centos-5.9-i386/minimize.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -eux
+
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY

--- a/definitions/centos-5.9-i386/vagrant.sh
+++ b/definitions/centos-5.9-i386/vagrant.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -eux
+
+mkdir /tmp/vbox
+VER=$(cat /home/vagrant/.vbox_version)
+wget http://download.virtualbox.org/virtualbox/$VER/VBoxGuestAdditions_$VER.iso
+mount -o loop VBoxGuestAdditions_$VER.iso /tmp/vbox
+sh /tmp/vbox/VBoxLinuxAdditions.run
+umount /tmp/vbox
+rmdir /tmp/vbox
+rm *.iso
+
+mkdir /home/vagrant/.ssh
+wget --no-check-certificate \
+    'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' \
+    -O /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh
+chmod -R go-rwsx /home/vagrant/.ssh

--- a/definitions/centos-5.9/chef-client.sh
+++ b/definitions/centos-5.9/chef-client.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -eux
+
+wget -O - http://opscode.com/chef/install.sh | sudo bash

--- a/definitions/centos-5.9/cleanup.sh
+++ b/definitions/centos-5.9/cleanup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -eux
+yum -y erase gtk2 libX11 hicolor-icon-theme avahi freetype bitstream-vera-fonts
+yum -y clean all
+rm -rf VBoxGuestAdditions_*.iso VBoxGuestAdditions_*.iso.?
+rm -f /tmp/chef*rpm

--- a/definitions/centos-5.9/definition.rb
+++ b/definitions/centos-5.9/definition.rb
@@ -1,0 +1,11 @@
+require File.dirname(__FILE__) + "/../.centos/session.rb"
+
+iso = "CentOS-5.9-x86_64-bin-DVD-1of2.iso"
+
+session =
+  CENTOS_SESSION.merge({ :os_type_id => 'RedHat_64',
+                         :iso_file => iso,
+                         :iso_md5 => "bb795391846e76a7071893cbdf6163c3",
+                         :iso_src => "http://mirror.stanford.edu/yum/pub/centos/5.9/isos/x86_64/#{iso}" })
+
+Veewee::Session.declare session

--- a/definitions/centos-5.9/ks.cfg
+++ b/definitions/centos-5.9/ks.cfg
@@ -1,0 +1,39 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw --iscrypted $1$damlkd,f$UC/u5pUts5QiU3ow.CSso/
+firewall --disabled
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+text
+skipx
+zerombr
+clearpart --all --initlabel
+autopart
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot
+
+%packages --ignoremissing
+@Base
+@Core
+@Development Tools
+openssl-devel
+readline-devel
+zlib-devel
+kernel-devel
+
+%post
+# update root certs
+wget -O/etc/pki/tls/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem
+# vagrant
+groupadd vagrant -g 999
+useradd vagrant -g vagrant -G wheel -u 900
+echo "vagrant" | passwd --stdin vagrant
+# sudo
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers

--- a/definitions/centos-5.9/minimize.sh
+++ b/definitions/centos-5.9/minimize.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -eux
+
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY

--- a/definitions/centos-5.9/vagrant.sh
+++ b/definitions/centos-5.9/vagrant.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -eux
+
+mkdir /tmp/vbox
+VER=$(cat /home/vagrant/.vbox_version)
+wget http://download.virtualbox.org/virtualbox/$VER/VBoxGuestAdditions_$VER.iso
+mount -o loop VBoxGuestAdditions_$VER.iso /tmp/vbox
+sh /tmp/vbox/VBoxLinuxAdditions.run
+umount /tmp/vbox
+rmdir /tmp/vbox
+rm *.iso
+
+mkdir /home/vagrant/.ssh
+wget --no-check-certificate \
+    'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' \
+    -O /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh
+chmod -R go-rwsx /home/vagrant/.ssh

--- a/definitions/centos-6.4-i386/chef-client.sh
+++ b/definitions/centos-6.4-i386/chef-client.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -eux
+
+wget -O - http://opscode.com/chef/install.sh | sudo bash

--- a/definitions/centos-6.4-i386/cleanup.sh
+++ b/definitions/centos-6.4-i386/cleanup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -eux
+yum -y erase gtk2 libX11 hicolor-icon-theme avahi freetype bitstream-vera-fonts
+yum -y clean all
+rm -rf VBoxGuestAdditions_*.iso VBoxGuestAdditions_*.iso.?
+rm -f /tmp/chef*rpm

--- a/definitions/centos-6.4-i386/definition.rb
+++ b/definitions/centos-6.4-i386/definition.rb
@@ -1,0 +1,14 @@
+require File.dirname(__FILE__) + "/../.centos/session.rb"
+
+iso = "CentOS-6.4-i386-bin-DVD1.iso"
+
+session =
+  CENTOS_SESSION.merge( :boot_cmd_sequence =>
+                        [ '<Tab> text ks=http://%IP%:%PORT%/ks.cfg<Enter>' ],
+                        :memory_size=> '480',
+                        :os_type_id => 'RedHat',
+                        :iso_file => iso,
+                        :iso_md5 => "a6049df141579169b217cbb625da4c6d",
+                        :iso_src => "http://mirrors.kernel.org/centos/6.4/isos/i386/#{iso}" )
+
+Veewee::Session.declare session

--- a/definitions/centos-6.4-i386/ks.cfg
+++ b/definitions/centos-6.4-i386/ks.cfg
@@ -1,0 +1,39 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw --iscrypted $1$damlkd,f$UC/u5pUts5QiU3ow.CSso/
+firewall --disabled
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+text
+skipx
+zerombr
+clearpart --all --initlabel
+autopart
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot
+
+%packages --ignoremissing
+@Base
+@Core
+@Development Tools
+openssl-devel
+readline-devel
+zlib-devel
+kernel-devel
+
+%post
+# update root certs
+wget -O/etc/pki/tls/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem
+# vagrant
+groupadd vagrant -g 999
+useradd vagrant -g vagrant -G wheel -u 900
+echo "vagrant" | passwd --stdin vagrant
+# sudo
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers

--- a/definitions/centos-6.4-i386/minimize.sh
+++ b/definitions/centos-6.4-i386/minimize.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -eux
+
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY

--- a/definitions/centos-6.4-i386/vagrant.sh
+++ b/definitions/centos-6.4-i386/vagrant.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -eux
+
+mkdir /tmp/vbox
+VER=$(cat /home/vagrant/.vbox_version)
+wget http://download.virtualbox.org/virtualbox/$VER/VBoxGuestAdditions_$VER.iso
+mount -o loop VBoxGuestAdditions_$VER.iso /tmp/vbox
+sh /tmp/vbox/VBoxLinuxAdditions.run
+umount /tmp/vbox
+rmdir /tmp/vbox
+rm *.iso
+
+mkdir /home/vagrant/.ssh
+wget --no-check-certificate \
+    'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' \
+    -O /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh
+chmod -R go-rwsx /home/vagrant/.ssh

--- a/definitions/centos-6.4/chef-client.sh
+++ b/definitions/centos-6.4/chef-client.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -eux
+
+wget -O - http://opscode.com/chef/install.sh | sudo bash

--- a/definitions/centos-6.4/cleanup.sh
+++ b/definitions/centos-6.4/cleanup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -eux
+yum -y erase gtk2 libX11 hicolor-icon-theme avahi freetype bitstream-vera-fonts
+yum -y clean all
+rm -rf VBoxGuestAdditions_*.iso VBoxGuestAdditions_*.iso.?
+rm -f /tmp/chef*rpm

--- a/definitions/centos-6.4/definition.rb
+++ b/definitions/centos-6.4/definition.rb
@@ -1,0 +1,13 @@
+require File.dirname(__FILE__) + "/../.centos/session.rb"
+
+iso = "CentOS-6.4-x86_64-bin-DVD1.iso"
+
+session =
+  CENTOS_SESSION.merge( :boot_cmd_sequence =>
+                        [ '<Tab> text ks=http://%IP%:%PORT%/ks.cfg<Enter>' ],
+                        :memory_size=> '480',
+                        :iso_file => iso,
+                        :iso_md5 => "0128cfc7c86072b13ee80dd013e0e5d7",
+                        :iso_src => "http://mirrors.kernel.org/centos/6.4/isos/x86_64/#{iso}" )
+
+Veewee::Session.declare session

--- a/definitions/centos-6.4/ks.cfg
+++ b/definitions/centos-6.4/ks.cfg
@@ -1,0 +1,39 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw --iscrypted $1$damlkd,f$UC/u5pUts5QiU3ow.CSso/
+firewall --disabled
+authconfig --enableshadow --passalgo=sha512
+selinux --disabled
+timezone UTC
+bootloader --location=mbr
+text
+skipx
+zerombr
+clearpart --all --initlabel
+autopart
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot
+
+%packages --ignoremissing
+@Base
+@Core
+@Development Tools
+openssl-devel
+readline-devel
+zlib-devel
+kernel-devel
+
+%post
+# update root certs
+wget -O/etc/pki/tls/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem
+# vagrant
+groupadd vagrant -g 999
+useradd vagrant -g vagrant -G wheel -u 900
+echo "vagrant" | passwd --stdin vagrant
+# sudo
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers

--- a/definitions/centos-6.4/minimize.sh
+++ b/definitions/centos-6.4/minimize.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -eux
+
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY

--- a/definitions/centos-6.4/vagrant.sh
+++ b/definitions/centos-6.4/vagrant.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -eux
+
+mkdir /tmp/vbox
+VER=$(cat /home/vagrant/.vbox_version)
+wget http://download.virtualbox.org/virtualbox/$VER/VBoxGuestAdditions_$VER.iso
+mount -o loop VBoxGuestAdditions_$VER.iso /tmp/vbox
+sh /tmp/vbox/VBoxLinuxAdditions.run
+umount /tmp/vbox
+rmdir /tmp/vbox
+rm *.iso
+
+mkdir /home/vagrant/.ssh
+wget --no-check-certificate \
+    'http://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' \
+    -O /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh
+chmod -R go-rwsx /home/vagrant/.ssh


### PR DESCRIPTION
CentOS 5.8 x86_64 box does not have RedHat_64 as type; this will cause a build failure as VirtualBox won't start properly.

Import box templates for CentOS 5.9 and CentOS 6.4.
