### PR TITLE
Repair incorrect SHA1 checksum on Ubuntu 12.04-i386 box

### DIFF
--- a/packer/ubuntu-12.04-i386.json
+++ b/packer/ubuntu-12.04-i386.json
@@ -81,7 +81,7 @@
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
       "http_directory": "http",
-      "iso_checksum": "f6fb4e12e12e6ba4247aee5985dd92cc5a653122",
+      "iso_checksum": "2ec0e913959f6c2ba7a558e8bfa361428bb00e56",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/12.04/ubuntu-12.04.3-server-i386.iso",
       "tools_upload_flavor": "linux",


### PR DESCRIPTION
The VMWare clause didn't match VirtualBox and caused the box to be redownloaded every time only for the build to fail.
