### PR TITLE
BENTO-96 fix execute_command for debian to include env vars

### DIFF
--- a/packer/debian-6.0.8-i386.json
+++ b/packer/debian-6.0.8-i386.json
@@ -85,7 +85,7 @@
   ],
   "provisioners": [
     {
-      "type": "shell",
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
         "scripts/debian/update.sh",
         "scripts/common/sshd.sh",
@@ -96,7 +96,7 @@
         "scripts/debian/cleanup.sh",
         "scripts/common/minimize.sh"
       ],
-      "execute_command": "echo 'vagrant'|sudo -S sh '{{.Path}}'"
+      "type": "shell"
     }
   ]
 }

--- a/packer/debian-7.2.0-amd64.json
+++ b/packer/debian-7.2.0-amd64.json
@@ -85,7 +85,7 @@
   ],
   "provisioners": [
     {
-      "type": "shell",
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
         "scripts/debian/update.sh",
         "scripts/common/sshd.sh",
@@ -96,7 +96,7 @@
         "scripts/debian/cleanup.sh",
         "scripts/common/minimize.sh"
       ],
-      "execute_command": "echo 'vagrant'|sudo -S sh '{{.Path}}'"
+      "type": "shell"
     }
   ]
 }

--- a/packer/debian-7.2.0-i386.json
+++ b/packer/debian-7.2.0-i386.json
@@ -85,7 +85,7 @@
   ],
   "provisioners": [
     {
-      "type": "shell",
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
         "scripts/debian/update.sh",
         "scripts/common/sshd.sh",
@@ -96,7 +96,7 @@
         "scripts/debian/cleanup.sh",
         "scripts/common/minimize.sh"
       ],
-      "execute_command": "echo 'vagrant'|sudo -S sh '{{.Path}}'"
+      "type": "shell"
     }
   ]
 }


### PR DESCRIPTION
I have applied to be an approved contributor, and this should fix the bento debian images where some of the post-install scripts don't run because the environmental variables set by packer are missing.
