### PR TITLE
Added ubuntu-13.04 definitions.

### DIFF
--- a/definitions/ubuntu-13.04-i386/chef-client.sh
+++ b/definitions/ubuntu-13.04-i386/chef-client.sh
@@ -1,0 +1,1 @@
+../.common/chef-client.sh

--- a/definitions/ubuntu-13.04-i386/cleanup.sh
+++ b/definitions/ubuntu-13.04-i386/cleanup.sh
@@ -1,0 +1,1 @@
+../.ubuntu/cleanup.sh

--- a/definitions/ubuntu-13.04-i386/definition.rb
+++ b/definitions/ubuntu-13.04-i386/definition.rb
@@ -1,0 +1,11 @@
+require File.dirname(__FILE__) + "/../.ubuntu/session.rb"
+
+iso = "ubuntu-13.04-server-i386.iso"
+
+session =
+  UBUNTU_SESSION.merge( :os_type_id => 'Ubuntu',
+                        :iso_file => iso,
+                        :iso_md5 => "73d595b804149fca9547ed94db8ff44f",
+                        :iso_src => "http://releases.ubuntu.com/13.04/#{iso}" )
+
+Veewee::Session.declare session

--- a/definitions/ubuntu-13.04-i386/minimize.sh
+++ b/definitions/ubuntu-13.04-i386/minimize.sh
@@ -1,0 +1,1 @@
+../.common/minimize.sh

--- a/definitions/ubuntu-13.04-i386/networking.sh
+++ b/definitions/ubuntu-13.04-i386/networking.sh
@@ -1,0 +1,1 @@
+../.ubuntu/networking.sh

--- a/definitions/ubuntu-13.04-i386/preseed.cfg
+++ b/definitions/ubuntu-13.04-i386/preseed.cfg
@@ -1,0 +1,1 @@
+../.ubuntu/preseed.cfg

--- a/definitions/ubuntu-13.04-i386/sudoers.sh
+++ b/definitions/ubuntu-13.04-i386/sudoers.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -eux
+
+sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=sudo' /etc/sudoers
+sed -i -e 's/%sudo  ALL=(ALL:ALL) ALL/%sudo  ALL=NOPASSWD:ALL/g' /etc/sudoers

--- a/definitions/ubuntu-13.04-i386/update.sh
+++ b/definitions/ubuntu-13.04-i386/update.sh
@@ -1,0 +1,1 @@
+../.ubuntu/update.sh

--- a/definitions/ubuntu-13.04-i386/vagrant.sh
+++ b/definitions/ubuntu-13.04-i386/vagrant.sh
@@ -1,0 +1,1 @@
+../.common/vagrant.sh

--- a/definitions/ubuntu-13.04/chef-client.sh
+++ b/definitions/ubuntu-13.04/chef-client.sh
@@ -1,0 +1,1 @@
+../.common/chef-client.sh

--- a/definitions/ubuntu-13.04/cleanup.sh
+++ b/definitions/ubuntu-13.04/cleanup.sh
@@ -1,0 +1,1 @@
+../.ubuntu/cleanup.sh

--- a/definitions/ubuntu-13.04/definition.rb
+++ b/definitions/ubuntu-13.04/definition.rb
@@ -1,0 +1,11 @@
+require File.dirname(__FILE__) + "/../.ubuntu/session.rb"
+
+iso = "ubuntu-13.04-server-amd64.iso"
+
+session =
+  UBUNTU_SESSION.merge( :os_type_id => 'Ubuntu',
+                        :iso_file => iso,
+                        :iso_md5 => "7d335ca541fc4945b674459cde7bffb9",
+                        :iso_src => "http://releases.ubuntu.com/13.04/#{iso}" )
+
+Veewee::Session.declare session

--- a/definitions/ubuntu-13.04/minimize.sh
+++ b/definitions/ubuntu-13.04/minimize.sh
@@ -1,0 +1,1 @@
+../.common/minimize.sh

--- a/definitions/ubuntu-13.04/networking.sh
+++ b/definitions/ubuntu-13.04/networking.sh
@@ -1,0 +1,1 @@
+../.ubuntu/networking.sh

--- a/definitions/ubuntu-13.04/preseed.cfg
+++ b/definitions/ubuntu-13.04/preseed.cfg
@@ -1,0 +1,1 @@
+../.ubuntu/preseed.cfg

--- a/definitions/ubuntu-13.04/sudoers.sh
+++ b/definitions/ubuntu-13.04/sudoers.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -eux
+
+sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=sudo' /etc/sudoers
+sed -i -e 's/%sudo  ALL=(ALL:ALL) ALL/%sudo  ALL=NOPASSWD:ALL/g' /etc/sudoers

--- a/definitions/ubuntu-13.04/update.sh
+++ b/definitions/ubuntu-13.04/update.sh
@@ -1,0 +1,1 @@
+../.ubuntu/update.sh

--- a/definitions/ubuntu-13.04/vagrant.sh
+++ b/definitions/ubuntu-13.04/vagrant.sh
@@ -1,0 +1,1 @@
+../.common/vagrant.sh


### PR DESCRIPTION
This includes the 64-bit and i386 definitions. They are a copy of the same ones that
I was using for building the 12.10 ones as well. Everything goes fine and nothing
has changed other than the MD5SUM and obviously the URL.
