### PR TITLE
[BENTO-5] Add NFS client capability to CentOS and Fedora templates.

### DIFF
--- a/packer/http/centos-5.10/ks.cfg
+++ b/packer/http/centos-5.10/ks.cfg
@@ -26,6 +26,7 @@ openssl-devel
 readline-devel
 zlib-devel
 kernel-devel
+nfs-utils
 
 %post
 # update root certs

--- a/packer/http/centos-6.4/ks.cfg
+++ b/packer/http/centos-6.4/ks.cfg
@@ -26,6 +26,7 @@ openssl-devel
 readline-devel
 zlib-devel
 kernel-devel
+nfs-utils
 
 %post
 # update root certs

--- a/packer/http/fedora-18/ks.cfg
+++ b/packer/http/fedora-18/ks.cfg
@@ -35,6 +35,7 @@ tar
 wget
 net-tools
 zlib-devel
+nfs-utils
 %end
 
 %post

--- a/packer/http/fedora-19/ks.cfg
+++ b/packer/http/fedora-19/ks.cfg
@@ -35,6 +35,7 @@ tar
 wget
 net-tools
 zlib-devel
+nfs-utils
 %end
 
 %post

--- a/packer/http/fedora-20/ks.cfg
+++ b/packer/http/fedora-20/ks.cfg
@@ -35,6 +35,7 @@ tar
 wget
 net-tools
 zlib-devel
+nfs-utils
 %end
 
 %post

--- a/packer/scripts/centos/ks.cfg
+++ b/packer/scripts/centos/ks.cfg
@@ -26,6 +26,7 @@ openssl-devel
 readline-devel
 zlib-devel
 kernel-devel
+nfs-utils
 
 %post
 # update root certs

--- a/packer/scripts/fedora/ks.cfg
+++ b/packer/scripts/fedora/ks.cfg
@@ -34,6 +34,7 @@ readline-devel
 tar
 wget
 zlib-devel
+nfs-utils
 %end
 
 %post


### PR DESCRIPTION
All other packer templates already have this added.
