### PR TITLE
Allow building provisionered OmniOS boxes.

### DIFF
--- a/packer/omnios-r151008f.json
+++ b/packer/omnios-r151008f.json
@@ -8,9 +8,11 @@
       "type": "shell",
       "scripts": [
         "scripts/omnios/vmtools.sh",
+        "scripts/common/chef.sh",
         "scripts/omnios/postinstall.sh"
       ],
-      "execute_command": "{{.Vars}} sh '{{.Path}}'"
+      "execute_command": "export {{.Vars}} && sh '{{.Path}}'",
+      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ]
     }
   ],
   "post-processors": [

--- a/packer/scripts/common/chef.sh
+++ b/packer/scripts/common/chef.sh
@@ -185,14 +185,15 @@ do_download() {
 
 if [ x$CHEF_VERSION != x'provisionerless' ]; then
   do_download "$chef_installer_url" "$chef_installer"
+  chmod +x $chef_installer
   if [ x$CHEF_VERSION == x'latest' ]; then
-    sh "$chef_installer"
+    $chef_installer
   elif [ x$CHEF_VERSION == x'prerelease' ]; then
-    sh "$chef_installer" -p
+    $chef_installer -p
   else
-    sh "$chef_installer" -v $CHEF_VERSION
+    $chef_installer -v $CHEF_VERSION
   fi
-  rm -f "$chef_installer"
+  rm -f $chef_installer
 else
   echo "Building a box without Chef"
 fi


### PR DESCRIPTION
Make chef.sh more reliable by not shelling so much. Just chmod +x the downloaded script.
