### PR TITLE
Use correct sudoers changes for Ubuntu 12+.

### DIFF
--- a/packer/scripts/ubuntu/sudoers.sh
+++ b/packer/scripts/ubuntu/sudoers.sh
@@ -9,10 +9,9 @@ fi
 
 if [ ! -z "$major_version" -a "$major_version" -lt 12 ]
 then
-  exempt_group="admin"
+  sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=admin' /etc/sudoers
+  sed -i -e 's/%admin\s*ALL=(ALL) ALL/%admin\tALL=NOPASSWD:ALL/g' /etc/sudoers
 else
-  exempt_group="sudo"
+  sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=sudo' /etc/sudoers
+  sed -i -e 's/%sudo\s*ALL=(ALL:ALL) ALL/%sudo\tALL=NOPASSWD:ALL/g' /etc/sudoers
 fi
-
-sed -i -e "/Defaults\s\+env_reset/a Defaults\texempt_group=${exempt_group}" /etc/sudoers
-sed -i -e "s/%${exempt_group}  ALL=(ALL:ALL) ALL/%${exempt_group}  ALL=NOPASSWD:ALL/g" /etc/sudoers


### PR DESCRIPTION
In the veewee definitions, Ubuntu 10 and 11 use the common ubuntu
configuration which exempts the admin group. The Ubuntu 12 and 13
definitions don't use the common configuration, instead they exempt the sudo
group.
