### PR TITLE
Update sshd.sh

### DIFF
--- a/packer/scripts/common/sshd.sh
+++ b/packer/scripts/common/sshd.sh
@@ -1,3 +1,4 @@
 #!/bin/bash -eux
 
 echo "UseDNS no" >> /etc/ssh/sshd_config
+echo "GSSAPIAuthentication no" >> /etc/ssh/sshd_config


### PR DESCRIPTION
Update to prevent centos and redhat delay during login of around 20 seconds on initial startup.   Does not happen if you already have the GSSAPI infrastructure setup correctly but most folks don't, and those who do will be able to re-configure this easily.  In other words, GSSAPI disabled by default.
