### PR TITLE
Added templates for RHEL.

### DIFF
--- a/packer/rhel-5.10-i386.json
+++ b/packer/rhel-5.10-i386.json
@@ -1,0 +1,71 @@
+{
+  "builders": [
+    {
+      "type": "virtualbox",
+      "boot_command": [
+        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-5.10/ks.cfg<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 40960,
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_os_type": "RedHat",
+      "http_directory": "http",
+      "iso_checksum": "3a4db78ab70d866057c5285e0064d78125e1b8fd9dcaefea28818f6604b3515d",
+      "iso_checksum_type": "sha256",
+      "iso_url": "https://content-web.rhn.redhat.com/rhn/isos/rhel-5.10/md5sum/1ab756241a4a209b8d39abe6bace84a9/rhel-server-5.10-i386-dvd.iso",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "vboxmanage": [
+        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
+        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+      ],
+      "virtualbox_version_file": ".vbox_version"
+    },
+    {
+      "type": "vmware",
+      "boot_command": [
+        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-5.10/ks.cfg<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 40960,
+      "guest_os_type": "redhat",
+      "http_directory": "http",
+      "iso_checksum": "3a4db78ab70d866057c5285e0064d78125e1b8fd9dcaefea28818f6604b3515d",
+      "iso_checksum_type": "sha256",
+      "iso_url": "https://content-web.rhn.redhat.com/rhn/isos/rhel-5.10/md5sum/1ab756241a4a209b8d39abe6bace84a9/rhel-server-5.10-i386-dvd.iso",
+      "tools_upload_flavor": "linux",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "vmx_data": {
+        "cpuid.coresPerSocket": "1",
+        "memsize": "384",
+        "numvcpus": "1"
+      }
+    }
+  ],
+  "post-processors": [
+    {
+      "output": "../builds/{{.Provider}}/opscode_rhel-5.10-i386_provisionerless.box",
+      "type": "vagrant"
+    }
+  ],
+  "provisioners": [
+    {
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
+      "scripts": [
+        "scripts/common/vagrant.sh",
+        "scripts/common/sshd.sh",
+        "scripts/common/vmtools.sh",
+        "scripts/centos/cleanup.sh",
+        "scripts/common/minimize.sh"
+      ],
+      "type": "shell"
+    }
+  ]
+}

--- a/packer/rhel-5.10-x86_64.json
+++ b/packer/rhel-5.10-x86_64.json
@@ -1,0 +1,71 @@
+{
+  "builders": [
+    {
+      "type": "virtualbox",
+      "boot_command": [
+        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-5.10/ks.cfg<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 40960,
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_os_type": "RedHat_64",
+      "http_directory": "http",
+      "iso_checksum": "8b38e74b0993d478aad9c950f51a3e3441199639a3422e06fc3beca1f8825bf2",
+      "iso_checksum_type": "sha256",
+      "iso_url": "https://content-web.rhn.redhat.com/rhn/isos/rhel-5.10/md5sum/86cc2d5548ee2ff9c8d3e2b4db3e6001/rhel-server-5.10-x86_64-dvd.iso",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "vboxmanage": [
+        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
+        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+      ],
+      "virtualbox_version_file": ".vbox_version"
+    },
+    {
+      "type": "vmware",
+      "boot_command": [
+        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-5.10/ks.cfg<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 40960,
+      "guest_os_type": "redhat-64",
+      "http_directory": "http",
+      "iso_checksum": "8b38e74b0993d478aad9c950f51a3e3441199639a3422e06fc3beca1f8825bf2",
+      "iso_checksum_type": "sha256",
+      "iso_url": "https://content-web.rhn.redhat.com/rhn/isos/rhel-5.10/md5sum/86cc2d5548ee2ff9c8d3e2b4db3e6001/rhel-server-5.10-x86_64-dvd.iso",
+      "tools_upload_flavor": "linux",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "vmx_data": {
+        "cpuid.coresPerSocket": "1",
+        "memsize": "384",
+        "numvcpus": "1"
+      }
+    }
+  ],
+  "post-processors": [
+    {
+      "output": "../builds/{{.Provider}}/opscode_rhel-5.10_provisionerless.box",
+      "type": "vagrant"
+    }
+  ],
+  "provisioners": [
+    {
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
+      "scripts": [
+        "scripts/common/vagrant.sh",
+        "scripts/common/sshd.sh",
+        "scripts/common/vmtools.sh",
+        "scripts/centos/cleanup.sh",
+        "scripts/common/minimize.sh"
+      ],
+      "type": "shell"
+    }
+  ]
+}

--- a/packer/rhel-6.4-i386.json
+++ b/packer/rhel-6.4-i386.json
@@ -1,0 +1,72 @@
+{
+  "builders": [
+    {
+      "type": "virtualbox",
+      "boot_command": [
+        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-6.4/ks.cfg<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 40960,
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_os_type": "RedHat",
+      "http_directory": "http",
+      "iso_checksum": "d953b7e1cc9fcc0415b78dcd79737929842575ae8b903d6868e337a2a21dcaee",
+      "iso_checksum_type": "sha256",
+      "iso_url": "https://content-web.rhn.redhat.com/rhn/isos/rhel-6.4/md5sum/2f1927af5bca9a34f2d9488655b4fdf4/rhel-server-6.4-i386-dvd.iso",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "vboxmanage": [
+        [ "modifyvm", "{{.Name}}", "--memory", "480" ],
+        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+      ],
+      "virtualbox_version_file": ".vbox_version"
+    },
+    {
+      "type": "vmware",
+      "boot_command": [
+        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-6.4/ks.cfg<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 40960,
+      "guest_os_type": "redhat",
+      "http_directory": "http",
+      "iso_checksum": "d953b7e1cc9fcc0415b78dcd79737929842575ae8b903d6868e337a2a21dcaee",
+      "iso_checksum_type": "sha256",
+      "iso_url": "https://content-web.rhn.redhat.com/rhn/isos/rhel-6.4/md5sum/2f1927af5bca9a34f2d9488655b4fdf4/rhel-server-6.4-i386-dvd.iso",
+      "tools_upload_flavor": "linux",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "vmx_data": {
+        "cpuid.coresPerSocket": "1",
+        "memsize": "480",
+        "numvcpus": "1"
+      }
+    }
+  ],
+  "post-processors": [
+    {
+      "output": "../builds/{{.Provider}}/opscode_rhel-6.4-i386_provisionerless.box",
+      "type": "vagrant"
+    }
+  ],
+  "provisioners": [
+    {
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
+      "scripts": [
+        "scripts/common/sshd.sh",
+        "scripts/common/vagrant.sh",
+        "scripts/common/vmtools.sh",
+        "scripts/centos/cleanup.sh",
+        "scripts/common/minimize.sh"
+      ],
+      "type": "shell"
+    }
+  ]
+}
+

--- a/packer/rhel-6.4-x86_64.json
+++ b/packer/rhel-6.4-x86_64.json
@@ -1,0 +1,71 @@
+{
+  "builders": [
+    {
+      "type": "virtualbox",
+      "boot_command": [
+        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-6.4/ks.cfg<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 40960,
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_os_type": "RedHat_64",
+      "http_directory": "http",
+      "iso_checksum": "1eabfc4eb1bea0d1d6c6c2802c7d44c6e68078b678186669bd2bcb87ca2ebeb8",
+      "iso_checksum_type": "sha256",
+      "iso_url": "https://content-web.rhn.redhat.com/rhn/isos/rhel-6.4/md5sum/467b53791903f9a0c477cbb1b24ffd1f/rhel-server-6.4-x86_64-dvd.iso",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "vboxmanage": [
+        [ "modifyvm", "{{.Name}}", "--memory", "480" ],
+        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+      ],
+      "virtualbox_version_file": ".vbox_version"
+    },
+    {
+      "type": "vmware",
+      "boot_command": [
+        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-6.4/ks.cfg<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 40960,
+      "guest_os_type": "redhat-64",
+      "http_directory": "http",
+      "iso_checksum": "1eabfc4eb1bea0d1d6c6c2802c7d44c6e68078b678186669bd2bcb87ca2ebeb8",
+      "iso_checksum_type": "sha256",
+      "iso_url": "https://content-web.rhn.redhat.com/rhn/isos/rhel-6.4/md5sum/467b53791903f9a0c477cbb1b24ffd1f/rhel-server-6.4-x86_64-dvd.iso",
+      "tools_upload_flavor": "linux",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "vmx_data": {
+        "cpuid.coresPerSocket": "1",
+        "memsize": "480",
+        "numvcpus": "1"
+      }
+    }
+  ],
+  "post-processors": [
+    {
+      "output": "../builds/{{.Provider}}/opscode_redhat-6.4_provisionerless.box",
+      "type": "vagrant"
+    }
+  ],
+  "provisioners": [
+    {
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
+      "scripts": [
+        "scripts/common/sshd.sh",
+        "scripts/common/vagrant.sh",
+        "scripts/common/vmtools.sh",
+        "scripts/centos/cleanup.sh",
+        "scripts/common/minimize.sh"
+      ],
+      "type": "shell"
+    }
+  ]
+}


### PR DESCRIPTION
These re-use the CentOS kickstart scripts, but have the correct ISO checksums.
