### PR TITLE
Ensure that we install chef client on centos-6.4

### DIFF
--- a/definitions/.centos/chef-client.sh
+++ b/definitions/.centos/chef-client.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -eux
+
+wget -O - http://opscode.com/chef/install.sh | sudo bash

--- a/definitions/.centos/session.rb
+++ b/definitions/.centos/session.rb
@@ -7,6 +7,7 @@ CENTOS_SESSION =
                          :os_type_id => 'Centos_64',
                          :postinstall_files => [ "vagrant.sh",
                                                  "sshd.sh",
+                                                 "chef-client.sh",
                                                  "cleanup.sh",
                                                  "minimize.sh" ],
                          :shutdown_cmd => "/sbin/halt -h -p" })

--- a/definitions/centos-6.4/chef-client.sh
+++ b/definitions/centos-6.4/chef-client.sh
@@ -1,0 +1,1 @@
+../.centos/chef-client.sh


### PR DESCRIPTION
This pull request ensures that bento install chef client on centos 6.4.
