### PR TITLE
[BENTO-111] Added a .gitattributes and a note for Windows hosts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Detect text files automatically
+* text=auto
+
+# Force LF line ending on these files
+*.sh eol=lf
+
+ks.cfg eol=lf
+preseed.cfg eol=lf
+
+# Force CRLF line ending on these files
+*.bat eol=crlf
+
+# Force binary on these files
+*.cer binary

--- a/README.md
+++ b/README.md
@@ -113,6 +113,28 @@ boxes yourself due to licensing constraints. You can build these as follows:
     $ bundle install
     $ bundle exec veewee vbox build [definition-name]
 
+### Windows Hosts
+
+When building boxes from a Windows host system, you must ensure that kickstart configuration files (`ks.cfg` for RHEL
+based systems) and preseed files (`preseed.cfg` for Debian based systems) have Unix line endings (i.e. lines end with
+LF character only). Moreover, it's also a good idea to have `*.sh` scripts with Unix line endings too.
+
+When these files have Windows line endings, the group creation can fail in the pre-seed phase and in turn, prevents the
+user `vagrant` to be created correctly. This ultimately results in Packer not being able to connect to the newly booted
+up machine with an error message that looks like this:
+
+```
+==> virtualbox-iso: Waiting for SSH to become available...
+==> virtualbox-iso: Error waiting for SSH: handshake failed: ssh: unable to authenticate, attempted methods [none password], no support
+```
+
+Since Packer tries to log in with user `vagrant` but it was not created successfully in the pre-seed phase, it is unable
+to connect to the machine and the packaging process stops.
+
+By default, when cloning this repository, git should normalized `ks.cfg`, `preseed.cfg` and `*.sh` to Unix line endings
+and `*.bat` to Windows line endings, thanks to the [.gitattributes](.gitattributes) file in the repository. However, if
+it's not the case, convert the offending files so they have the correct line endings.
+
 ## Bugs and Issues
 
 Use the [issue tracker](http://tickets.opscode.com/browse/BENTO) to report


### PR DESCRIPTION
A .gitattributes was added to the repository to ensure `ks.cfg`, `preseed.cfg` and `*.sh` files have correct `LF` line endings and `*.bat` files have correct `CRLF` line endings. Also added a note about this in the `README` so people packaging boxes from Windows Hosts can fix the problem if they encounter it.

See [BENTO-111](https://tickets.opscode.com/browse/BENTO-111) for the rationale behind this.

Regards,
Matt
