### PR TITLE
Fix Windows 8 Enterprise box builds.

### DIFF
--- a/definitions/windows-8-enterprise/Autounattend.xml
+++ b/definitions/windows-8-enterprise/Autounattend.xml
@@ -36,8 +36,8 @@
             </DiskConfiguration>
 
             <UserData>
-              <!-- Product Key from http://technet.microsoft.com/en-us/library/ff793406.aspx -->
-                <ProductKey>YC6KT-GKW9T-YTKYR-T4X34-R7VHC
+              <!-- Product Key from http://technet.microsoft.com/en-us/library/jj612867.aspx -->
+                <ProductKey>32JNW-9KQ84-P47T8-D8GGY-CWCK7
                     <WillShowUI>Never</WillShowUI>
                 </ProductKey>
 

--- a/definitions/windows-8-enterprise/definition.rb
+++ b/definitions/windows-8-enterprise/definition.rb
@@ -10,7 +10,8 @@ session = WINDOWS_SESSION.merge({
     :iso_src => iso_src,
     :iso_md5 => "6beffd994574ca89417286f0dc056108",
     :winrm_host_port => "5988",
-    :kickstart_port => "7150"
+    :kickstart_port => "7150",
+    :memory_size=> "512"
   })
 
 Veewee::Session.declare session


### PR DESCRIPTION
KMS license key was outdated, and I allocated insufficient RAM to it.
