### PR TITLE
Fix DHCP lease directory name in Debian

### DIFF
--- a/packer/scripts/debian/networking.sh
+++ b/packer/scripts/debian/networking.sh
@@ -3,5 +3,5 @@
 rm /etc/udev/rules.d/70-persistent-net.rules
 mkdir /etc/udev/rules.d/70-persistent-net.rules
 rm /lib/udev/rules.d/75-persistent-net-generator.rules
-rm -rf /dev/.udev/ /var/lib/dhcp3/*
+rm -rf /dev/.udev/ /var/lib/dhcp/*
 echo "pre-up sleep 2" >> /etc/network/interfaces


### PR DESCRIPTION
Both Debian 6.0 and 7 use /var/lib/dhcp instead of dhcp3.
