### PR TITLE
[BENTO-97] Specify a Virtualbox VM name for each Packer template

### DIFF
--- a/packer/centos-5.10-i386.json
+++ b/packer/centos-5.10-i386.json
@@ -27,7 +27,8 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-centos-5.10-i386"
+      "vm_name": "packer-centos-5.10-i386",
+      "output_directory": "packer-centos-5.10-i386"
     },
     {
       "type": "vmware",
@@ -47,6 +48,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "vm_name": "packer-centos-5.10-i386",
+      "output_directory": "packer-centos-5.10-i386",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",

--- a/packer/centos-5.10-x86_64.json
+++ b/packer/centos-5.10-x86_64.json
@@ -27,7 +27,8 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-centos-5.10-x86_64"
+      "vm_name": "packer-centos-5.10-x86_64",
+      "output_directory": "packer-centos-5.10-x86_64"
     },
     {
       "type": "vmware",
@@ -47,6 +48,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "vm_name": "packer-centos-5.10-x86_64",
+      "output_directory": "packer-centos-5.10-x86_64",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",

--- a/packer/centos-6.4-i386.json
+++ b/packer/centos-6.4-i386.json
@@ -27,7 +27,8 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-centos-6.4-i386"
+      "vm_name": "packer-centos-6.4-i386",
+      "output_directory": "packer-centos-6.4-i386"
     },
     {
       "type": "vmware",
@@ -47,6 +48,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "vm_name": "packer-centos-6.4-i386",
+      "output_directory": "packer-centos-6.4-i386",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "480",

--- a/packer/centos-6.4-x86_64.json
+++ b/packer/centos-6.4-x86_64.json
@@ -27,7 +27,8 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-centos-6.4-x86_64"
+      "vm_name": "packer-centos-6.4-x86_64",
+      "output_directory": "packer-centos-6.4-x86_64"
     },
     {
       "type": "vmware",
@@ -47,6 +48,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "vm_name": "packer-centos-6.4-x86_64",
+      "output_directory": "packer-centos-6.4-x86_64",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "480",

--- a/packer/debian-6.0.8-amd64.json
+++ b/packer/debian-6.0.8-amd64.json
@@ -38,6 +38,7 @@
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "packer-debian-6.0.8-amd64",
+      "output_directory": "packer-debian-6.0.8-amd64",
       "vboxmanage": [
         [ "modifyvm", "{{.Name}}", "--memory", "384" ],
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
@@ -75,6 +76,8 @@
       "ssh_wait_timeout": "10000s",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "tools_upload_flavor": "linux",
+      "vm_name": "packer-debian-6.0.8-amd64",
+      "output_directory": "packer-debian-6.0.8-amd64",
       "vmx_data": {
         "memsize": "384",
         "numvcpus": "1",

--- a/packer/debian-6.0.8-i386.json
+++ b/packer/debian-6.0.8-i386.json
@@ -38,6 +38,7 @@
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "packer-debian-6.0.8-i386",
+      "output_directory": "packer-debian-6.0.8-i386",
       "vboxmanage": [
         [ "modifyvm", "{{.Name}}", "--memory", "384" ],
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
@@ -75,6 +76,8 @@
       "ssh_wait_timeout": "10000s",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "tools_upload_flavor": "linux",
+      "vm_name": "packer-debian-6.0.8-i386",
+      "output_directory": "packer-debian-6.0.8-i386",
       "vmx_data": {
         "memsize": "384",
         "numvcpus": "1",

--- a/packer/debian-7.2.0-amd64.json
+++ b/packer/debian-7.2.0-amd64.json
@@ -38,6 +38,7 @@
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "packer-debian-7.2.0-amd64",
+      "output_directory": "packer-debian-7.2.0-amd64",
       "vboxmanage": [
         [ "modifyvm", "{{.Name}}", "--memory", "384" ],
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
@@ -75,6 +76,8 @@
       "ssh_wait_timeout": "10000s",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "tools_upload_flavor": "linux",
+      "vm_name": "packer-debian-7.2.0-amd64",
+      "output_directory": "packer-debian-7.2.0-amd64",
       "vmx_data": {
         "memsize": "384",
         "numvcpus": "1",

--- a/packer/debian-7.2.0-i386.json
+++ b/packer/debian-7.2.0-i386.json
@@ -37,7 +37,8 @@
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "virtualbox_version_file": ".vbox_version",
-      "vm_name":"packer-debian-7.2.0-i386",
+      "vm_name": "packer-debian-7.2.0-i386",
+      "output_directory": "packer-debian-7.2.0-i386",
       "vboxmanage": [
         [ "modifyvm", "{{.Name}}", "--memory", "384" ],
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
@@ -75,6 +76,8 @@
       "ssh_wait_timeout": "10000s",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "tools_upload_flavor": "linux",
+      "vm_name": "packer-debian-7.2.0-i386",
+      "output_directory": "packer-debian-7.2.0-i386",
       "vmx_data": {
         "memsize": "384",
         "numvcpus": "1",

--- a/packer/fedora-18-i386.json
+++ b/packer/fedora-18-i386.json
@@ -27,7 +27,8 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-fedora-18-i386"
+      "vm_name": "packer-fedora-18-i386",
+      "output_directory": "packer-fedora-18-i386"
     },
     {
       "type": "vmware",
@@ -47,6 +48,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "vm_name": "packer-fedora-18-i386",
+      "output_directory": "packer-fedora-18-i386",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "512",

--- a/packer/fedora-18-x86_64.json
+++ b/packer/fedora-18-x86_64.json
@@ -27,7 +27,8 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-fedora-18-x86_64"
+      "vm_name": "packer-fedora-18-x86_64",
+      "output_directory": "packer-fedora-18-x86_64"
     },
     {
       "type": "vmware",
@@ -47,6 +48,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "vm_name": "packer-fedora-18-x86_64",
+      "output_directory": "packer-fedora-18-x86_64",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "512",

--- a/packer/fedora-19-i386.json
+++ b/packer/fedora-19-i386.json
@@ -27,7 +27,8 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-fedora-19-i386"
+      "vm_name": "packer-fedora-19-i386",
+      "output_directory": "packer-fedora-19-i386"
     },
     {
       "type": "vmware",
@@ -47,6 +48,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "vm_name": "packer-fedora-19-i386",
+      "output_directory": "packer-fedora-19-i386",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "512",

--- a/packer/fedora-19-x86_64.json
+++ b/packer/fedora-19-x86_64.json
@@ -27,7 +27,8 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-fedora-19-x86_64"
+      "vm_name": "packer-fedora-19-x86_64",
+      "output_directory": "packer-fedora-19-x86_64"
     },
     {
       "type": "vmware",
@@ -47,6 +48,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "vm_name": "packer-fedora-19-x86_64",
+      "output_directory": "packer-fedora-19-x86_64",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "512",

--- a/packer/fedora-20-i386.json
+++ b/packer/fedora-20-i386.json
@@ -27,7 +27,8 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-fedora-20-i386"
+      "vm_name": "packer-fedora-20-i386",
+      "output_directory": "packer-fedora-20-i386"
     },
     {
       "type": "vmware",
@@ -47,6 +48,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "vm_name": "packer-fedora-20-i386",
+      "output_directory": "packer-fedora-20-i386",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "512",

--- a/packer/fedora-20-x86_64.json
+++ b/packer/fedora-20-x86_64.json
@@ -27,7 +27,8 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-fedora-20-x86_64"
+      "vm_name": "packer-fedora-20-x86_64",
+      "output_directory": "packer-fedora-20-x86_64"
     },
     {
       "type": "vmware",
@@ -47,6 +48,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "vm_name": "packer-fedora-20-x86_64",
+      "output_directory": "packer-fedora-20-x86_64",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "512",

--- a/packer/freebsd-9.1-amd64.json
+++ b/packer/freebsd-9.1-amd64.json
@@ -47,6 +47,7 @@
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "packer-freebsd-9.1-amd64",
+      "output_directory": "packer-freebsd-9.1-amd64",
       "vboxmanage": [
         [ "modifyvm", "{{.Name}}", "--memory", "768" ],
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
@@ -81,6 +82,8 @@
       "ssh_port": 22,
       "ssh_wait_timeout": "10000s",
       "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
+      "vm_name": "packer-freebsd-9.1-amd64",
+      "output_directory": "packer-freebsd-9.1-amd64",
       "vmx_data": {
         "memsize": "768",
         "numvcpus": "1",

--- a/packer/rhel-5.10-i386.json
+++ b/packer/rhel-5.10-i386.json
@@ -26,7 +26,8 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-rhel-5.10-i386"
+      "vm_name": "packer-rhel-5.10-i386",
+      "output_directory": "packer-rhel-5.10-i386"
     },
     {
       "type": "vmware",
@@ -46,6 +47,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "vm_name": "packer-rhel-5.10-i386",
+      "output_directory": "packer-rhel-5.10-i386",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",

--- a/packer/rhel-5.10-x86_64.json
+++ b/packer/rhel-5.10-x86_64.json
@@ -26,7 +26,8 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-rhel-5.10-x86_64"
+      "vm_name": "packer-rhel-5.10-x86_64",
+      "output_directory": "packer-rhel-5.10-x86_64"
     },
     {
       "type": "vmware",
@@ -46,6 +47,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "vm_name": "packer-rhel-5.10-x86_64",
+      "output_directory": "packer-rhel-5.10-x86_64",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",

--- a/packer/rhel-6.5-i386.json
+++ b/packer/rhel-6.5-i386.json
@@ -26,7 +26,8 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-rhel-6.4-i386"
+      "vm_name": "packer-rhel-6.4-i386",
+      "output_directory": "packer-rhel-6.4-i386"
     },
     {
       "type": "vmware",
@@ -46,6 +47,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "vm_name": "packer-rhel-6.4-i386",
+      "output_directory": "packer-rhel-6.4-i386",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "480",

--- a/packer/rhel-6.5-x86_64.json
+++ b/packer/rhel-6.5-x86_64.json
@@ -26,7 +26,8 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-rhel-6.4-x86_64"
+      "vm_name": "packer-rhel-6.4-x86_64",
+      "output_directory": "packer-rhel-6.4-x86_64"
     },
     {
       "type": "vmware",
@@ -47,6 +48,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "vm_name": "packer-rhel-6.4-x86_64",
+      "output_directory": "packer-rhel-6.4-x86_64",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "480",

--- a/packer/ubuntu-10.04-amd64.json
+++ b/packer/ubuntu-10.04-amd64.json
@@ -48,7 +48,8 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-10.04-amd64"
+      "vm_name": "packer-ubuntu-10.04-amd64",
+      "output_directory": "packer-ubuntu-10.04-amd64"
     },
     {
       "type": "vmware",
@@ -89,6 +90,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "vm_name": "packer-ubuntu-10.04-amd64",
+      "output_directory": "packer-ubuntu-10.04-amd64",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",

--- a/packer/ubuntu-10.04-i386.json
+++ b/packer/ubuntu-10.04-i386.json
@@ -48,7 +48,8 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-10.04-i386"
+      "vm_name": "packer-ubuntu-10.04-i386",
+      "output_directory": "packer-ubuntu-10.04-i386"
     },
     {
       "type": "vmware",
@@ -89,6 +90,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "vm_name": "packer-ubuntu-10.04-i386",
+      "output_directory": "packer-ubuntu-10.04-i386",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",

--- a/packer/ubuntu-12.04-amd64.json
+++ b/packer/ubuntu-12.04-amd64.json
@@ -45,6 +45,7 @@
       "guest_additions_path": "VBoxGuestAdditions_{{ .Version }}.iso",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "packer-ubuntu-12.04-amd64",
+      "output_directory": "packer-ubuntu-12.04-amd64",
       "vboxmanage": [
         [ "modifyvm", "{{.Name}}", "--memory", "384" ],
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
@@ -89,6 +90,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "vm_name": "packer-ubuntu-12.04-amd64",
+      "output_directory": "packer-ubuntu-12.04-amd64",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",

--- a/packer/ubuntu-12.04-i386.json
+++ b/packer/ubuntu-12.04-i386.json
@@ -48,7 +48,8 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-12.04-i386"
+      "vm_name": "packer-ubuntu-12.04-i386",
+      "output_directory": "packer-ubuntu-12.04-i386"
     },
     {
       "type": "vmware",
@@ -89,6 +90,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "vm_name": "packer-ubuntu-12.04-i386",
+      "output_directory": "packer-ubuntu-12.04-i386",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",

--- a/packer/ubuntu-12.10-amd64.json
+++ b/packer/ubuntu-12.10-amd64.json
@@ -48,7 +48,8 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-12.10-amd64"
+      "vm_name": "packer-ubuntu-12.10-amd64",
+      "output_directory": "packer-ubuntu-12.10-amd64"
     },
     {
       "type": "vmware",
@@ -89,6 +90,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "vm_name": "packer-ubuntu-12.10-amd64",
+      "output_directory": "packer-ubuntu-12.10-amd64",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",

--- a/packer/ubuntu-12.10-i386.json
+++ b/packer/ubuntu-12.10-i386.json
@@ -48,7 +48,8 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-12.10-i386"
+      "vm_name": "packer-ubuntu-12.10-i386",
+      "output_directory": "packer-ubuntu-12.10-i386"
     },
     {
       "boot_command": [
@@ -88,6 +89,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "vm_name": "packer-ubuntu-12.10-i386",
+      "output_directory": "packer-ubuntu-12.10-i386",
       "type": "vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",

--- a/packer/ubuntu-13.04-amd64.json
+++ b/packer/ubuntu-13.04-amd64.json
@@ -48,7 +48,8 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-13.04-amd64"
+      "vm_name": "packer-ubuntu-13.04-amd64",
+      "output_directory": "packer-ubuntu-13.04-amd64"
     },
     {
       "type": "vmware",
@@ -90,6 +91,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "vm_name": "packer-ubuntu-13.04-amd64",
+      "output_directory": "packer-ubuntu-13.04-amd64",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",

--- a/packer/ubuntu-13.04-i386.json
+++ b/packer/ubuntu-13.04-i386.json
@@ -48,7 +48,8 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-13.04-i386"
+      "vm_name": "packer-ubuntu-13.04-i386",
+      "output_directory": "packer-ubuntu-13.04-i386"
     },
     {
       "type": "vmware",
@@ -89,6 +90,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "vm_name": "packer-ubuntu-13.04-i386",
+      "output_directory": "packer-ubuntu-13.04-i386",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",

--- a/packer/ubuntu-13.10-amd64.json
+++ b/packer/ubuntu-13.10-amd64.json
@@ -48,7 +48,8 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-13.10-amd64"
+      "vm_name": "packer-ubuntu-13.10-amd64",
+      "output_directory": "packer-ubuntu-13.10-amd64"
     },
     {
       "type": "vmware",
@@ -90,6 +91,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "vm_name": "packer-ubuntu-13.10-amd64",
+      "output_directory": "packer-ubuntu-13.10-amd64",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",

--- a/packer/ubuntu-13.10-i386.json
+++ b/packer/ubuntu-13.10-i386.json
@@ -48,7 +48,8 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-13.10-i386"
+      "vm_name": "packer-ubuntu-13.10-i386",
+      "output_directory": "packer-ubuntu-13.10-i386"
     },
     {
       "type": "vmware",
@@ -89,6 +90,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "vm_name": "packer-ubuntu-13.10-i386",
+      "output_directory": "packer-ubuntu-13.10-i386",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",


### PR DESCRIPTION
The current packer templates do not contain `vm_name` and therefore Packer is defaulting the virtualbox name to be set as [packer-virtualbox](https://github.com/mitchellh/packer/blob/master/builder/virtualbox/builder.go#L153)

The use case for this is when you're trying to build multiple templates concurrently, it won't work:

```
echo "centos-5.10-x86_64.json\ncentos-6.4-x86_64.json" | xargs -P20 -I% packer build -only=virtualbox %
```

Virtualbox will already see a VM named `packer-virtualbox` and will only build `centos-5.10-x86_64`.

I [already signed the CLA](https://wiki.opscode.com/display/chef/Approved+Contributors), number `1462`.

Thanks!
