### PR TITLE
Add preseed command to comment out cdrom in /etc/apt/sources.list.

### DIFF
--- a/definitions/debian-7.1.0/preseed.cfg
+++ b/definitions/debian-7.1.0/preseed.cfg
@@ -1,1 +1,48 @@
-../.debian/preseed.cfg
+choose-mirror-bin mirror/http/proxy string
+d-i apt-setup/use_mirror boolean true
+d-i base-installer/kernel/override-image string linux-server
+d-i clock-setup/utc boolean true
+d-i clock-setup/utc-auto boolean true
+d-i finish-install/reboot_in_progress note
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean true
+d-i keymap select us
+d-i mirror/country string manual
+d-i mirror/http/directory string /debian
+d-i mirror/http/hostname string mirrors.kernel.org
+d-i mirror/http/proxy string
+d-i partman-auto-lvm/guided_size string max
+d-i partman-auto/choose_recipe select atomic
+d-i partman-auto/method string lvm
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+d-i partman-lvm/device_remove_lvm boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman/confirm_write_new_label boolean true
+d-i passwd/root-login boolean false
+d-i passwd/root-password-again password vagrant
+d-i passwd/root-password password vagrant
+d-i passwd/user-fullname string vagrant
+d-i passwd/user-uid string 900
+d-i passwd/user-password password vagrant
+d-i passwd/user-password-again password vagrant
+d-i passwd/username string vagrant
+d-i pkgsel/include string openssh-server sudo bzip2 acpid cryptsetup zlib1g-dev wget curl dkms make
+d-i pkgsel/install-language-support boolean false
+d-i pkgsel/update-policy select unattended-upgrades
+d-i pkgsel/upgrade select full-upgrade
+# Prevent packaged version of VirtualBox Guest Additions being installed:
+d-i preseed/early_command string sed -i \
+  '/in-target/idiscover(){/sbin/discover|grep -v VirtualBox;}' \
+  /usr/lib/pre-pkgsel.d/20install-hwpackages
+d-i time/zone string UTC
+d-i user-setup/allow-password-weak boolean true
+d-i user-setup/encrypt-home boolean false
+d-i preseed/late_command string sed -i '/^deb cdrom:/s/^/#/' /target/etc/apt/sources.list
+apt-cdrom-setup apt-setup/cdrom/set-first boolean false
+apt-mirror-setup apt-setup/use_mirror boolean true
+popularity-contest popularity-contest/participate boolean false
+tasksel tasksel/first multiselect standard, ubuntu-server


### PR DESCRIPTION
[Line #44](https://github.com/socialally/bento/blob/ad4c9c59d6c3b666e07ecbaefad0da49a2bea3d7/definitions/debian-7.1.0/preseed.cfg#L44) comments out the cdrom source in `/etc/apt/sources.list`, resolving [BENTO-82](http://tickets.opscode.com/browse/BENTO-82?page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel).

I created a new preseed file rather than modifying the shared `debian/preseed.cfg` file as this fix is only necessary for the definition for Debian 7, as far as I am aware.
