### PR TITLE
Allow `packer_cache` to be symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@ bin/
 iso
 *.box
 virtualfloppy.vfd
-packer_cache/
+packer_cache
 packer.log
 .DS_Store


### PR DESCRIPTION
The trailing slash ignores only directories.
