### PR TITLE
Update common session.rb for VirtualBox.

### DIFF
--- a/definitions/.common/session.rb
+++ b/definitions/.common/session.rb
@@ -3,7 +3,7 @@ COMMON_SESSION = {
   :cpu_count => "1",
   :disk_format => "VDI",
   :disk_size => "40960",
-  :hostiocache => "off",
+  :hostiocache => "on",
   :iso_download_timeout => "1000",
   :kickstart_port => "7122",
   :kickstart_timeout => "10000",
@@ -19,7 +19,8 @@ COMMON_SESSION = {
   :virtualbox => {
     :vm_options => {
       :ioapic => "on",
-      :pae => "on"
+      :pae => "on",
+      :chipset => "ich9"
     }
   }
  


### PR DESCRIPTION
I have been debugging poor performance of my VirtualBox VM images for awhile and ran across a couple of articles suggesting that both the `hostiocache` flag and the `chipset` are set to the appropriate values in this PR. I was a little hesitant regarding the hostiocache value since I wasn't sure how it would affect other providers. 

Thoughts?
