### PR TITLE
[BENTO-80] Sudoer should use secure_path by default

### DIFF
--- a/definitions/.debian/sudoers.sh
+++ b/definitions/.debian/sudoers.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -eux
 
-sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=sudo' /etc/sudoers
+sed -i -e '/Defaults\s\+env_reset/a Defaults\tsecure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"' /etc/sudoers
 sed -i -e 's/%sudo ALL=(ALL) ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers


### PR DESCRIPTION
The current sudoer configuration will not work with chef-omnibus install because by default a debian user doesn't have link to sbin.

Debian recommends that you use secure_path (and not exempt_group)
- http://wiki.debian.org/sudo

This change makes it possible for a clean bento build of debian 6.0.7 to be able to install chef-omnibus without having to switch to root or change the PATH variable.
