### PR TITLE
Ensure /etc/sudoers sed replacement works for Debian 7.x.

### DIFF
--- a/definitions/debian-7.1.0/sudoers.sh
+++ b/definitions/debian-7.1.0/sudoers.sh
@@ -1,1 +1,4 @@
-../.debian/sudoers.sh
+#!/bin/bash -eux
+
+sed -i -e '/Defaults\s\+env_reset/a Defaults\tsecure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"' /etc/sudoers
+sed -i -e 's/%sudo\tALL=(ALL:ALL) ALL/%sudo\tALL=(ALL:ALL) NOPASSWD: ALL/' /etc/sudoers


### PR DESCRIPTION
Debian 7's `/etc/sudoers` file format has changed, requiring an update to the sed regex in the `sudoers.sh` script.

As this is only specific to this definition, I've removed the symlink to the common `debian/sudoers.sh` and created a new `sudoers.sh` file with the required updates.
