### PR TITLE
CentOS 6.4 won't install with only 384MB of RAM

### DIFF
--- a/packer/centos-6.4-i386.json
+++ b/packer/centos-6.4-i386.json
@@ -19,7 +19,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
+        [ "modifyvm", "{{.Name}}", "--memory", "480" ],
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version"

--- a/packer/centos-6.4-x86_64.json
+++ b/packer/centos-6.4-x86_64.json
@@ -19,7 +19,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
+        [ "modifyvm", "{{.Name}}", "--memory", "480" ],
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version"


### PR DESCRIPTION
This was already fixed in the vmware section but not in the virtualbox section, so copy it.
