### PR TITLE
Update to packer 0.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 rvm:
   - 2.0.0
 
-before_install: wget --no-check-certificate https://dl.bintray.com/mitchellh/packer/0.4.1_linux_amd64.zip && unzip -d packer 0.4.1_linux_amd64.zip
+before_install: wget --no-check-certificate https://dl.bintray.com/mitchellh/packer/0.5.1_linux_amd64.zip && unzip -d packer 0.5.1_linux_amd64.zip
 before_script: export PATH=$PATH:$PWD/packer
 
 script: bundle exec thor packer:validate

--- a/packer/centos-5.10-i386.json
+++ b/packer/centos-5.10-i386.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://mirrors.kernel.org/centos"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-5.10/ks.cfg<enter><wait>"
       ],
@@ -17,21 +12,31 @@
       "iso_checksum": "bb4e61210e1c0389fdf55c59bd2dd7bc957dd400",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/5.10/isos/i386/CentOS-5.10-i386-bin-DVD-1of2.iso",
+      "output_directory": "packer-centos-5.10-i386-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "384"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-centos-5.10-i386",
-      "output_directory": "packer-centos-5.10-i386-virtualbox"
+      "vm_name": "packer-centos-5.10-i386"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-5.10/ks.cfg<enter><wait>"
       ],
@@ -42,14 +47,15 @@
       "iso_checksum": "bb4e61210e1c0389fdf55c59bd2dd7bc957dd400",
       "iso_checksum_type": "sha1",
       "iso_url": "http://mirrors.kernel.org/centos/5.10/isos/i386/CentOS-5.10-i386-bin-DVD-1of2.iso",
-      "tools_upload_flavor": "linux",
+      "output_directory": "packer-centos-5.10-i386-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-centos-5.10-i386",
-      "output_directory": "packer-centos-5.10-i386-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -65,7 +71,9 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
         "scripts/common/vagrant.sh",
@@ -77,5 +85,10 @@
       ],
       "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://mirrors.kernel.org/centos"
+  }
 }
+

--- a/packer/centos-5.10-x86_64.json
+++ b/packer/centos-5.10-x86_64.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://mirrors.kernel.org/centos"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-5.10/ks.cfg<enter><wait>"
       ],
@@ -17,21 +12,31 @@
       "iso_checksum": "d8403b3fe4972eda3e147ee76d682a4a3beae1e1",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/5.10/isos/x86_64/CentOS-5.10-x86_64-bin-DVD-1of2.iso",
+      "output_directory": "packer-centos-5.10-x86_64-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "384"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-centos-5.10-x86_64",
-      "output_directory": "packer-centos-5.10-x86_64-virtualbox"
+      "vm_name": "packer-centos-5.10-x86_64"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-5.10/ks.cfg<enter><wait>"
       ],
@@ -42,14 +47,15 @@
       "iso_checksum": "d8403b3fe4972eda3e147ee76d682a4a3beae1e1",
       "iso_checksum_type": "sha1",
       "iso_url": "http://mirrors.kernel.org/centos/5.10/isos/x86_64/CentOS-5.10-x86_64-bin-DVD-1of2.iso",
-      "tools_upload_flavor": "linux",
+      "output_directory": "packer-centos-5.10-x86_64-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-centos-5.10-x86_64",
-      "output_directory": "packer-centos-5.10-x86_64-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -65,7 +71,9 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
         "scripts/common/vagrant.sh",
@@ -77,5 +85,10 @@
       ],
       "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://mirrors.kernel.org/centos"
+  }
 }
+

--- a/packer/centos-6.5-i386.json
+++ b/packer/centos-6.5-i386.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://mirrors.kernel.org/centos"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-6.5/ks.cfg<enter><wait>"
       ],
@@ -17,21 +12,31 @@
       "iso_checksum": "67ea68068ae53d1f23431072ec0288b3e1abfe4d",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/6.5/isos/i386/CentOS-6.5-i386-bin-DVD1.iso",
+      "output_directory": "packer-centos-6.5-i386-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "480" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "480"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-centos-6.5-i386",
-      "output_directory": "packer-centos-6.5-i386-virtualbox"
+      "vm_name": "packer-centos-6.5-i386"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-6.5/ks.cfg<enter><wait>"
       ],
@@ -42,14 +47,15 @@
       "iso_checksum": "67ea68068ae53d1f23431072ec0288b3e1abfe4d",
       "iso_checksum_type": "sha1",
       "iso_url": "http://mirrors.kernel.org/centos/6.5/isos/i386/CentOS-6.5-i386-bin-DVD1.iso",
-      "tools_upload_flavor": "linux",
+      "output_directory": "packer-centos-6.5-i386-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-centos-6.5-i386",
-      "output_directory": "packer-centos-6.5-i386-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "480",
@@ -65,7 +71,9 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
         "scripts/common/sshd.sh",
@@ -77,6 +85,10 @@
       ],
       "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://mirrors.kernel.org/centos"
+  }
 }
 

--- a/packer/centos-6.5-x86_64.json
+++ b/packer/centos-6.5-x86_64.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://mirrors.kernel.org/centos"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-6.5/ks.cfg<enter><wait>"
       ],
@@ -17,21 +12,31 @@
       "iso_checksum": "32c7695b97f7dcd1f59a77a71f64f2957dddf738",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/6.5/isos/x86_64/CentOS-6.5-x86_64-bin-DVD1.iso",
+      "output_directory": "packer-centos-6.5-x86_64-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "480" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "480"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-centos-6.5-x86_64",
-      "output_directory": "packer-centos-6.5-x86_64-virtualbox"
+      "vm_name": "packer-centos-6.5-x86_64"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-6.5/ks.cfg<enter><wait>"
       ],
@@ -42,14 +47,15 @@
       "iso_checksum": "32c7695b97f7dcd1f59a77a71f64f2957dddf738",
       "iso_checksum_type": "sha1",
       "iso_url": "http://mirrors.kernel.org/centos/6.5/isos/x86_64/CentOS-6.5-x86_64-bin-DVD1.iso",
-      "tools_upload_flavor": "linux",
+      "output_directory": "packer-centos-6.5-x86_64-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-centos-6.5-x86_64",
-      "output_directory": "packer-centos-6.5-x86_64-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "480",
@@ -65,7 +71,9 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
         "scripts/common/sshd.sh",
@@ -77,5 +85,10 @@
       ],
       "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://mirrors.kernel.org/centos"
+  }
 }
+

--- a/packer/debian-6.0.8-amd64.json
+++ b/packer/debian-6.0.8-amd64.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://cdimage.debian.org/cdimage/archive"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -25,27 +20,37 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "Debian_64",
       "http_directory": "http",
       "iso_checksum": "d0ec1c64c00ff601995139dbacfb54109a23788f",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/6.0.8/amd64/iso-cd/debian-6.0.8-amd64-CD-1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-debian-6.0.8-amd64-virtualbox",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
-      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
-      "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-debian-6.0.8-amd64",
-      "output_directory": "packer-debian-6.0.8-amd64-virtualbox",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
-      ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "384"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-debian-6.0.8-amd64"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -70,30 +75,34 @@
       "iso_checksum": "d0ec1c64c00ff601995139dbacfb54109a23788f",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/6.0.8/amd64/iso-cd/debian-6.0.8-amd64-CD-1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-debian-6.0.8-amd64-vmware",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-debian-6.0.8-amd64",
-      "output_directory": "packer-debian-6.0.8-amd64-vmware",
       "vmx_data": {
+        "cpuid.coresPerSocket": "1",
         "memsize": "384",
-        "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
+        "numvcpus": "1"
       }
     }
   ],
   "post-processors": [
     {
-      "type": "vagrant",
-      "output": "../builds/{{.Provider}}/opscode_debian-6.0.8_chef-{{user `chef_version`}}.box"
+      "output": "../builds/{{.Provider}}/opscode_debian-6.0.8_chef-{{user `chef_version`}}.box",
+      "type": "vagrant"
     }
   ],
   "provisioners": [
     {
-      "type": "shell",
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
+      "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
         "scripts/debian/update.sh",
         "scripts/common/sshd.sh",
@@ -105,8 +114,12 @@
         "scripts/debian/cleanup.sh",
         "scripts/common/minimize.sh"
       ],
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
-      "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'"
+      "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://cdimage.debian.org/cdimage/archive"
+  }
 }
+

--- a/packer/debian-6.0.8-i386.json
+++ b/packer/debian-6.0.8-i386.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://cdimage.debian.org/cdimage/archive"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -25,27 +20,37 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "Debian",
       "http_directory": "http",
       "iso_checksum": "144194cea77f0e527fd07bd6aa28d1ab50cb5a95",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/6.0.8/i386/iso-cd/debian-6.0.8-i386-CD-1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-debian-6.0.8-i386-virtualbox",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
-      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
-      "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-debian-6.0.8-i386",
-      "output_directory": "packer-debian-6.0.8-i386-virtualbox",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
-      ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "384"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-debian-6.0.8-i386"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -70,29 +75,33 @@
       "iso_checksum": "144194cea77f0e527fd07bd6aa28d1ab50cb5a95",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/6.0.8/i386/iso-cd/debian-6.0.8-i386-CD-1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-debian-6.0.8-i386-vmware",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-debian-6.0.8-i386",
-      "output_directory": "packer-debian-6.0.8-i386-vmware",
       "vmx_data": {
+        "cpuid.coresPerSocket": "1",
         "memsize": "384",
-        "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
+        "numvcpus": "1"
       }
     }
   ],
   "post-processors": [
     {
-      "type": "vagrant",
-      "output": "../builds/{{.Provider}}/opscode_debian-6.0.8-i386_chef-{{user `chef_version`}}.box"
+      "output": "../builds/{{.Provider}}/opscode_debian-6.0.8-i386_chef-{{user `chef_version`}}.box",
+      "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
         "scripts/debian/update.sh",
@@ -105,8 +114,12 @@
         "scripts/debian/cleanup.sh",
         "scripts/common/minimize.sh"
       ],
-      "type": "shell",
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ]
+      "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://cdimage.debian.org/cdimage/archive"
+  }
 }
+

--- a/packer/debian-7.2.0-amd64.json
+++ b/packer/debian-7.2.0-amd64.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://cdimage.debian.org/debian-cd"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -25,27 +20,37 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "Debian_64",
       "http_directory": "http",
       "iso_checksum": "c7c1e2bf7ec4760b9fecf77fefa6062b73330359",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/7.2.0/amd64/iso-cd/debian-7.2.0-amd64-CD-1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-debian-7.2.0-amd64-virtualbox",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
-      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
-      "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-debian-7.2.0-amd64",
-      "output_directory": "packer-debian-7.2.0-amd64-virtualbox",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
-      ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "384"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-debian-7.2.0-amd64"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -70,29 +75,33 @@
       "iso_checksum": "c7c1e2bf7ec4760b9fecf77fefa6062b73330359",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/7.2.0/amd64/iso-cd/debian-7.2.0-amd64-CD-1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-debian-7.2.0-amd64-vmware",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-debian-7.2.0-amd64",
-      "output_directory": "packer-debian-7.2.0-amd64-vmware",
       "vmx_data": {
+        "cpuid.coresPerSocket": "1",
         "memsize": "384",
-        "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
+        "numvcpus": "1"
       }
     }
   ],
   "post-processors": [
     {
-      "type": "vagrant",
-      "output": "../builds/{{.Provider}}/opscode_debian-7.2.0_chef-{{user `chef_version`}}.box"
+      "output": "../builds/{{.Provider}}/opscode_debian-7.2.0_chef-{{user `chef_version`}}.box",
+      "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
         "scripts/debian/update.sh",
@@ -105,8 +114,12 @@
         "scripts/debian/cleanup.sh",
         "scripts/common/minimize.sh"
       ],
-      "type": "shell",
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ]
+      "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://cdimage.debian.org/debian-cd"
+  }
 }
+

--- a/packer/debian-7.2.0-i386.json
+++ b/packer/debian-7.2.0-i386.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://cdimage.debian.org/debian-cd"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -25,27 +20,37 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "Debian",
       "http_directory": "http",
       "iso_checksum": "011d42505fdafeb9be2bd0379a12d4042f24cfd5",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/7.2.0/i386/iso-cd/debian-7.2.0-i386-CD-1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-debian-7.2.0-i386-virtualbox",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
-      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
-      "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-debian-7.2.0-i386",
-      "output_directory": "packer-debian-7.2.0-i386-virtualbox",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
-      ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "384"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-debian-7.2.0-i386"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -70,29 +75,33 @@
       "iso_checksum": "011d42505fdafeb9be2bd0379a12d4042f24cfd5",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/7.2.0/i386/iso-cd/debian-7.2.0-i386-CD-1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-debian-7.2.0-i386-vmware",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-debian-7.2.0-i386",
-      "output_directory": "packer-debian-7.2.0-i386-vmware",
       "vmx_data": {
+        "cpuid.coresPerSocket": "1",
         "memsize": "384",
-        "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
+        "numvcpus": "1"
       }
     }
   ],
   "post-processors": [
     {
-      "type": "vagrant",
-      "output": "../builds/{{.Provider}}/opscode_debian-7.2.0-i386_chef-{{user `chef_version`}}.box"
+      "output": "../builds/{{.Provider}}/opscode_debian-7.2.0-i386_chef-{{user `chef_version`}}.box",
+      "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
         "scripts/debian/update.sh",
@@ -105,8 +114,12 @@
         "scripts/debian/cleanup.sh",
         "scripts/common/minimize.sh"
       ],
-      "type": "shell",
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ]
+      "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://cdimage.debian.org/debian-cd"
+  }
 }
+

--- a/packer/fedora-18-i386.json
+++ b/packer/fedora-18-i386.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://mirrors.kernel.org/fedora"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-18/ks.cfg<enter><wait>"
       ],
@@ -17,21 +12,31 @@
       "iso_checksum": "a22e6ab7b0e5e93397e4a1d8d994693d0afb9ad46b1f47a4fe10bfbbc2e7f354",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/18/Fedora/i386/iso/Fedora-18-i386-DVD.iso",
+      "output_directory": "packer-fedora-18-i386-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "512" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "512"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-fedora-18-i386",
-      "output_directory": "packer-fedora-18-i386-virtualbox"
+      "vm_name": "packer-fedora-18-i386"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-18/ks.cfg<enter><wait>"
       ],
@@ -42,14 +47,15 @@
       "iso_checksum": "a22e6ab7b0e5e93397e4a1d8d994693d0afb9ad46b1f47a4fe10bfbbc2e7f354",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/18/Fedora/i386/iso/Fedora-18-i386-DVD.iso",
-      "tools_upload_flavor": "linux",
+      "output_directory": "packer-fedora-18-i386-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-fedora-18-i386",
-      "output_directory": "packer-fedora-18-i386-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "512",
@@ -65,7 +71,9 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
         "scripts/common/sshd.sh",
@@ -77,6 +85,10 @@
       ],
       "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://mirrors.kernel.org/fedora"
+  }
 }
 

--- a/packer/fedora-18-x86_64.json
+++ b/packer/fedora-18-x86_64.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://mirrors.kernel.org/fedora"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-18/ks.cfg<enter><wait>"
       ],
@@ -17,21 +12,31 @@
       "iso_checksum": "91c5f0aca391acf76a047e284144f90d66d3d5f5dcd26b01f368a43236832c03",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/18/Fedora/x86_64/iso/Fedora-18-x86_64-DVD.iso",
+      "output_directory": "packer-fedora-18-x86_64-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "512" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "512"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-fedora-18-x86_64",
-      "output_directory": "packer-fedora-18-x86_64-virtualbox"
+      "vm_name": "packer-fedora-18-x86_64"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-18/ks.cfg<enter><wait>"
       ],
@@ -42,14 +47,15 @@
       "iso_checksum": "91c5f0aca391acf76a047e284144f90d66d3d5f5dcd26b01f368a43236832c03",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/18/Fedora/x86_64/iso/Fedora-18-x86_64-DVD.iso",
-      "tools_upload_flavor": "linux",
+      "output_directory": "packer-fedora-18-x86_64-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-fedora-18-x86_64",
-      "output_directory": "packer-fedora-18-x86_64-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "512",
@@ -65,7 +71,9 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
         "scripts/common/sshd.sh",
@@ -77,6 +85,10 @@
       ],
       "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://mirrors.kernel.org/fedora"
+  }
 }
 

--- a/packer/fedora-19-i386.json
+++ b/packer/fedora-19-i386.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://mirrors.kernel.org/fedora"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-19/ks.cfg<enter><wait>"
       ],
@@ -17,21 +12,31 @@
       "iso_checksum": "0da29695c4f503e2b27350406c1ceb7a4e5b9b699ea722774368fd16ab277bce",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/19/Fedora/i386/iso/Fedora-19-i386-DVD.iso",
+      "output_directory": "packer-fedora-19-i386-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "512" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "512"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-fedora-19-i386",
-      "output_directory": "packer-fedora-19-i386-virtualbox"
+      "vm_name": "packer-fedora-19-i386"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-19/ks.cfg<enter><wait>"
       ],
@@ -42,14 +47,15 @@
       "iso_checksum": "0da29695c4f503e2b27350406c1ceb7a4e5b9b699ea722774368fd16ab277bce",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/19/Fedora/i386/iso/Fedora-19-i386-DVD.iso",
-      "tools_upload_flavor": "linux",
+      "output_directory": "packer-fedora-19-i386-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-fedora-19-i386",
-      "output_directory": "packer-fedora-19-i386-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "512",
@@ -65,7 +71,9 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
         "scripts/common/sshd.sh",
@@ -77,6 +85,10 @@
       ],
       "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://mirrors.kernel.org/fedora"
+  }
 }
 

--- a/packer/fedora-19-x86_64.json
+++ b/packer/fedora-19-x86_64.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://mirrors.kernel.org/fedora"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-19/ks.cfg<enter><wait>"
       ],
@@ -17,21 +12,31 @@
       "iso_checksum": "6e7e263e607cfcadc90ea2ef5668aa3945d9eca596485a7a1f8a9f2478cc7084",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/19/Fedora/x86_64/iso/Fedora-19-x86_64-DVD.iso",
+      "output_directory": "packer-fedora-19-x86_64-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "512" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "512"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-fedora-19-x86_64",
-      "output_directory": "packer-fedora-19-x86_64-virtualbox"
+      "vm_name": "packer-fedora-19-x86_64"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-19/ks.cfg<enter><wait>"
       ],
@@ -42,14 +47,15 @@
       "iso_checksum": "6e7e263e607cfcadc90ea2ef5668aa3945d9eca596485a7a1f8a9f2478cc7084",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/19/Fedora/x86_64/iso/Fedora-19-x86_64-DVD.iso",
-      "tools_upload_flavor": "linux",
+      "output_directory": "packer-fedora-19-x86_64-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-fedora-19-x86_64",
-      "output_directory": "packer-fedora-19-x86_64-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "512",
@@ -65,7 +71,9 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
         "scripts/common/sshd.sh",
@@ -77,6 +85,10 @@
       ],
       "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://mirrors.kernel.org/fedora"
+  }
 }
 

--- a/packer/fedora-20-i386.json
+++ b/packer/fedora-20-i386.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://download.fedoraproject.org/pub/fedora/linux"
-  }, 
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-20/ks.cfg<enter><wait>"
       ],
@@ -17,21 +12,31 @@
       "iso_checksum": "284ea30ddd50db1b30cd5cd9fae7495dad8714ef1e4428d69a8c8ce80e03b6a9",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/20/Fedora/i386/iso/Fedora-20-i386-DVD.iso",
+      "output_directory": "packer-fedora-20-i386-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "512" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "512"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-fedora-20-i386",
-      "output_directory": "packer-fedora-20-i386-virtualbox"
+      "vm_name": "packer-fedora-20-i386"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-20/ks.cfg<enter><wait>"
       ],
@@ -42,14 +47,15 @@
       "iso_checksum": "284ea30ddd50db1b30cd5cd9fae7495dad8714ef1e4428d69a8c8ce80e03b6a9",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/20/Fedora/i386/iso/Fedora-20-i386-DVD.iso",
-      "tools_upload_flavor": "linux",
+      "output_directory": "packer-fedora-20-i386-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-fedora-20-i386",
-      "output_directory": "packer-fedora-20-i386-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "512",
@@ -65,7 +71,9 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
         "scripts/common/sshd.sh",
@@ -77,6 +85,10 @@
       ],
       "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://download.fedoraproject.org/pub/fedora/linux"
+  }
 }
 

--- a/packer/fedora-20-x86_64.json
+++ b/packer/fedora-20-x86_64.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://download.fedoraproject.org/pub/fedora/linux"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-20/ks.cfg<enter><wait>"
       ],
@@ -17,21 +12,31 @@
       "iso_checksum": "f2eeed5102b8890e9e6f4b9053717fe73031e699c4b76dc7028749ab66e7f917",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/20/Fedora/x86_64/iso/Fedora-20-x86_64-DVD.iso",
+      "output_directory": "packer-fedora-20-x86_64-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "512" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "512"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-fedora-20-x86_64",
-      "output_directory": "packer-fedora-20-x86_64-virtualbox"
+      "vm_name": "packer-fedora-20-x86_64"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-20/ks.cfg<enter><wait>"
       ],
@@ -42,14 +47,15 @@
       "iso_checksum": "f2eeed5102b8890e9e6f4b9053717fe73031e699c4b76dc7028749ab66e7f917",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/20/Fedora/x86_64/iso/Fedora-20-x86_64-DVD.iso",
-      "tools_upload_flavor": "linux",
+      "output_directory": "packer-fedora-20-x86_64-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-fedora-20-x86_64",
-      "output_directory": "packer-fedora-20-x86_64-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "512",
@@ -65,7 +71,9 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
         "scripts/common/sshd.sh",
@@ -77,6 +85,10 @@
       ],
       "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://download.fedoraproject.org/pub/fedora/linux"
+  }
 }
 

--- a/packer/freebsd-9.2-amd64.json
+++ b/packer/freebsd-9.2-amd64.json
@@ -1,25 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://ftp.freebsd.org/pub/FreeBSD"
-  },
-  "provisioners": [
-    {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
-      "type": "shell",
-      "scripts": [
-        "scripts/freebsd/postinstall.sh",
-        "scripts/freebsd/vmtools.sh",
-        "scripts/common/chef.sh",
-        "scripts/freebsd/cleanup.sh",
-        "scripts/common/minimize.sh"
-      ],
-      "execute_command": "export {{.Vars}} && cat {{.Path}} | su -m"
-    }
-  ],
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<esc><wait>",
         "load geom_mbr<wait>",
@@ -33,31 +14,41 @@
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
         "dhclient -l /tmp/dhclient.lease.em0 em0<enter><wait>",
-        "fetch -o /tmp/install.sh http://{{ .HTTPIP }}:{{ .HTTPPort }}/freebsd-9.2/install.sh && chmod +x /tmp/install.sh && /tmp/install.sh {{ .Name }}<enter><wait>"
+        "fetch -o /tmp/install.sh http://{{ .HTTPIP }}:{{ .HTTPPort }}/freebsd-9.2/install.sh \u0026\u0026 chmod +x /tmp/install.sh \u0026\u0026 /tmp/install.sh {{ .Name }}<enter><wait>"
       ],
       "boot_wait": "10s",
       "disk_size": 10140,
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "FreeBSD_64",
       "http_directory": "http",
       "iso_checksum": "a8c1751b83646530148766618a89a97009e7500e7057a5cbe3afd74ef480c915",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/amd64/amd64/ISO-IMAGES/9.2/FreeBSD-9.2-RELEASE-amd64-disc1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-freebsd-9.2-amd64-virtualbox",
+      "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
-      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
-      "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-freebsd-9.2-amd64",
-      "output_directory": "packer-freebsd-9.2-amd64-virtualbox",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "512" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
-      ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "512"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-freebsd-9.2-amd64"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<esc><wait>",
         "load geom_mbr<wait>",
@@ -72,7 +63,7 @@
         "mdmfs -s 100m md2 /mnt<enter><wait>",
         "dhclient -l /tmp/dhclient.lease.em0 em0<enter><wait>",
         "<wait5>",
-        "fetch -o /tmp/install.sh http://{{ .HTTPIP }}:{{ .HTTPPort }}/freebsd-9.2/install.sh && chmod +x /tmp/install.sh && /tmp/install.sh {{ .Name }}<enter><wait>"
+        "fetch -o /tmp/install.sh http://{{ .HTTPIP }}:{{ .HTTPPort }}/freebsd-9.2/install.sh \u0026\u0026 chmod +x /tmp/install.sh \u0026\u0026 /tmp/install.sh {{ .Name }}<enter><wait>"
       ],
       "boot_wait": "10s",
       "disk_size": 10140,
@@ -81,18 +72,19 @@
       "iso_checksum": "a8c1751b83646530148766618a89a97009e7500e7057a5cbe3afd74ef480c915",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/amd64/amd64/ISO-IMAGES/9.2/FreeBSD-9.2-RELEASE-amd64-disc1.iso",
-      "tools_upload_flavor": "freebsd",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-freebsd-9.2-amd64-vmware",
+      "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
+      "tools_upload_flavor": "freebsd",
+      "type": "vmware-iso",
       "vm_name": "packer-freebsd-9.2-amd64",
-      "output_directory": "packer-freebsd-9.2-amd64-vmware",
       "vmx_data": {
+        "cpuid.coresPerSocket": "1",
         "memsize": "512",
-        "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
+        "numvcpus": "1"
       }
     }
   ],
@@ -101,5 +93,26 @@
       "output": "../builds/{{.Provider}}/opscode_freebsd-9.2_chef-{{user `chef_version`}}.box",
       "type": "vagrant"
     }
-  ]
+  ],
+  "provisioners": [
+    {
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
+      "execute_command": "export {{.Vars}} \u0026\u0026 cat {{.Path}} | su -m",
+      "scripts": [
+        "scripts/freebsd/postinstall.sh",
+        "scripts/freebsd/vmtools.sh",
+        "scripts/common/chef.sh",
+        "scripts/freebsd/cleanup.sh",
+        "scripts/common/minimize.sh"
+      ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://ftp.freebsd.org/pub/FreeBSD"
+  }
 }
+

--- a/packer/freebsd-9.2-i386.json
+++ b/packer/freebsd-9.2-i386.json
@@ -1,24 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://ftp.freebsd.org/pub/FreeBSD"
-  },
-  "provisioners": [
-    {
-      "type": "shell",
-      "scripts": [
-        "scripts/freebsd/postinstall.sh",
-        "scripts/freebsd/vmtools.sh",
-        "scripts/common/chef.sh",
-        "scripts/freebsd/cleanup.sh",
-        "scripts/common/minimize.sh"
-      ],
-      "execute_command": "export {{.Vars}} && cat {{.Path}} | su -m"
-    }
-  ],
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<esc><wait>",
         "load geom_mbr<wait>",
@@ -32,31 +14,41 @@
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
         "dhclient -l /tmp/dhclient.lease.em0 em0<enter><wait>",
-        "fetch -o /tmp/install.sh http://{{ .HTTPIP }}:{{ .HTTPPort }}/freebsd-9.2/install.sh && chmod +x /tmp/install.sh && /tmp/install.sh {{ .Name }}<enter><wait>"
+        "fetch -o /tmp/install.sh http://{{ .HTTPIP }}:{{ .HTTPPort }}/freebsd-9.2/install.sh \u0026\u0026 chmod +x /tmp/install.sh \u0026\u0026 /tmp/install.sh {{ .Name }}<enter><wait>"
       ],
       "boot_wait": "10s",
       "disk_size": 10140,
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "FreeBSD",
       "http_directory": "http",
       "iso_checksum": "76093c27288f0ab939a5de14b621ec8eb1420d96343132c2b7c382747d35b67c",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/i386/ISO-IMAGES/9.2/FreeBSD-9.2-RELEASE-i386-disc1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-freebsd-9.2-i386-virtualbox",
+      "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
-      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
-      "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-freebsd-9.2-i386",
-      "output_directory": "packer-freebsd-9.2-i386-virtualbox",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "512" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
-      ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "512"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-freebsd-9.2-i386"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<esc><wait>",
         "load geom_mbr<wait>",
@@ -71,7 +63,7 @@
         "mdmfs -s 100m md2 /mnt<enter><wait>",
         "dhclient -l /tmp/dhclient.lease.em0 em0<enter><wait>",
         "<wait5>",
-        "fetch -o /tmp/install.sh http://{{ .HTTPIP }}:{{ .HTTPPort }}/freebsd-9.2/install.sh && chmod +x /tmp/install.sh && /tmp/install.sh {{ .Name }}<enter><wait>"
+        "fetch -o /tmp/install.sh http://{{ .HTTPIP }}:{{ .HTTPPort }}/freebsd-9.2/install.sh \u0026\u0026 chmod +x /tmp/install.sh \u0026\u0026 /tmp/install.sh {{ .Name }}<enter><wait>"
       ],
       "boot_wait": "10s",
       "disk_size": 10140,
@@ -80,18 +72,19 @@
       "iso_checksum": "76093c27288f0ab939a5de14b621ec8eb1420d96343132c2b7c382747d35b67c",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/i386/ISO-IMAGES/9.2/FreeBSD-9.2-RELEASE-i386-disc1.iso",
-      "tools_upload_flavor": "freebsd",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-freebsd-9.2-i386-vmware",
+      "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
+      "tools_upload_flavor": "freebsd",
+      "type": "vmware-iso",
       "vm_name": "packer-freebsd-9.2-i386",
-      "output_directory": "packer-freebsd-9.2-i386-vmware",
       "vmx_data": {
+        "cpuid.coresPerSocket": "1",
         "memsize": "512",
-        "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
+        "numvcpus": "1"
       }
     }
   ],
@@ -100,5 +93,23 @@
       "output": "../builds/{{.Provider}}/opscode_freebsd-9.2-i386_chef-{{user `chef_version`}}.box",
       "type": "vagrant"
     }
-  ]
+  ],
+  "provisioners": [
+    {
+      "execute_command": "export {{.Vars}} \u0026\u0026 cat {{.Path}} | su -m",
+      "scripts": [
+        "scripts/freebsd/postinstall.sh",
+        "scripts/freebsd/vmtools.sh",
+        "scripts/common/chef.sh",
+        "scripts/freebsd/cleanup.sh",
+        "scripts/common/minimize.sh"
+      ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://ftp.freebsd.org/pub/FreeBSD"
+  }
 }
+

--- a/packer/omnios-r151008f.json
+++ b/packer/omnios-r151008f.json
@@ -1,47 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://omnios.omniti.com/media"
-  },
-  "provisioners": [
-    {
-      "type": "shell",
-      "scripts": [
-        "scripts/omnios/vmtools.sh",
-        "scripts/common/chef.sh",
-        "scripts/omnios/postinstall.sh"
-      ],
-      "execute_command": "export {{.Vars}} && sh '{{.Path}}'",
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ]
-    }
-  ],
-  "post-processors": [
-    {
-      "type": "vagrant",
-      "compression_level": 9,
-      "output": "../builds/{{.Provider}}/opscode_omnios-r151008f_chef-{{user `chef_version`}}.box"
-    }
-  ],
   "builders": [
     {
-      "type": "virtualbox",
-      "guest_os_type": "OpenSolaris_64",
-      "iso_url": "{{user `mirror`}}/OmniOS_Text_r151008f.iso",
-      "iso_checksum": "d64d206c1e5aeeb61c5b579dd39ed11a86ef5737",
-      "iso_checksum_type": "sha1",
-      "ssh_username": "root",
-      "ssh_password": "vagrant",
-      "shutdown_command": "/usr/sbin/shutdown -g 0 -y -i 5",
-      "boot_wait": "30s",
-      "disk_size": 40960,
-      "ssh_port": 22,
-      "vboxmanage": [
-        ["modifyvm", "{{.Name}}", "--memory", "1024"],
-        ["modifyvm", "{{.Name}}", "--cpus", "1"]
-      ],
-      "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-omnios-r151008f",
-      "output_directory": "packer-omnios-r151008f-virtualbox",
       "boot_command": [
         "<enter><wait10><wait5>",
         "1<enter><wait10>",
@@ -70,29 +29,37 @@
         "cp /etc/nsswitch.dns /etc/nsswitch.conf<enter><wait>",
         "sed -i -e 's/PermitRootLogin no/PermitRootLogin yes/' /etc/ssh/sshd_config<enter><wait>",
         "svcadm restart ssh<enter><wait>"
-      ]
-    },
-    {
-      "type": "vmware",
-      "guest_os_type": "solaris11-64",
-      "iso_url": "{{user `mirror`}}/OmniOS_Text_r151008f.iso",
-      "iso_checksum": "d64d206c1e5aeeb61c5b579dd39ed11a86ef5737",
-      "iso_checksum_type": "sha1",
-      "ssh_username": "root",
-      "ssh_password": "vagrant",
-      "shutdown_command": "/usr/sbin/shutdown -g 0 -y -i 5",
+      ],
       "boot_wait": "30s",
       "disk_size": 40960,
+      "guest_os_type": "OpenSolaris_64",
+      "iso_checksum": "d64d206c1e5aeeb61c5b579dd39ed11a86ef5737",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{user `mirror`}}/OmniOS_Text_r151008f.iso",
+      "output_directory": "packer-omnios-r151008f-virtualbox",
+      "shutdown_command": "/usr/sbin/shutdown -g 0 -y -i 5",
+      "ssh_password": "vagrant",
       "ssh_port": 22,
-      "floppy_files": [ "floppy/omnios/README.TXT" ],
-      "tools_upload_flavor": "solaris",
-      "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "1024",
-        "numvcpus": "1"
-      },
-      "vm_name": "packer-omnios-r151008f",
-      "output_directory": "packer-omnios-r151008f-vmware",
+      "ssh_username": "root",
+      "type": "virtualbox-iso",
+      "vboxmanage": [
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "1024"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-omnios-r151008f"
+    },
+    {
       "boot_command": [
         "<enter><wait10><wait5>",
         "1<enter><wait10>",
@@ -123,7 +90,55 @@
         "cp /etc/nsswitch.dns /etc/nsswitch.conf<enter><wait>",
         "sed -i -e 's/PermitRootLogin no/PermitRootLogin yes/' /etc/ssh/sshd_config<enter><wait>",
         "svcadm restart ssh<enter><wait>"
-      ]
+      ],
+      "boot_wait": "30s",
+      "disk_size": 40960,
+      "floppy_files": [
+        "floppy/omnios/README.TXT"
+      ],
+      "guest_os_type": "solaris11-64",
+      "iso_checksum": "d64d206c1e5aeeb61c5b579dd39ed11a86ef5737",
+      "iso_checksum_type": "sha1",
+      "iso_url": "{{user `mirror`}}/OmniOS_Text_r151008f.iso",
+      "output_directory": "packer-omnios-r151008f-vmware",
+      "shutdown_command": "/usr/sbin/shutdown -g 0 -y -i 5",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "root",
+      "tools_upload_flavor": "solaris",
+      "type": "vmware-iso",
+      "vm_name": "packer-omnios-r151008f",
+      "vmx_data": {
+        "cpuid.coresPerSocket": "1",
+        "memsize": "1024",
+        "numvcpus": "1"
+      }
     }
-  ]
+  ],
+  "post-processors": [
+    {
+      "compression_level": 9,
+      "output": "../builds/{{.Provider}}/opscode_omnios-r151008f_chef-{{user `chef_version`}}.box",
+      "type": "vagrant"
+    }
+  ],
+  "provisioners": [
+    {
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
+      "execute_command": "export {{.Vars}} \u0026\u0026 sh '{{.Path}}'",
+      "scripts": [
+        "scripts/omnios/vmtools.sh",
+        "scripts/common/chef.sh",
+        "scripts/omnios/postinstall.sh"
+      ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://omnios.omniti.com/media"
+  }
 }
+

--- a/packer/rhel-5.10-i386.json
+++ b/packer/rhel-5.10-i386.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "https://content-web.rhn.redhat.com/rhn/isos/rhel-5.10/md5sum/1ab756241a4a209b8d39abe6bace84a9"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-5.10/ks.cfg<enter><wait>"
       ],
@@ -17,21 +12,31 @@
       "iso_checksum": "3a4db78ab70d866057c5285e0064d78125e1b8fd9dcaefea28818f6604b3515d",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/rhel-server-5.10-i386-dvd.iso",
+      "output_directory": "packer-rhel-5.10-i386-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "384"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-rhel-5.10-i386",
-      "output_directory": "packer-rhel-5.10-i386-virtualbox"
+      "vm_name": "packer-rhel-5.10-i386"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-5.10/ks.cfg<enter><wait>"
       ],
@@ -42,14 +47,15 @@
       "iso_checksum": "3a4db78ab70d866057c5285e0064d78125e1b8fd9dcaefea28818f6604b3515d",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/rhel-server-5.10-i386-dvd.iso",
-      "tools_upload_flavor": "linux",
+      "output_directory": "packer-rhel-5.10-i386-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-rhel-5.10-i386",
-      "output_directory": "packer-rhel-5.10-i386-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -65,7 +71,9 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
         "scripts/common/vagrant.sh",
@@ -77,5 +85,10 @@
       ],
       "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "https://content-web.rhn.redhat.com/rhn/isos/rhel-5.10/md5sum/1ab756241a4a209b8d39abe6bace84a9"
+  }
 }
+

--- a/packer/rhel-5.10-x86_64.json
+++ b/packer/rhel-5.10-x86_64.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "https://content-web.rhn.redhat.com/rhn/isos/rhel-5.10/md5sum/86cc2d5548ee2ff9c8d3e2b4db3e6001"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-5.10/ks.cfg<enter><wait>"
       ],
@@ -17,21 +12,31 @@
       "iso_checksum": "8b38e74b0993d478aad9c950f51a3e3441199639a3422e06fc3beca1f8825bf2",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/rhel-server-5.10-x86_64-dvd.iso",
+      "output_directory": "packer-rhel-5.10-x86_64-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "384"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-rhel-5.10-x86_64",
-      "output_directory": "packer-rhel-5.10-x86_64-virtualbox"
+      "vm_name": "packer-rhel-5.10-x86_64"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-5.10/ks.cfg<enter><wait>"
       ],
@@ -42,14 +47,15 @@
       "iso_checksum": "8b38e74b0993d478aad9c950f51a3e3441199639a3422e06fc3beca1f8825bf2",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/rhel-server-5.10-x86_64-dvd.iso",
-      "tools_upload_flavor": "linux",
+      "output_directory": "packer-rhel-5.10-x86_64-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-rhel-5.10-x86_64",
-      "output_directory": "packer-rhel-5.10-x86_64-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -65,7 +71,9 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
         "scripts/common/vagrant.sh",
@@ -77,5 +85,10 @@
       ],
       "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "https://content-web.rhn.redhat.com/rhn/isos/rhel-5.10/md5sum/86cc2d5548ee2ff9c8d3e2b4db3e6001"
+  }
 }
+

--- a/packer/rhel-6.5-i386.json
+++ b/packer/rhel-6.5-i386.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "https://content-web.rhn.redhat.com/rhn/isos/rhel-6.5/md5sum/04a1fa06a6b7e70cd586535eea83c0ef"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-6.5/ks.cfg<enter><wait>"
       ],
@@ -17,21 +12,31 @@
       "iso_checksum": "eec692b436193ba9fc365cafe2b8f85323d98192dc99b23b02ae75045667fe4a",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/rhel-server-6.5-i386-dvd.iso",
+      "output_directory": "packer-rhel-6.5-i386-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "480" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "480"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-rhel-6.5-i386",
-      "output_directory": "packer-rhel-6.5-i386-virtualbox"
+      "vm_name": "packer-rhel-6.5-i386"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-6.5/ks.cfg<enter><wait>"
       ],
@@ -42,14 +47,15 @@
       "iso_checksum": "eec692b436193ba9fc365cafe2b8f85323d98192dc99b23b02ae75045667fe4a",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/rhel-server-6.5-i386-dvd.iso",
-      "tools_upload_flavor": "linux",
+      "output_directory": "packer-rhel-6.5-i386-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-rhel-6.5-i386",
-      "output_directory": "packer-rhel-6.5-i386-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "480",
@@ -65,7 +71,9 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
         "scripts/common/sshd.sh",
@@ -77,6 +85,10 @@
       ],
       "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "https://content-web.rhn.redhat.com/rhn/isos/rhel-6.5/md5sum/04a1fa06a6b7e70cd586535eea83c0ef"
+  }
 }
 

--- a/packer/rhel-6.5-x86_64.json
+++ b/packer/rhel-6.5-x86_64.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "https://content-web.rhn.redhat.com/rhn/isos/rhel-6.5/md5sum/a84d4d9eddb36fb417832166cd10a4c2"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-6.5/ks.cfg<enter><wait>"
       ],
@@ -17,21 +12,31 @@
       "iso_checksum": "a51b90f3dd4585781293ea08adde60eeb9cfa94670943bd99e9c07f13a259539",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/rhel-server-6.5-x86_64-dvd.iso",
+      "output_directory": "packer-rhel-6.5-x86_64-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "480" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "480"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-rhel-6.5-x86_64",
-      "output_directory": "packer-rhel-6.5-x86_64-virtualbox"
+      "vm_name": "packer-rhel-6.5-x86_64"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-6.5/ks.cfg<enter><wait>"
       ],
@@ -39,18 +44,18 @@
       "disk_size": 40960,
       "guest_os_type": "rhel6-64",
       "http_directory": "http",
-      "iso_checksum": "a51b90f3dd4585781293ea08adde60eeb9cfa94670943bd99e9c07f13a259539"
-,
+      "iso_checksum": "a51b90f3dd4585781293ea08adde60eeb9cfa94670943bd99e9c07f13a259539",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/rhel-server-6.5-x86_64-dvd.iso",
-      "tools_upload_flavor": "linux",
+      "output_directory": "packer-rhel-6.5-x86_64-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-rhel-6.5-x86_64",
-      "output_directory": "packer-rhel-6.5-x86_64-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "480",
@@ -66,7 +71,9 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
         "scripts/common/sshd.sh",
@@ -78,5 +85,10 @@
       ],
       "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "https://content-web.rhn.redhat.com/rhn/isos/rhel-6.5/md5sum/a84d4d9eddb36fb417832166cd10a4c2"
+  }
 }
+

--- a/packer/sles-11-sp2-i386.json
+++ b/packer/sles-11-sp2-i386.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://cdn2.novell.com/prot/FkjGyLMMiss~"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<esc><enter><wait>",
         "linux netdevice=eth0 netsetup=dhcp install=cd:/<wait>",
@@ -15,20 +10,19 @@
       ],
       "boot_wait": "10s",
       "disk_size": 20480,
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "OpenSUSE",
       "http_directory": "http",
       "iso_checksum": "a0b34f6237b2b2a6b2174c82b40ed326",
       "iso_checksum_type": "md5",
       "iso_url": "{{user `mirror`}}/SLES-11-SP2-DVD-i586-GM-DVD1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-sles-11-sp2-x86_64-virtualbox",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
-      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
-      "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-sles-11-sp2-x86_64",
-      "output_directory": "packer-sles-11-sp2-x86_64-virtualbox",
+      "type": "virtualbox-iso",
       "vboxmanage": [
         [
           "modifyvm",
@@ -42,10 +36,11 @@
           "--cpus",
           "1"
         ]
-      ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-sles-11-sp2-x86_64"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<esc><enter><wait>",
         "linux netdevice=eth0 netsetup=dhcp install=cd:/<wait>",
@@ -60,19 +55,20 @@
       "iso_checksum": "a0b34f6237b2b2a6b2174c82b40ed326",
       "iso_checksum_type": "md5",
       "iso_url": "{{user `mirror`}}/SLES-11-SP2-DVD-i586-GM-DVD1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-sles11sp2-x86_64-vmware",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "tools_upload_flavor": "linux",
-      "vmx_data": {
-        "memsize": "480",
-        "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
-      },
+      "type": "vmware-iso",
       "vm_name": "packer-sles11sp2-x86_64",
-      "output_directory": "packer-sles11sp2-x86_64-vmware"
+      "vmx_data": {
+        "cpuid.coresPerSocket": "1",
+        "memsize": "480",
+        "numvcpus": "1"
+      }
     }
   ],
   "post-processors": [
@@ -83,8 +79,10 @@
   ],
   "provisioners": [
     {
-      "type": "shell",
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh '{{.Path}}'",
       "scripts": [
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",
@@ -95,7 +93,12 @@
         "scripts/sles/remove-dvd-source.sh",
         "scripts/common/minimize.sh"
       ],
-      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh '{{.Path}}'"
+      "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://cdn2.novell.com/prot/FkjGyLMMiss~"
+  }
 }
+

--- a/packer/sles-11-sp2-x86_64.json
+++ b/packer/sles-11-sp2-x86_64.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://cdn2.novell.com/free/h0AOp5AT-18~"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<esc><enter><wait>",
         "linux netdevice=eth0 netsetup=dhcp install=cd:/<wait>",
@@ -15,20 +10,19 @@
       ],
       "boot_wait": "10s",
       "disk_size": 20480,
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "OpenSUSE_64",
       "http_directory": "http",
       "iso_checksum": "461d82ae6e15062b0807c1338f040497",
       "iso_checksum_type": "md5",
       "iso_url": "{{user `mirror`}}/SLES-11-SP2-DVD-x86_64-GM-DVD1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-sles-11-sp2-x86_64-virtualbox",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
-      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
-      "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-sles-11-sp2-x86_64",
-      "output_directory": "packer-sles-11-sp2-x86_64-virtualbox",
+      "type": "virtualbox-iso",
       "vboxmanage": [
         [
           "modifyvm",
@@ -42,10 +36,11 @@
           "--cpus",
           "1"
         ]
-      ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-sles-11-sp2-x86_64"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<esc><enter><wait>",
         "linux netdevice=eth0 netsetup=dhcp install=cd:/<wait>",
@@ -60,19 +55,20 @@
       "iso_checksum": "461d82ae6e15062b0807c1338f040497",
       "iso_checksum_type": "md5",
       "iso_url": "{{user `mirror`}}/SLES-11-SP2-DVD-x86_64-GM-DVD1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-sles11sp2-x86_64-vmware",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "tools_upload_flavor": "linux",
-      "vmx_data": {
-        "memsize": "480",
-        "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
-      },
+      "type": "vmware-iso",
       "vm_name": "packer-sles11sp2-x86_64",
-      "output_directory": "packer-sles11sp2-x86_64-vmware"
+      "vmx_data": {
+        "cpuid.coresPerSocket": "1",
+        "memsize": "480",
+        "numvcpus": "1"
+      }
     }
   ],
   "post-processors": [
@@ -83,8 +79,10 @@
   ],
   "provisioners": [
     {
-      "type": "shell",
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh '{{.Path}}'",
       "scripts": [
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",
@@ -95,7 +93,12 @@
         "scripts/sles/remove-dvd-source.sh",
         "scripts/common/minimize.sh"
       ],
-      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh '{{.Path}}'"
+      "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://cdn2.novell.com/free/h0AOp5AT-18~"
+  }
 }
+

--- a/packer/sles-11-sp3-i386.json
+++ b/packer/sles-11-sp3-i386.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://cdn2.novell.com/prot/4uiuDMzX0ck~"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<esc><enter><wait>",
         "linux netdevice=eth0 netsetup=dhcp install=cd:/<wait>",
@@ -15,20 +10,19 @@
       ],
       "boot_wait": "10s",
       "disk_size": 20480,
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "OpenSUSE",
       "http_directory": "http",
       "iso_checksum": "5c30a409fc8fb3343b4dc90d93ff2c89",
       "iso_checksum_type": "md5",
       "iso_url": "{{user `mirror`}}/SLES-11-SP3-DVD-i586-GM-DVD1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-sles-11-sp3-x86_64-virtualbox",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
-      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
-      "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-sles-11-sp3-x86_64",
-      "output_directory": "packer-sles-11-sp3-x86_64-virtualbox",
+      "type": "virtualbox-iso",
       "vboxmanage": [
         [
           "modifyvm",
@@ -42,10 +36,11 @@
           "--cpus",
           "1"
         ]
-      ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-sles-11-sp3-x86_64"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<esc><enter><wait>",
         "linux netdevice=eth0 netsetup=dhcp install=cd:/<wait>",
@@ -60,19 +55,20 @@
       "iso_checksum": "5c30a409fc8fb3343b4dc90d93ff2c89",
       "iso_checksum_type": "md5",
       "iso_url": "{{user `mirror`}}/SLES-11-SP3-DVD-i586-GM-DVD1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-sles11sp2-x86_64-vmware",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "tools_upload_flavor": "linux",
-      "vmx_data": {
-        "memsize": "480",
-        "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
-      },
+      "type": "vmware-iso",
       "vm_name": "packer-sles11sp2-x86_64",
-      "output_directory": "packer-sles11sp2-x86_64-vmware"
+      "vmx_data": {
+        "cpuid.coresPerSocket": "1",
+        "memsize": "480",
+        "numvcpus": "1"
+      }
     }
   ],
   "post-processors": [
@@ -83,8 +79,10 @@
   ],
   "provisioners": [
     {
-      "type": "shell",
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh '{{.Path}}'",
       "scripts": [
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",
@@ -95,7 +93,12 @@
         "scripts/sles/remove-dvd-source.sh",
         "scripts/common/minimize.sh"
       ],
-      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh '{{.Path}}'"
+      "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://cdn2.novell.com/prot/4uiuDMzX0ck~"
+  }
 }
+

--- a/packer/sles-11-sp3-x86_64.json
+++ b/packer/sles-11-sp3-x86_64.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://cdn2.novell.com/prot/Q_VbW21BiB4~"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<esc><enter><wait>",
         "linux netdevice=eth0 netsetup=dhcp install=cd:/<wait>",
@@ -15,20 +10,19 @@
       ],
       "boot_wait": "10s",
       "disk_size": 20480,
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "OpenSUSE_64",
       "http_directory": "http",
       "iso_checksum": "480b70d50cbb538382dc2b9325221e1b",
       "iso_checksum_type": "md5",
       "iso_url": "{{user `mirror`}}/SLES-11-SP3-DVD-x86_64-GM-DVD1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-sles-11-sp3-x86_64-virtualbox",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
-      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
-      "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-sles-11-sp3-x86_64",
-      "output_directory": "packer-sles-11-sp3-x86_64-virtualbox",
+      "type": "virtualbox-iso",
       "vboxmanage": [
         [
           "modifyvm",
@@ -42,10 +36,11 @@
           "--cpus",
           "1"
         ]
-      ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-sles-11-sp3-x86_64"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<esc><enter><wait>",
         "linux netdevice=eth0 netsetup=dhcp install=cd:/<wait>",
@@ -60,19 +55,20 @@
       "iso_checksum": "480b70d50cbb538382dc2b9325221e1b",
       "iso_checksum_type": "md5",
       "iso_url": "{{user `mirror`}}/SLES-11-SP3-DVD-x86_64-GM-DVD1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-sles11sp3-x86_64-vmware",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "tools_upload_flavor": "linux",
-      "vmx_data": {
-        "memsize": "480",
-        "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
-      },
+      "type": "vmware-iso",
       "vm_name": "packer-sles11sp3-x86_64",
-      "output_directory": "packer-sles11sp3-x86_64-vmware"
+      "vmx_data": {
+        "cpuid.coresPerSocket": "1",
+        "memsize": "480",
+        "numvcpus": "1"
+      }
     }
   ],
   "post-processors": [
@@ -83,8 +79,10 @@
   ],
   "provisioners": [
     {
-      "type": "shell",
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh '{{.Path}}'",
       "scripts": [
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",
@@ -95,7 +93,12 @@
         "scripts/sles/remove-dvd-source.sh",
         "scripts/common/minimize.sh"
       ],
-      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh '{{.Path}}'"
+      "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://cdn2.novell.com/prot/Q_VbW21BiB4~"
+  }
 }
+

--- a/packer/ubuntu-10.04-amd64.json
+++ b/packer/ubuntu-10.04-amd64.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://releases.ubuntu.com"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -38,21 +33,31 @@
       "iso_checksum": "796e80702d65f2ee96e88874a1ab437e24df9cd6",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/10.04.4/ubuntu-10.04.4-server-amd64.iso",
+      "output_directory": "packer-ubuntu-10.04-amd64-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "384"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-10.04-amd64",
-      "output_directory": "packer-ubuntu-10.04-amd64-virtualbox"
+      "vm_name": "packer-ubuntu-10.04-amd64"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -84,14 +89,15 @@
       "iso_checksum": "796e80702d65f2ee96e88874a1ab437e24df9cd6",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/10.04.4/ubuntu-10.04.4-server-amd64.iso",
-      "tools_upload_flavor": "linux",
+      "output_directory": "packer-ubuntu-10.04-amd64-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-ubuntu-10.04-amd64",
-      "output_directory": "packer-ubuntu-10.04-amd64-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -107,7 +113,9 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
         "scripts/ubuntu/update.sh",
@@ -122,5 +130,10 @@
       ],
       "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://releases.ubuntu.com"
+  }
 }
+

--- a/packer/ubuntu-10.04-i386.json
+++ b/packer/ubuntu-10.04-i386.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://releases.ubuntu.com"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -38,21 +33,31 @@
       "iso_checksum": "5695d8b6b914269d1374ac8d4c3dd3786e92d3fe",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/10.04.4/ubuntu-10.04.4-server-i386.iso",
+      "output_directory": "packer-ubuntu-10.04-i386-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "384"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-10.04-i386",
-      "output_directory": "packer-ubuntu-10.04-i386-virtualbox"
+      "vm_name": "packer-ubuntu-10.04-i386"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -84,14 +89,15 @@
       "iso_checksum": "5695d8b6b914269d1374ac8d4c3dd3786e92d3fe",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/10.04.4/ubuntu-10.04.4-server-i386.iso",
-      "tools_upload_flavor": "linux",
+      "output_directory": "packer-ubuntu-10.04-i386-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-ubuntu-10.04-i386",
-      "output_directory": "packer-ubuntu-10.04-i386-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -107,7 +113,9 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
         "scripts/ubuntu/update.sh",
@@ -122,5 +130,10 @@
       ],
       "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://releases.ubuntu.com"
+  }
 }
+

--- a/packer/ubuntu-12.04-amd64.json
+++ b/packer/ubuntu-12.04-amd64.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://releases.ubuntu.com"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -32,27 +27,37 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "guest_additions_path": "VBoxGuestAdditions_{{ .Version }}.iso",
       "guest_os_type": "Ubuntu_64",
       "http_directory": "http",
       "iso_checksum": "4e36c272dde245cfadf14ff8895566571a38f4d2",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/12.04/ubuntu-12.04.3-server-amd64.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-ubuntu-12.04-amd64-virtualbox",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
-      "guest_additions_path": "VBoxGuestAdditions_{{ .Version }}.iso",
-      "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-12.04-amd64",
-      "output_directory": "packer-ubuntu-12.04-amd64-virtualbox",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
-      ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "384"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-ubuntu-12.04-amd64"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -84,14 +89,15 @@
       "iso_checksum": "4e36c272dde245cfadf14ff8895566571a38f4d2",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/12.04/ubuntu-12.04.3-server-amd64.iso",
-      "tools_upload_flavor": "linux",
+      "output_directory": "packer-ubuntu-12.04-amd64-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-ubuntu-12.04-amd64",
-      "output_directory": "packer-ubuntu-12.04-amd64-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -101,13 +107,15 @@
   ],
   "post-processors": [
     {
-      "type": "vagrant",
-      "output": "../builds/{{.Provider}}/opscode_ubuntu-12.04_chef-{{user `chef_version`}}.box"
+      "output": "../builds/{{.Provider}}/opscode_ubuntu-12.04_chef-{{user `chef_version`}}.box",
+      "type": "vagrant"
     }
   ],
   "provisioners": [
     {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
         "scripts/ubuntu/update.sh",
@@ -122,5 +130,10 @@
       ],
       "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://releases.ubuntu.com"
+  }
 }
+

--- a/packer/ubuntu-12.04-i386.json
+++ b/packer/ubuntu-12.04-i386.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://releases.ubuntu.com"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -38,21 +33,31 @@
       "iso_checksum": "2ec0e913959f6c2ba7a558e8bfa361428bb00e56",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/12.04/ubuntu-12.04.3-server-i386.iso",
+      "output_directory": "packer-ubuntu-12.04-i386-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "384"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-12.04-i386",
-      "output_directory": "packer-ubuntu-12.04-i386-virtualbox"
+      "vm_name": "packer-ubuntu-12.04-i386"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -84,14 +89,15 @@
       "iso_checksum": "2ec0e913959f6c2ba7a558e8bfa361428bb00e56",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/12.04/ubuntu-12.04.3-server-i386.iso",
-      "tools_upload_flavor": "linux",
+      "output_directory": "packer-ubuntu-12.04-i386-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-ubuntu-12.04-i386",
-      "output_directory": "packer-ubuntu-12.04-i386-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -107,7 +113,9 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
         "scripts/ubuntu/update.sh",
@@ -122,6 +130,10 @@
       ],
       "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://releases.ubuntu.com"
+  }
 }
 

--- a/packer/ubuntu-12.10-amd64.json
+++ b/packer/ubuntu-12.10-amd64.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://releases.ubuntu.com"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -38,21 +33,31 @@
       "iso_checksum": "e2a48af008ff3c4db6a8235151a1e90ea600fceb",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/12.10/ubuntu-12.10-server-amd64.iso",
+      "output_directory": "packer-ubuntu-12.10-amd64-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "384"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-12.10-amd64",
-      "output_directory": "packer-ubuntu-12.10-amd64-virtualbox"
+      "vm_name": "packer-ubuntu-12.10-amd64"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -84,14 +89,15 @@
       "iso_checksum": "e2a48af008ff3c4db6a8235151a1e90ea600fceb",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/12.10/ubuntu-12.10-server-amd64.iso",
-      "tools_upload_flavor": "linux",
+      "output_directory": "packer-ubuntu-12.10-amd64-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-ubuntu-12.10-amd64",
-      "output_directory": "packer-ubuntu-12.10-amd64-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -107,7 +113,9 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
         "scripts/ubuntu/update.sh",
@@ -122,6 +130,10 @@
       ],
       "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://releases.ubuntu.com"
+  }
 }
 

--- a/packer/ubuntu-12.10-i386.json
+++ b/packer/ubuntu-12.10-i386.json
@@ -1,8 +1,4 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://releases.ubuntu.com"
-  },
   "builders": [
     {
       "boot_command": [
@@ -37,19 +33,29 @@
       "iso_checksum": "e0e48be7ae21003cf0b25591d71d8cdbee7063e7",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/12.10/ubuntu-12.10-server-i386.iso",
+      "output_directory": "packer-ubuntu-12.10-i386-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "type": "virtualbox",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "384"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-12.10-i386",
-      "output_directory": "packer-ubuntu-12.10-i386-virtualbox"
+      "vm_name": "packer-ubuntu-12.10-i386"
     },
     {
       "boot_command": [
@@ -83,15 +89,15 @@
       "iso_checksum": "e0e48be7ae21003cf0b25591d71d8cdbee7063e7",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/12.10/ubuntu-12.10-server-i386.iso",
-      "tools_upload_flavor": "linux",
+      "output_directory": "packer-ubuntu-12.10-i386-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-ubuntu-12.10-i386",
-      "output_directory": "packer-ubuntu-12.10-i386-vmware",
-      "type": "vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -107,7 +113,9 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
         "scripts/ubuntu/update.sh",
@@ -122,6 +130,10 @@
       ],
       "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://releases.ubuntu.com"
+  }
 }
 

--- a/packer/ubuntu-13.04-amd64.json
+++ b/packer/ubuntu-13.04-amd64.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://releases.ubuntu.com"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -38,21 +33,31 @@
       "iso_checksum": "2af1c223f586f59237212bb9c06ad774673c8952",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/13.04/ubuntu-13.04-server-amd64.iso",
+      "output_directory": "packer-ubuntu-13.04-amd64-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "384"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-13.04-amd64",
-      "output_directory": "packer-ubuntu-13.04-amd64-virtualbox"
+      "vm_name": "packer-ubuntu-13.04-amd64"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -85,14 +90,15 @@
       "iso_checksum": "2af1c223f586f59237212bb9c06ad774673c8952",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/13.04/ubuntu-13.04-server-amd64.iso",
-      "tools_upload_flavor": "linux",
+      "output_directory": "packer-ubuntu-13.04-amd64-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-ubuntu-13.04-amd64",
-      "output_directory": "packer-ubuntu-13.04-amd64-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -108,7 +114,9 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
         "scripts/ubuntu/update.sh",
@@ -123,6 +131,10 @@
       ],
       "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://releases.ubuntu.com"
+  }
 }
 

--- a/packer/ubuntu-13.04-i386.json
+++ b/packer/ubuntu-13.04-i386.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://releases.ubuntu.com"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -38,21 +33,31 @@
       "iso_checksum": "27bbe172d66d4ce634d10fd655e840f72fe56130",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/13.04/ubuntu-13.04-server-i386.iso",
+      "output_directory": "packer-ubuntu-13.04-i386-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "384"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-13.04-i386",
-      "output_directory": "packer-ubuntu-13.04-i386-virtualbox"
+      "vm_name": "packer-ubuntu-13.04-i386"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -84,14 +89,15 @@
       "iso_checksum": "27bbe172d66d4ce634d10fd655e840f72fe56130",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/13.04/ubuntu-13.04-server-i386.iso",
-      "tools_upload_flavor": "linux",
+      "output_directory": "packer-ubuntu-13.04-i386-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-ubuntu-13.04-i386",
-      "output_directory": "packer-ubuntu-13.04-i386-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -107,12 +113,14 @@
   ],
   "provisioners": [
     {
-      "type": "file",
+      "destination": "/tmp/shutdown.sh",
       "source": "scripts/common/shutdown.sh",
-      "destination": "/tmp/shutdown.sh"
+      "type": "file"
     },
     {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
         "scripts/ubuntu/update.sh",
@@ -127,6 +135,10 @@
       ],
       "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://releases.ubuntu.com"
+  }
 }
 

--- a/packer/ubuntu-13.10-amd64.json
+++ b/packer/ubuntu-13.10-amd64.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://releases.ubuntu.com"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -38,21 +33,31 @@
       "iso_checksum": "5dd72c694c3a7e06a3b4dd651ca26cfc70985004",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/13.10/ubuntu-13.10-server-amd64.iso",
+      "output_directory": "packer-ubuntu-13.10-amd64-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "384"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-13.10-amd64",
-      "output_directory": "packer-ubuntu-13.10-amd64-virtualbox"
+      "vm_name": "packer-ubuntu-13.10-amd64"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -85,14 +90,15 @@
       "iso_checksum": "5dd72c694c3a7e06a3b4dd651ca26cfc70985004",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/13.10/ubuntu-13.10-server-amd64.iso",
-      "tools_upload_flavor": "linux",
+      "output_directory": "packer-ubuntu-13.10-amd64-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-ubuntu-13.10-amd64",
-      "output_directory": "packer-ubuntu-13.10-amd64-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -108,7 +114,9 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
         "scripts/ubuntu/update.sh",
@@ -123,5 +131,10 @@
       ],
       "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://releases.ubuntu.com"
+  }
 }
+

--- a/packer/ubuntu-13.10-i386.json
+++ b/packer/ubuntu-13.10-i386.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://releases.ubuntu.com"
-  },
   "builders": [
     {
-      "type": "virtualbox",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -38,21 +33,31 @@
       "iso_checksum": "2dda06d01d3ad495b53f7c03a4313b4af76a1c96",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/13.10/ubuntu-13.10-server-i386.iso",
+      "output_directory": "packer-ubuntu-13.10-i386-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "384"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-13.10-i386",
-      "output_directory": "packer-ubuntu-13.10-i386-virtualbox"
+      "vm_name": "packer-ubuntu-13.10-i386"
     },
     {
-      "type": "vmware",
       "boot_command": [
         "<esc><wait>",
         "<esc><wait>",
@@ -84,14 +89,15 @@
       "iso_checksum": "2dda06d01d3ad495b53f7c03a4313b4af76a1c96",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/13.10/ubuntu-13.10-server-i386.iso",
-      "tools_upload_flavor": "linux",
+      "output_directory": "packer-ubuntu-13.10-i386-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-ubuntu-13.10-i386",
-      "output_directory": "packer-ubuntu-13.10-i386-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -107,12 +113,14 @@
   ],
   "provisioners": [
     {
-      "type": "file",
+      "destination": "/tmp/shutdown.sh",
       "source": "scripts/common/shutdown.sh",
-      "destination": "/tmp/shutdown.sh"
+      "type": "file"
     },
     {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
         "scripts/ubuntu/update.sh",
@@ -127,5 +135,10 @@
       ],
       "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://releases.ubuntu.com"
+  }
 }
+


### PR DESCRIPTION
packer fix on packer/*.json
0.4.1=>0.5.1 in .travis.yml

The packer fix command did the heavy lifting for the update of all jsons.

And travis validated successfully. (https://travis-ci.org/lwieske/bento)
