### PR TITLE
Use sudoers.d in Debian

### DIFF
--- a/packer/scripts/debian/sudoers.sh
+++ b/packer/scripts/debian/sudoers.sh
@@ -1,7 +1,9 @@
 #!/bin/bash -eux
 
-# Only add the secure path line if it is not already present - Debian 7.1.0
+# Only add the secure path line if it is not already present - Debian 7
 # includes it by default.
 grep -q 'secure_path' /etc/sudoers || sed -i -e '/Defaults\s\+env_reset/a Defaults\tsecure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"' /etc/sudoers
 
-sed -i -e 's/^%sudo.*/%sudo ALL=(ALL) NOPASSWD: ALL/' /etc/sudoers
+# Set up password-less sudo for the vagrant user
+echo 'vagrant ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/99_vagrant
+chmod 440 /etc/sudoers.d/99_vagrant


### PR DESCRIPTION
Debian 6.0+ have sudoers.d enabled by default. Use it so that the provisioners (like Chef) don't need to agree on using "sudo" group, or know anything about "vagrant" user if it manages the /etc/sudoers file.
