### PR TITLE
Reduce memory usage of FreeBSD box to 512M

### DIFF
--- a/packer/freebsd-9.2-i386.json
+++ b/packer/freebsd-9.2-i386.json
@@ -49,7 +49,7 @@
       "vm_name": "packer-freebsd-9.2-i386",
       "output_directory": "packer-freebsd-9.2-i386",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "768" ],
+        [ "modifyvm", "{{.Name}}", "--memory", "512" ],
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ]
     },
@@ -86,7 +86,7 @@
       "vm_name": "packer-freebsd-9.2-i386",
       "output_directory": "packer-freebsd-9.2-i386",
       "vmx_data": {
-        "memsize": "768",
+        "memsize": "512",
         "numvcpus": "1",
         "cpuid.coresPerSocket": "1"
       }


### PR DESCRIPTION
Now that we use the swapspace right away, we don't need 768M of memory.

This is already in the amd64 template but was missed in the i386 template.
