### PR TITLE
Clean FreeBSD boxes to save space.

### DIFF
--- a/packer/freebsd-9.1-amd64.json
+++ b/packer/freebsd-9.1-amd64.json
@@ -3,7 +3,8 @@
     {
       "type": "shell",
       "scripts": [
-        "scripts/freebsd/postinstall.csh"
+        "scripts/freebsd/postinstall.csh",
+        "scripts/common/minimize.sh"
       ],
       "execute_command": "cat '{{.Path}}' | su -"
     }

--- a/packer/scripts/common/minimize.sh
+++ b/packer/scripts/common/minimize.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eux
+#!/bin/sh -eux
 
 dd if=/dev/zero of=/EMPTY bs=1M
 rm -f /EMPTY


### PR DESCRIPTION
Use regular Bourne shell for that script, since FreeBSD doesn't have bash by default, and the script will work on all Linuxes anyway.
