### PR TITLE
Packer 0.5.x compatibility

### DIFF
--- a/packer/centos-5.10-i386.json
+++ b/packer/centos-5.10-i386.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-5.10/ks.cfg<enter><wait>"
       ],
@@ -31,7 +31,7 @@
       "output_directory": "packer-centos-5.10-i386-virtualbox"
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-5.10/ks.cfg<enter><wait>"
       ],

--- a/packer/centos-5.10-x86_64.json
+++ b/packer/centos-5.10-x86_64.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-5.10/ks.cfg<enter><wait>"
       ],
@@ -31,7 +31,7 @@
       "output_directory": "packer-centos-5.10-x86_64-virtualbox"
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-5.10/ks.cfg<enter><wait>"
       ],

--- a/packer/centos-6.5-i386.json
+++ b/packer/centos-6.5-i386.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-6.5/ks.cfg<enter><wait>"
       ],
@@ -31,7 +31,7 @@
       "output_directory": "packer-centos-6.5-i386-virtualbox"
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-6.5/ks.cfg<enter><wait>"
       ],

--- a/packer/centos-6.5-x86_64.json
+++ b/packer/centos-6.5-x86_64.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-6.5/ks.cfg<enter><wait>"
       ],
@@ -31,7 +31,7 @@
       "output_directory": "packer-centos-6.5-x86_64-virtualbox"
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-6.5/ks.cfg<enter><wait>"
       ],

--- a/packer/debian-6.0.8-amd64.json
+++ b/packer/debian-6.0.8-amd64.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -45,7 +45,7 @@
       ]
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",

--- a/packer/debian-6.0.8-i386.json
+++ b/packer/debian-6.0.8-i386.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -45,7 +45,7 @@
       ]
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",

--- a/packer/debian-7.2.0-amd64.json
+++ b/packer/debian-7.2.0-amd64.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -45,7 +45,7 @@
       ]
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",

--- a/packer/debian-7.2.0-i386.json
+++ b/packer/debian-7.2.0-i386.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -45,7 +45,7 @@
       ]
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",

--- a/packer/fedora-18-i386.json
+++ b/packer/fedora-18-i386.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-18/ks.cfg<enter><wait>"
       ],
@@ -31,7 +31,7 @@
       "output_directory": "packer-fedora-18-i386-virtualbox"
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-18/ks.cfg<enter><wait>"
       ],

--- a/packer/fedora-18-x86_64.json
+++ b/packer/fedora-18-x86_64.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-18/ks.cfg<enter><wait>"
       ],
@@ -31,7 +31,7 @@
       "output_directory": "packer-fedora-18-x86_64-virtualbox"
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-18/ks.cfg<enter><wait>"
       ],

--- a/packer/fedora-19-i386.json
+++ b/packer/fedora-19-i386.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-19/ks.cfg<enter><wait>"
       ],
@@ -31,7 +31,7 @@
       "output_directory": "packer-fedora-19-i386-virtualbox"
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-19/ks.cfg<enter><wait>"
       ],

--- a/packer/fedora-19-x86_64.json
+++ b/packer/fedora-19-x86_64.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-19/ks.cfg<enter><wait>"
       ],
@@ -31,7 +31,7 @@
       "output_directory": "packer-fedora-19-x86_64-virtualbox"
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-19/ks.cfg<enter><wait>"
       ],

--- a/packer/fedora-20-i386.json
+++ b/packer/fedora-20-i386.json
@@ -5,7 +5,7 @@
   }, 
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-20/ks.cfg<enter><wait>"
       ],
@@ -31,7 +31,7 @@
       "output_directory": "packer-fedora-20-i386-virtualbox"
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-20/ks.cfg<enter><wait>"
       ],

--- a/packer/fedora-20-x86_64.json
+++ b/packer/fedora-20-x86_64.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-20/ks.cfg<enter><wait>"
       ],
@@ -31,7 +31,7 @@
       "output_directory": "packer-fedora-20-x86_64-virtualbox"
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-20/ks.cfg<enter><wait>"
       ],

--- a/packer/freebsd-9.2-amd64.json
+++ b/packer/freebsd-9.2-amd64.json
@@ -19,7 +19,7 @@
   ],
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><wait>",
         "load geom_mbr<wait>",
@@ -57,7 +57,7 @@
       ]
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<esc><wait>",
         "load geom_mbr<wait>",

--- a/packer/freebsd-9.2-i386.json
+++ b/packer/freebsd-9.2-i386.json
@@ -18,7 +18,7 @@
   ],
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><wait>",
         "load geom_mbr<wait>",
@@ -56,7 +56,7 @@
       ]
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<esc><wait>",
         "load geom_mbr<wait>",

--- a/packer/omnios-r151008f.json
+++ b/packer/omnios-r151008f.json
@@ -24,7 +24,7 @@
   ],
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "guest_os_type": "OpenSolaris_64",
       "iso_url": "{{user `mirror`}}/OmniOS_Text_r151008f.iso",
       "iso_checksum": "d64d206c1e5aeeb61c5b579dd39ed11a86ef5737",
@@ -73,7 +73,7 @@
       ]
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "guest_os_type": "solaris11-64",
       "iso_url": "{{user `mirror`}}/OmniOS_Text_r151008f.iso",
       "iso_checksum": "d64d206c1e5aeeb61c5b579dd39ed11a86ef5737",

--- a/packer/rhel-5.10-i386.json
+++ b/packer/rhel-5.10-i386.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-5.10/ks.cfg<enter><wait>"
       ],
@@ -31,7 +31,7 @@
       "output_directory": "packer-rhel-5.10-i386-virtualbox"
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-5.10/ks.cfg<enter><wait>"
       ],

--- a/packer/rhel-5.10-x86_64.json
+++ b/packer/rhel-5.10-x86_64.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-5.10/ks.cfg<enter><wait>"
       ],
@@ -31,7 +31,7 @@
       "output_directory": "packer-rhel-5.10-x86_64-virtualbox"
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-5.10/ks.cfg<enter><wait>"
       ],

--- a/packer/rhel-6.5-i386.json
+++ b/packer/rhel-6.5-i386.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-6.5/ks.cfg<enter><wait>"
       ],
@@ -31,7 +31,7 @@
       "output_directory": "packer-rhel-6.5-i386-virtualbox"
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-6.5/ks.cfg<enter><wait>"
       ],

--- a/packer/rhel-6.5-x86_64.json
+++ b/packer/rhel-6.5-x86_64.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-6.5/ks.cfg<enter><wait>"
       ],
@@ -31,7 +31,7 @@
       "output_directory": "packer-rhel-6.5-x86_64-virtualbox"
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-6.5/ks.cfg<enter><wait>"
       ],

--- a/packer/sles-11-sp2-i386.json
+++ b/packer/sles-11-sp2-i386.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><enter><wait>",
         "linux netdevice=eth0 netsetup=dhcp install=cd:/<wait>",
@@ -45,7 +45,7 @@
       ]
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<esc><enter><wait>",
         "linux netdevice=eth0 netsetup=dhcp install=cd:/<wait>",

--- a/packer/sles-11-sp2-x86_64.json
+++ b/packer/sles-11-sp2-x86_64.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><enter><wait>",
         "linux netdevice=eth0 netsetup=dhcp install=cd:/<wait>",
@@ -45,7 +45,7 @@
       ]
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<esc><enter><wait>",
         "linux netdevice=eth0 netsetup=dhcp install=cd:/<wait>",

--- a/packer/sles-11-sp3-i386.json
+++ b/packer/sles-11-sp3-i386.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><enter><wait>",
         "linux netdevice=eth0 netsetup=dhcp install=cd:/<wait>",
@@ -45,7 +45,7 @@
       ]
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<esc><enter><wait>",
         "linux netdevice=eth0 netsetup=dhcp install=cd:/<wait>",

--- a/packer/sles-11-sp3-x86_64.json
+++ b/packer/sles-11-sp3-x86_64.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><enter><wait>",
         "linux netdevice=eth0 netsetup=dhcp install=cd:/<wait>",
@@ -45,7 +45,7 @@
       ]
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<esc><enter><wait>",
         "linux netdevice=eth0 netsetup=dhcp install=cd:/<wait>",

--- a/packer/ubuntu-10.04-amd64.json
+++ b/packer/ubuntu-10.04-amd64.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -52,7 +52,7 @@
       "output_directory": "packer-ubuntu-10.04-amd64-virtualbox"
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",

--- a/packer/ubuntu-10.04-i386.json
+++ b/packer/ubuntu-10.04-i386.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -52,7 +52,7 @@
       "output_directory": "packer-ubuntu-10.04-i386-virtualbox"
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",

--- a/packer/ubuntu-12.04-amd64.json
+++ b/packer/ubuntu-12.04-amd64.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -52,7 +52,7 @@
       ]
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",

--- a/packer/ubuntu-12.04-i386.json
+++ b/packer/ubuntu-12.04-i386.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -52,7 +52,7 @@
       "output_directory": "packer-ubuntu-12.04-i386-virtualbox"
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",

--- a/packer/ubuntu-12.10-amd64.json
+++ b/packer/ubuntu-12.10-amd64.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -52,7 +52,7 @@
       "output_directory": "packer-ubuntu-12.10-amd64-virtualbox"
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",

--- a/packer/ubuntu-12.10-i386.json
+++ b/packer/ubuntu-12.10-i386.json
@@ -42,7 +42,7 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "vboxmanage": [
         [ "modifyvm", "{{.Name}}", "--memory", "384" ],
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
@@ -91,7 +91,7 @@
       "ssh_wait_timeout": "10000s",
       "vm_name": "packer-ubuntu-12.10-i386",
       "output_directory": "packer-ubuntu-12.10-i386-vmware",
-      "type": "vmware",
+      "type": "vmware-iso",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",

--- a/packer/ubuntu-13.04-amd64.json
+++ b/packer/ubuntu-13.04-amd64.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -52,7 +52,7 @@
       "output_directory": "packer-ubuntu-13.04-amd64-virtualbox"
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",

--- a/packer/ubuntu-13.04-i386.json
+++ b/packer/ubuntu-13.04-i386.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -52,7 +52,7 @@
       "output_directory": "packer-ubuntu-13.04-i386-virtualbox"
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",

--- a/packer/ubuntu-13.10-amd64.json
+++ b/packer/ubuntu-13.10-amd64.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -52,7 +52,7 @@
       "output_directory": "packer-ubuntu-13.10-amd64-virtualbox"
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",

--- a/packer/ubuntu-13.10-i386.json
+++ b/packer/ubuntu-13.10-i386.json
@@ -5,7 +5,7 @@
   },
   "builders": [
     {
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -52,7 +52,7 @@
       "output_directory": "packer-ubuntu-13.10-i386-virtualbox"
     },
     {
-      "type": "vmware",
+      "type": "vmware-iso",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",


### PR DESCRIPTION
Packer 0.5.0 introduced some [backwards incompatiblities].(https://github.com/mitchellh/packer/blob/master/CHANGELOG.md#050-12302013)

The builders `virtualbox` and `vmware` got renamed to `virtualbox-iso` and `vmware-iso` respectively.

Thanks for looking into it!
