### PR TITLE
fix Windows box builds for Vagrant 1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gem "vagrant", :git => 'https://github.com/mitchellh/vagrant.git', :tag => 'v1.1.5'
 gem "veewee", :git => 'https://github.com/jedi4ever/veewee.git', :ref => '164a10dd24'
+gem "vagrant-windows", :git => 'https://github.com/sneal/vagrant-windows.git', :branch => 'vagrant-1.1-plugin-architecture-vbox4.1' # mainline vagrant-windows isn't working yet with Vagrant 1.1
 gem "em-winrm" # for windows!
 gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,15 @@ GIT
       net-scp (~> 1.1.0)
       net-ssh (~> 2.6.6)
 
+GIT
+  remote: https://github.com/sneal/vagrant-windows.git
+  revision: fbe11646d674e2ee5253089b958fdc2e573aab78
+  branch: vagrant-1.1-plugin-architecture-vbox4.1
+  specs:
+    vagrant-windows (0.2.0)
+      highline
+      winrm (~> 1.1.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -135,4 +144,5 @@ DEPENDENCIES
   em-winrm
   rake
   vagrant!
+  vagrant-windows!
   veewee!

--- a/definitions/.windows/install-chef.bat
+++ b/definitions/.windows/install-chef.bat
@@ -1,6 +1,6 @@
 timeout 10
 REM sleeping to give outbound networking a chance to come up
-cmd /C cscript wget.vbs /url:http://www.opscode.com/chef/install.msi /path:chef-client.msi
+cmd /C cscript %TEMP%\wget.vbs /url:http://www.opscode.com/chef/install.msi /path:chef-client.msi
 cmd /C msiexec /qn /i chef-client.msi
 
 


### PR DESCRIPTION
Use @sneal's vagrant-windows gem for now until @BIAINC's gets fixed for use with Vagrant 1.1/1.2.

Bugfix for wget.vbs not being in vagrant's home directory, but rather in %TEMP%
