### PR TITLE
Bash is dead, Long live Bash.

### DIFF
--- a/packer/freebsd-9.1-i386.json
+++ b/packer/freebsd-9.1-i386.json
@@ -1,0 +1,91 @@
+{
+  "provisioners": [
+    {
+      "type": "shell",
+      "scripts": [
+        "scripts/freebsd/postinstall.csh",
+        "scripts/freebsd/cleanup.sh",
+        "scripts/common/minimize.sh"
+      ],
+      "execute_command": "cat '{{.Path}}' | su -"
+    }
+  ],
+  "builders": [
+    {
+      "type": "virtualbox",
+      "boot_command": [
+        "<esc><wait>",
+        "load geom_mbr<wait>",
+        "<enter><wait>",
+        "load zfs<wait>",
+        "<enter><wait>",
+        "boot -s<wait>",
+        "<enter><wait>",
+        "<wait10><wait10>",
+        "/bin/sh<enter><wait>",
+        "mdmfs -s 100m md1 /tmp<enter><wait>",
+        "dhclient -l /tmp/dhclient.lease.em0 em0<enter><wait>",
+        "fetch -o /tmp/install.sh http://{{ .HTTPIP }}:{{ .HTTPPort }}/freebsd-9.1/install.sh && chmod +x /tmp/install.sh && /tmp/install.sh {{ .Name }}<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 10140,
+      "guest_os_type": "FreeBSD_64",
+      "http_directory": "http",
+      "iso_checksum": "e37d86ce83908bf4b667fdae7298bca5",
+      "iso_checksum_type": "md5",
+      "iso_url": "http://ftp.freebsd.org/pub/FreeBSD/releases/i386/i386/ISO-IMAGES/9.1/FreeBSD-9.1-RELEASE-i386-disc1.iso",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "virtualbox_version_file": ".vbox_version",
+      "vboxmanage": [
+        [ "modifyvm", "{{.Name}}", "--memory", "768" ],
+        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+      ]
+    },
+    {
+      "type": "vmware",
+      "boot_command": [
+        "<esc><wait>",
+        "load geom_mbr<wait>",
+        "<enter><wait>",
+        "load zfs<wait>",
+        "<enter><wait>",
+        "boot -s<wait>",
+        "<enter><wait>",
+        "<wait10><wait10>",
+        "/bin/sh<enter><wait>",
+        "mdmfs -s 100m md1 /tmp<enter><wait>",
+        "dhclient -l /tmp/dhclient.lease.em0 em0<enter><wait>",
+        "<wait5>",
+        "fetch -o /tmp/install.sh http://{{ .HTTPIP }}:{{ .HTTPPort }}/freebsd-9.1/install.sh && chmod +x /tmp/install.sh && /tmp/install.sh {{ .Name }}<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 10140,
+      "guest_os_type": "freebsd-64",
+      "http_directory": "http",
+      "iso_checksum": "e37d86ce83908bf4b667fdae7298bca5",
+      "iso_checksum_type": "md5",
+      "iso_url": "http://ftp.freebsd.org/pub/FreeBSD/releases/i386/i386/ISO-IMAGES/9.1/FreeBSD-9.1-RELEASE-i386-disc1.iso",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
+      "vmx_data": {
+        "memsize": "768",
+        "numvcpus": "1",
+        "cpuid.coresPerSocket": "1"
+      }
+    }
+  ],
+  "post-processors": [
+    {
+      "output": "../builds/{{.Provider}}/opscode_freebsd-9.1_provisionerless.box",
+      "type": "vagrant"
+    }
+  ]
+}

--- a/packer/scripts/freebsd/postinstall.csh
+++ b/packer/scripts/freebsd/postinstall.csh
@@ -17,7 +17,7 @@ env PAGER=/bin/cat /tmp/freebsd-update fetch
 env PAGER=/bin/cat /tmp/freebsd-update install
 
 #Install sudo and bash and curl
-pkg_add -r sudo bash-static curl
+pkg_add -r sudo curl
 
 #Installing vagrant keys
 mkdir /home/vagrant/.ssh
@@ -26,12 +26,6 @@ cd /home/vagrant/.ssh
 fetch -am -o authorized_keys 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub'
 chown -R vagrant /home/vagrant/.ssh
 chmod -R go-rwsx /home/vagrant/.ssh
-
-# Cleaning portstree to save space
-# http://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/ports-using.html
-pkg_add -r portupgrade
-
-/usr/local/sbin/portsclean -C
 
 # As sharedfolders are not in defaults ports tree
 # We will use vagrant via NFS


### PR DESCRIPTION
This adjusts the following
- Remove bash - no longer needed for vagrant
- Removes installing portsclean - as cleanup script does this
- Add a Freebsd i386 9.1 build config

This should finalize https://github.com/opscode/bento/pull/108
