### PR TITLE
Update vmtools branch logic to reflect new providers in packer 0.5.1-

### DIFF
--- a/packer/scripts/common/vmtools.sh
+++ b/packer/scripts/common/vmtools.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-if [ $PACKER_BUILDER_TYPE == 'virtualbox' ]; then
+case "$PACKER_BUILDER_TYPE" in 
+
+virtualbox-iso|virtualbox-ovf) 
     mkdir /tmp/vbox
     VER=$(cat /home/vagrant/.vbox_version)
     mount -o loop /home/vagrant/VBoxGuestAdditions_$VER.iso /tmp/vbox 
@@ -8,9 +10,9 @@ if [ $PACKER_BUILDER_TYPE == 'virtualbox' ]; then
     umount /tmp/vbox
     rmdir /tmp/vbox
     rm /home/vagrant/*.iso
-fi
+    ;;
 
-if [ $PACKER_BUILDER_TYPE == 'vmware' ]; then
+vmware-iso|vmware-ovf) 
     mkdir /tmp/vmfusion
     mkdir /tmp/vmfusion-archive
     mount -o loop /home/vagrant/linux.iso /tmp/vmfusion
@@ -20,4 +22,11 @@ if [ $PACKER_BUILDER_TYPE == 'vmware' ]; then
     rm -rf  /tmp/vmfusion
     rm -rf  /tmp/vmfusion-archive
     rm /home/vagrant/*.iso
-fi
+    ;;
+
+*)
+    echo "Unknown Packer Builder Type >>$PACKER_BUILDER_TYPE<< selected."
+    echo "Known are virtualbox-iso|virtualbox-ovf|vmware-iso|vmware-ovf."
+    ;;
+
+esac


### PR DESCRIPTION
New providers in packer 0.5.1 are
- virtualbox-iso/ovf and
- vmware-iso/ovf

instead of the former „naked“ virtualbox and vmware.

Results for a CentOS 6.5 test build were (excerpts)

==> virtualbox-iso: Provisioning with shell script: scripts/common/vmtools.sh
    virtualbox-iso: Verifying archive integrity... All good.
    virtualbox-iso: Uncompressing VirtualBox 4.3.6 Guest Additions for Linux............
    virtualbox-iso: VirtualBox Guest Additions installer
    virtualbox-iso: Copying additional installer modules ...
    virtualbox-iso: Installing additional modules ...
    virtualbox-iso: Removing existing VirtualBox non-DKMS kernel modules[  OK  ]
    virtualbox-iso: Building the VirtualBox Guest Additions kernel modules
    **virtualbox-iso: Building the main Guest Additions module[  OK  ]**
    **virtualbox-iso: Building the shared folder support module[  OK  ]**
    virtualbox-iso: Building the OpenGL support module[FAILED]
    virtualbox-iso: (Look at /var/log/vboxadd-install.log to find out what went wrong)
    **virtualbox-iso: Doing non-kernel setup of the Guest Additions[  OK  ]**
    virtualbox-iso: Installing the Window System drivers[FAILED]
    virtualbox-iso: (Could not find the X.Org or XFree86 Window System.)

==> vmware-iso: Provisioning with shell script: scripts/common/vmtools.sh
    vmware-iso: Creating a new VMware Tools installer database using the tar4 format.
    vmware-iso:
    vmware-iso: Installing VMware Tools.
    vmware-iso:
    vmware-iso: In which directory do you want to install the binary files?
    vmware-iso: [/usr/bin]
    vmware-iso:
    vmware-iso: What is the directory that contains the init directories (rc0.d/ to rc6.d/)?
    vmware-iso: [/etc/rc.d]
    vmware-iso:
    vmware-iso: What is the directory that contains the init scripts?
    vmware-iso: [/etc/rc.d/init.d]
    vmware-iso:
    vmware-iso: In which directory do you want to install the daemon files?
    vmware-iso: [/usr/sbin]
    vmware-iso:
    vmware-iso: In which directory do you want to install the library files?
    vmware-iso: [/usr/lib/vmware-tools]
    vmware-iso:
    vmware-iso: The path "/usr/lib/vmware-tools" does not exist currently. This program is
    vmware-iso: going to create it, including needed parent directories. Is this what you want?
    vmware-iso: [yes]
    vmware-iso:
    vmware-iso: In which directory do you want to install the documentation files?
    vmware-iso: [/usr/share/doc/vmware-tools]
    vmware-iso:
    vmware-iso: The path "/usr/share/doc/vmware-tools" does not exist currently. This program
    vmware-iso: is going to create it, including needed parent directories. Is this what you
    vmware-iso: want? [yes]
    vmware-iso:
    vmware-iso: The installation of VMware Tools 9.6.1 build-1378637 for Linux completed
    vmware-iso: successfully. You can decide to remove this software from your system at any
    vmware-iso: time by invoking the following command: "/usr/bin/vmware-uninstall-tools.pl".
    vmware-iso:
    vmware-iso: Before running VMware Tools for the first time, you need to configure it by
    vmware-iso: invoking the following command: "/usr/bin/vmware-config-tools.pl". Do you want
    vmware-iso: this program to invoke the command for you now? [yes]
    vmware-iso:
    vmware-iso: Initializing...
    vmware-iso:
    vmware-iso:
    vmware-iso: Making sure services for VMware Tools are stopped.
    vmware-iso:
    vmware-iso:
    vmware-iso:
    vmware-iso: Found a compatible pre-built module for vmci.  Installing it...
    vmware-iso:
    vmware-iso:
    vmware-iso: Found a compatible pre-built module for vsock.  Installing it...
    vmware-iso:
    vmware-iso:
    vmware-iso: The module vmxnet3 has already been installed on this system by another
    vmware-iso: installer or package and will not be modified by this installer.
    vmware-iso:
    vmware-iso: Use the flag --clobber-kernel-modules=vmxnet3 to override.
    vmware-iso:
    vmware-iso: The module pvscsi has already been installed on this system by another
    vmware-iso: installer or package and will not be modified by this installer.
    vmware-iso:
    vmware-iso: Use the flag --clobber-kernel-modules=pvscsi to override.
    vmware-iso:
    vmware-iso: The module vmmemctl has already been installed on this system by another
    vmware-iso: installer or package and will not be modified by this installer.
    vmware-iso:
    vmware-iso: Use the flag --clobber-kernel-modules=vmmemctl to override.
    vmware-iso:
    vmware-iso: The VMware Host-Guest Filesystem allows for shared folders between the host OS
    vmware-iso: and the guest OS in a Fusion or Workstation virtual environment.  Do you wish
    vmware-iso: to enable this feature? [yes]
    vmware-iso:
    vmware-iso: Found a compatible pre-built module for vmhgfs.  Installing it...
    vmware-iso:
    vmware-iso:
    vmware-iso: Found a compatible pre-built module for vmxnet.  Installing it...
    vmware-iso:
    vmware-iso:
    vmware-iso: The vmblock enables dragging or copying files between host and guest in a
    vmware-iso: Fusion or Workstation virtual environment.  Do you wish to enable this feature?
    vmware-iso: [yes]
    vmware-iso:
    vmware-iso: NOTICE:  It appears your system does not have the required fuse packages
    vmware-iso: installed.  The VMware blocking filesystem requires the fuse packages and its
    vmware-iso: libraries to function properly.  Please install the fuse or fuse-utils package
    vmware-iso: using your systems package management utility and re-run this script in order
    vmware-iso: to enable the VMware blocking filesystem.
    vmware-iso:
    vmware-iso: VMware automatic kernel modules enables automatic building and installation of
    vmware-iso: VMware kernel modules at boot that are not already present. This feature can be
    vmware-iso:
    vmware-iso: enabled/disabled by re-running vmware-config-tools.pl.
    vmware-iso:
    vmware-iso: Would you like to enable VMware automatic kernel modules?
    vmware-iso: [no]
    vmware-iso:
    vmware-iso: No X install found.
    vmware-iso:
    vmware-iso: Creating a new initrd boot image for the kernel.
    vmware-iso: vmware-tools-thinprint start/running
    vmware-iso: vmware-tools start/running
    **vmware-iso: The configuration of VMware Tools 9.6.1 build-1378637 for Linux for this**
    **vmware-iso: running kernel completed successfully.**
    vmware-iso:
    vmware-iso: You must restart your X session before any mouse or graphics changes take
    vmware-iso: effect.
    vmware-iso:
    vmware-iso: You can now run VMware Tools by invoking "/usr/bin/vmware-toolbox-cmd" from the
    vmware-iso: command line.
    vmware-iso:
    vmware-iso: To enable advanced X features (e.g., guest resolution fit, drag and drop, and
    vmware-iso: file and text copy/paste), you will need to do one (or more) of the following:
    vmware-iso: 1. Manually start /usr/bin/vmware-user
    vmware-iso: 2. Log out and log back into your desktop session; and,
    vmware-iso: 3. Restart your X session.
    vmware-iso:
    vmware-iso: Enjoy,
    vmware-iso:
    vmware-iso: --the VMware team
    vmware-iso:
    vmware-iso: /sbin/restorecon:  Warning no default label for /tmp/vmware-block-restore0/tmp_file
