### PR TITLE
support mirror variable for iso_url in all centos/vmware builders

### DIFF
--- a/packer/centos-5.10-i386.json
+++ b/packer/centos-5.10-i386.json
@@ -46,7 +46,7 @@
       "http_directory": "http",
       "iso_checksum": "bb4e61210e1c0389fdf55c59bd2dd7bc957dd400",
       "iso_checksum_type": "sha1",
-      "iso_url": "http://mirrors.kernel.org/centos/5.10/isos/i386/CentOS-5.10-i386-bin-DVD-1of2.iso",
+      "iso_url": "{{user `mirror`}}/5.10/isos/i386/CentOS-5.10-i386-bin-DVD-1of2.iso",
       "output_directory": "packer-centos-5.10-i386-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer/centos-5.10-x86_64.json
+++ b/packer/centos-5.10-x86_64.json
@@ -46,7 +46,7 @@
       "http_directory": "http",
       "iso_checksum": "d8403b3fe4972eda3e147ee76d682a4a3beae1e1",
       "iso_checksum_type": "sha1",
-      "iso_url": "http://mirrors.kernel.org/centos/5.10/isos/x86_64/CentOS-5.10-x86_64-bin-DVD-1of2.iso",
+      "iso_url": "{{user `mirror`}}/5.10/isos/x86_64/CentOS-5.10-x86_64-bin-DVD-1of2.iso",
       "output_directory": "packer-centos-5.10-x86_64-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer/centos-6.5-i386.json
+++ b/packer/centos-6.5-i386.json
@@ -46,7 +46,7 @@
       "http_directory": "http",
       "iso_checksum": "67ea68068ae53d1f23431072ec0288b3e1abfe4d",
       "iso_checksum_type": "sha1",
-      "iso_url": "http://mirrors.kernel.org/centos/6.5/isos/i386/CentOS-6.5-i386-bin-DVD1.iso",
+      "iso_url": "{{user `mirror`}}/6.5/isos/i386/CentOS-6.5-i386-bin-DVD1.iso",
       "output_directory": "packer-centos-6.5-i386-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer/centos-6.5-x86_64.json
+++ b/packer/centos-6.5-x86_64.json
@@ -46,7 +46,7 @@
       "http_directory": "http",
       "iso_checksum": "32c7695b97f7dcd1f59a77a71f64f2957dddf738",
       "iso_checksum_type": "sha1",
-      "iso_url": "http://mirrors.kernel.org/centos/6.5/isos/x86_64/CentOS-6.5-x86_64-bin-DVD1.iso",
+      "iso_url": "{{user `mirror`}}/6.5/isos/x86_64/CentOS-6.5-x86_64-bin-DVD1.iso",
       "output_directory": "packer-centos-6.5-x86_64-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",


### PR DESCRIPTION
I noticed that the 'mirror' user variable was not being used in all builders
