### PR TITLE
Migrate to RHEL 6.5. Also be consistent about the output package name.

### DIFF
--- a/packer/rhel-5.10-x86_64.json
+++ b/packer/rhel-5.10-x86_64.json
@@ -34,7 +34,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "guest_os_type": "redhat-64",
+      "guest_os_type": "rhel5-64",
       "http_directory": "http",
       "iso_checksum": "8b38e74b0993d478aad9c950f51a3e3441199639a3422e06fc3beca1f8825bf2",
       "iso_checksum_type": "sha256",

--- a/packer/rhel-6.5-i386.json
+++ b/packer/rhel-6.5-i386.json
@@ -13,9 +13,9 @@
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "RedHat",
       "http_directory": "http",
-      "iso_checksum": "d953b7e1cc9fcc0415b78dcd79737929842575ae8b903d6868e337a2a21dcaee",
+      "iso_checksum": "eec692b436193ba9fc365cafe2b8f85323d98192dc99b23b02ae75045667fe4a",
       "iso_checksum_type": "sha256",
-      "iso_url": "https://content-web.rhn.redhat.com/rhn/isos/rhel-6.4/md5sum/2f1927af5bca9a34f2d9488655b4fdf4/rhel-server-6.4-i386-dvd.iso",
+      "iso_url": "https://content-web.rhn.redhat.com/rhn/isos/rhel-6.5/md5sum/04a1fa06a6b7e70cd586535eea83c0ef/rhel-server-6.5-i386-dvd.iso",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -36,9 +36,9 @@
       "disk_size": 40960,
       "guest_os_type": "redhat",
       "http_directory": "http",
-      "iso_checksum": "d953b7e1cc9fcc0415b78dcd79737929842575ae8b903d6868e337a2a21dcaee",
+      "iso_checksum": "eec692b436193ba9fc365cafe2b8f85323d98192dc99b23b02ae75045667fe4a",
       "iso_checksum_type": "sha256",
-      "iso_url": "https://content-web.rhn.redhat.com/rhn/isos/rhel-6.4/md5sum/2f1927af5bca9a34f2d9488655b4fdf4/rhel-server-6.4-i386-dvd.iso",
+      "iso_url": "https://content-web.rhn.redhat.com/rhn/isos/rhel-6.5/md5sum/04a1fa06a6b7e70cd586535eea83c0ef/rhel-server-6.5-i386-dvd.iso",
       "tools_upload_flavor": "linux",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
@@ -54,7 +54,7 @@
   ],
   "post-processors": [
     {
-      "output": "../builds/{{.Provider}}/opscode_rhel-6.4-i386_chef-{{user `chef_version`}}.box",
+      "output": "../builds/{{.Provider}}/opscode_rhel-6.5-i386_chef-{{user `chef_version`}}.box",
       "type": "vagrant"
     }
   ],

--- a/packer/rhel-6.5-x86_64.json
+++ b/packer/rhel-6.5-x86_64.json
@@ -13,9 +13,9 @@
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "RedHat_64",
       "http_directory": "http",
-      "iso_checksum": "1eabfc4eb1bea0d1d6c6c2802c7d44c6e68078b678186669bd2bcb87ca2ebeb8",
+      "iso_checksum": "a51b90f3dd4585781293ea08adde60eeb9cfa94670943bd99e9c07f13a259539",
       "iso_checksum_type": "sha256",
-      "iso_url": "https://content-web.rhn.redhat.com/rhn/isos/rhel-6.4/md5sum/467b53791903f9a0c477cbb1b24ffd1f/rhel-server-6.4-x86_64-dvd.iso",
+      "iso_url": "https://content-web.rhn.redhat.com/rhn/isos/rhel-6.5/md5sum/a84d4d9eddb36fb417832166cd10a4c2/rhel-server-6.5-x86_64-dvd.iso",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -34,11 +34,12 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "guest_os_type": "redhat-64",
+      "guest_os_type": "rhel6-64",
       "http_directory": "http",
-      "iso_checksum": "1eabfc4eb1bea0d1d6c6c2802c7d44c6e68078b678186669bd2bcb87ca2ebeb8",
+      "iso_checksum": "a51b90f3dd4585781293ea08adde60eeb9cfa94670943bd99e9c07f13a259539"
+,
       "iso_checksum_type": "sha256",
-      "iso_url": "https://content-web.rhn.redhat.com/rhn/isos/rhel-6.4/md5sum/467b53791903f9a0c477cbb1b24ffd1f/rhel-server-6.4-x86_64-dvd.iso",
+      "iso_url": "https://content-web.rhn.redhat.com/rhn/isos/rhel-6.5/md5sum/a84d4d9eddb36fb417832166cd10a4c2/rhel-server-6.5-x86_64-dvd.iso",
       "tools_upload_flavor": "linux",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
@@ -54,7 +55,7 @@
   ],
   "post-processors": [
     {
-      "output": "../builds/{{.Provider}}/opscode_redhat-6.4_chef-{{user `chef_version`}}.box",
+      "output": "../builds/{{.Provider}}/opscode_rhel-6.5_chef-{{user `chef_version`}}.box",
       "type": "vagrant"
     }
   ],


### PR DESCRIPTION
:construction: -- need to actually build the boxes and also maybe move the ks.cfg files to centos-6.5. Wait for CentOS 6.5?
