### PR TITLE
Add a task to update apt-get on boot in ubuntu.

### DIFF
--- a/definitions/.ubuntu/update.sh
+++ b/definitions/.ubuntu/update.sh
@@ -5,3 +5,11 @@ apt-get -y upgrade
 
 # ensure the correct kernel headers are installed
 apt-get -y install linux-headers-$(uname -r)
+
+# update package index on boot
+cat <<EOF > /etc/init/refresh-apt.conf
+description "update package index"
+start on networking
+task
+exec /usr/bin/apt-get update
+EOF


### PR DESCRIPTION
Bento boxes ship with package indexes that become stale. When the indexes are stale, package installation fails until the index is manually refreshed. This breaks the various Chef provisioners. I documented another approach to addressing this problem here:

https://gist.github.com/whilp/5430496

It seems preferable to deal with this in bento, though, to avoid copypasta/drift in Vagrantfiles.
