### PR TITLE
Upgrade to veewee that has hooks (we may use them)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "vagrant", :git => 'https://github.com/mitchellh/vagrant.git', :tag => 'v1.2.2'
-gem "veewee", :git => 'https://github.com/jedi4ever/veewee.git', :ref => '164a10dd24'
-gem "vagrant-windows", :git => 'https://github.com/sneal/vagrant-windows.git', :branch => 'vagrant-1.1-plugin-architecture-vbox4.1' # mainline vagrant-windows isn't working yet with Vagrant 1.1
+gem "veewee", :git => 'https://github.com/jedi4ever/veewee.git', :ref => '4e5d50de'
+gem "vagrant-windows", "~> 1.0.0" # still not working with Vagrant 1.2 btw
 gem "em-winrm" # for windows!
 gem "rake"


### PR DESCRIPTION
@WinRb vagrant-windows 1.0.x is released; no need to depend on @sneal's fork
