### PR TITLE
Add OpenBSD 5.4 templates for Packer

### DIFF
--- a/packer/openbsd-5.4-amd64.json
+++ b/packer/openbsd-5.4-amd64.json
@@ -1,0 +1,153 @@
+{
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://ftp.openbsd.org"
+  },
+  "provisioners": [
+    {
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}",
+        "MIRROR={{user `mirror`}}"
+      ],
+      "type": "shell",
+      "scripts": [
+        "scripts/openbsd/postinstall.sh",
+        "scripts/common/vagrant.sh",
+        "scripts/openbsd/chef.sh",
+        "scripts/common/minimize.sh"
+      ],
+      "execute_command": "export {{.Vars}} && cat {{.Path}} | su -m"
+    }
+  ],
+  "builders": [
+    {
+      "type": "virtualbox-iso",
+      "boot_command": [
+        "I<enter><wait>",
+        "us<enter><wait>",
+        "openbsd54<enter><wait>",
+        "<enter><wait>",
+        "dhcp<enter><wait>",
+        "none<enter><wait>",
+        "done<enter><wait>",
+        "vagrant<enter><wait>",
+        "vagrant<enter><wait>",
+        "yes<enter><wait>",
+        "no<enter><wait>",
+        "no<enter><wait>",
+        "vagrant<enter><wait>",
+        "vagrant<enter><wait>",
+        "vagrant<enter><wait>",
+        "vagrant<enter><wait>",
+        "no<enter><wait>",
+        "UTC<enter><wait>",
+        "<enter><wait>",
+        "yes<enter><wait>",
+        "W<enter><wait>",
+        "A<enter><wait10>",
+        "<wait10>",
+        "cd<enter><wait>",
+        "<enter><wait>",
+        "<enter><wait>",
+        "-game54.tgz<enter><wait>",
+        "-xbase54.tgz<enter><wait>",
+        "-xetc54.tgz<enter><wait>",
+        "-xshare54.tgz<enter><wait>",
+        "-xfont54.tgz<enter><wait>",
+        "-xserv54.tgz<enter><wait>",
+        "done<enter><wait10>",
+        "<wait10><wait10><wait10>",
+        "done<enter><wait>",
+        "yes<enter><wait5>",
+        "reboot<enter>"
+      ],
+      "boot_wait": "45s",
+      "disk_size": 10140,
+      "guest_additions_mode": "disable",
+      "guest_os_type": "OpenBSD_64",
+      "iso_checksum": "9b59c031a0a2c127f824449294be9a88a05624ccf179b0d1b44d714f13b68448",
+      "iso_checksum_type": "sha256",
+      "iso_url": "{{user `mirror`}}/pub/OpenBSD/5.4/amd64/install54.iso",
+      "output_directory": "packer-openbsd-5.4-amd64-virtualbox",
+      "shutdown_command": "/sbin/halt -p",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "vboxmanage": [
+        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
+        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-openbsd-5.4-amd64"
+    },
+    {
+      "type": "vmware-iso",
+      "boot_command": [
+        "I<enter><wait>",
+        "us<enter><wait>",
+        "openbsd54<enter><wait>",
+        "<enter><wait>",
+        "dhcp<enter><wait>",
+        "none<enter><wait>",
+        "done<enter><wait>",
+        "vagrant<enter><wait>",
+        "vagrant<enter><wait>",
+        "yes<enter><wait>",
+        "no<enter><wait>",
+        "no<enter><wait>",
+        "no<enter><wait>",
+        "vagrant<enter><wait>",
+        "vagrant<enter><wait>",
+        "vagrant<enter><wait>",
+        "vagrant<enter><wait>",
+        "no<enter><wait>",
+        "UTC<enter><wait>",
+        "<enter><wait>",
+        "yes<enter><wait>",
+        "W<enter><wait>",
+        "A<enter><wait10>",
+        "<wait10>",
+        "cd<enter><wait>",
+        "<enter><wait>",
+        "<enter><wait>",
+        "-game54.tgz<enter><wait>",
+        "-xbase54.tgz<enter><wait>",
+        "-xetc54.tgz<enter><wait>",
+        "-xshare54.tgz<enter><wait>",
+        "-xfont54.tgz<enter><wait>",
+        "-xserv54.tgz<enter><wait>",
+        "done<enter><wait10>",
+        "<wait10><wait10><wait10>",
+        "done<enter><wait>",
+        "yes<enter><wait5>",
+        "reboot<enter>"
+      ],
+      "boot_wait": "45s",
+      "disk_size": 10140,
+      "guest_os_type": "other-64",
+      "iso_checksum": "9b59c031a0a2c127f824449294be9a88a05624ccf179b0d1b44d714f13b68448",
+      "iso_checksum_type": "sha256",
+      "iso_url": "{{user `mirror`}}/pub/OpenBSD/5.4/amd64/install54.iso",
+      "output_directory": "packer-openbsd-5.4-amd64-vmware",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -p",
+      "vm_name": "packer-openbsd-5.4-amd64",
+      "vmx_data": {
+        "memsize": "384",
+        "numvcpus": "1",
+        "cpuid.coresPerSocket": "1"
+      }
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "vagrant",
+      "output": "../builds/{{.Provider}}/openbsd-5.4-amd64_chef-{{user `chef_version`}}.box",
+      "vagrantfile_template": "vagrantfiles/openbsd"
+    }
+  ]
+}

--- a/packer/openbsd-5.4-i386.json
+++ b/packer/openbsd-5.4-i386.json
@@ -1,0 +1,153 @@
+{
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://ftp.openbsd.org"
+  },
+  "provisioners": [
+    {
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}",
+        "MIRROR={{user `mirror`}}"
+      ],
+      "type": "shell",
+      "scripts": [
+        "scripts/openbsd/postinstall.sh",
+        "scripts/common/vagrant.sh",
+        "scripts/openbsd/chef.sh",
+        "scripts/common/minimize.sh"
+      ],
+      "execute_command": "export {{.Vars}} && cat {{.Path}} | su -m"
+    }
+  ],
+  "builders": [
+    {
+      "type": "virtualbox-iso",
+      "boot_command": [
+        "I<enter><wait>",
+        "us<enter><wait>",
+        "openbsd54<enter><wait>",
+        "<enter><wait>",
+        "dhcp<enter><wait>",
+        "none<enter><wait>",
+        "done<enter><wait>",
+        "vagrant<enter><wait>",
+        "vagrant<enter><wait>",
+        "yes<enter><wait>",
+        "no<enter><wait>",
+        "no<enter><wait>",
+        "vagrant<enter><wait>",
+        "vagrant<enter><wait>",
+        "vagrant<enter><wait>",
+        "vagrant<enter><wait>",
+        "no<enter><wait>",
+        "UTC<enter><wait>",
+        "<enter><wait>",
+        "yes<enter><wait>",
+        "W<enter><wait>",
+        "A<enter><wait10>",
+        "<wait10>",
+        "cd<enter><wait>",
+        "<enter><wait>",
+        "<enter><wait>",
+        "-game54.tgz<enter><wait>",
+        "-xbase54.tgz<enter><wait>",
+        "-xetc54.tgz<enter><wait>",
+        "-xshare54.tgz<enter><wait>",
+        "-xfont54.tgz<enter><wait>",
+        "-xserv54.tgz<enter><wait>",
+        "done<enter><wait10>",
+        "<wait10><wait10><wait10>",
+        "done<enter><wait>",
+        "yes<enter><wait5>",
+        "reboot<enter>"
+      ],
+      "boot_wait": "45s",
+      "disk_size": 10140,
+      "guest_additions_mode": "disable",
+      "guest_os_type": "OpenBSD",
+      "iso_checksum": "64261b5438fd04c9efded4dd17e44c6b033b69e00cc1ae4a0c55f1ff3a93e469",
+      "iso_checksum_type": "sha256",
+      "iso_url": "{{user `mirror`}}/pub/OpenBSD/5.4/i386/install54.iso",
+      "output_directory": "packer-openbsd-5.4-i386-virtualbox",
+      "shutdown_command": "/sbin/halt -p",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "vboxmanage": [
+        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
+        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-openbsd-5.4-i386"
+    },
+    {
+      "type": "vmware-iso",
+      "boot_command": [
+        "I<enter><wait>",
+        "us<enter><wait>",
+        "openbsd54<enter><wait>",
+        "<enter><wait>",
+        "dhcp<enter><wait>",
+        "none<enter><wait>",
+        "done<enter><wait>",
+        "vagrant<enter><wait>",
+        "vagrant<enter><wait>",
+        "yes<enter><wait>",
+        "no<enter><wait>",
+        "no<enter><wait>",
+        "no<enter><wait>",
+        "vagrant<enter><wait>",
+        "vagrant<enter><wait>",
+        "vagrant<enter><wait>",
+        "vagrant<enter><wait>",
+        "no<enter><wait>",
+        "UTC<enter><wait>",
+        "<enter><wait>",
+        "yes<enter><wait>",
+        "W<enter><wait>",
+        "A<enter><wait10>",
+        "<wait10>",
+        "cd<enter><wait>",
+        "<enter><wait>",
+        "<enter><wait>",
+        "-game54.tgz<enter><wait>",
+        "-xbase54.tgz<enter><wait>",
+        "-xetc54.tgz<enter><wait>",
+        "-xshare54.tgz<enter><wait>",
+        "-xfont54.tgz<enter><wait>",
+        "-xserv54.tgz<enter><wait>",
+        "done<enter><wait10>",
+        "<wait10><wait10><wait10>",
+        "done<enter><wait>",
+        "yes<enter><wait5>",
+        "reboot<enter>"
+      ],
+      "boot_wait": "45s",
+      "disk_size": 10140,
+      "guest_os_type": "other",
+      "iso_checksum": "64261b5438fd04c9efded4dd17e44c6b033b69e00cc1ae4a0c55f1ff3a93e469",
+      "iso_checksum_type": "sha256",
+      "iso_url": "{{user `mirror`}}/pub/OpenBSD/5.4/i386/install54.iso",
+      "output_directory": "packer-openbsd-5.4-i386-vmware",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -p",
+      "vm_name": "packer-openbsd-5.4-i386",
+      "vmx_data": {
+        "memsize": "384",
+        "numvcpus": "1",
+        "cpuid.coresPerSocket": "1"
+      }
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "vagrant",
+      "output": "../builds/{{.Provider}}/openbsd-5.4-i386_chef-{{user `chef_version`}}.box",
+      "vagrantfile_template": "vagrantfiles/openbsd"
+    }
+  ]
+}

--- a/packer/scripts/openbsd/chef.sh
+++ b/packer/scripts/openbsd/chef.sh
@@ -1,0 +1,23 @@
+if [ x$CHEF_VERSION = x'provisionerless' ]; then
+  echo "Building a box without Chef"
+else
+  . /root/.profile
+  pkg_add ruby-1.9.3.448
+
+  for f in ruby erb irb rdoc ri rake gem testrb \
+           chef-apply chef-client chef-shell chef-solo chef-zero \
+           knife ohai shef; do
+    ln -sf ${f}19 /usr/local/bin/$f
+  done
+
+  ln -sf /usr/local/bin/testrb19 /usr/local/bin/testrb
+
+  if [ x$CHEF_VERSION == x'latest' ]; then
+    gem install chef --no-ri --no-rdoc
+  elif [ x$CHEF_VERSION == x'prerelease' ]; then
+    gem install chef --no-ri --no-rdoc --pre
+    $chef_installer -p
+  else
+    gem install chef --no-ri --no-rdoc --version="$CHEF_VERSION"
+  fi
+fi

--- a/packer/scripts/openbsd/ports.sh
+++ b/packer/scripts/openbsd/ports.sh
@@ -1,0 +1,8 @@
+# install the ports system
+cd /tmp
+wget "$MIRROR/pub/OpenBSD/`uname -r`/ports.tar.gz"
+
+cd /usr
+tar xzf /tmp/ports.tar.gz
+
+rm /tmp/ports.tar.gz

--- a/packer/scripts/openbsd/postinstall.sh
+++ b/packer/scripts/openbsd/postinstall.sh
@@ -1,0 +1,11 @@
+export PKG_PATH="$MIRROR/pub/OpenBSD/`uname -r`/packages/`arch -s`/"
+
+# set pkg path for users
+echo "export PKG_PATH=\"$PKG_PATH\"" >> /root/.profile
+echo "export PKG_PATH=\"$PKG_PATH\"" >> /home/vagrant/.profile
+
+# install wget/curl
+pkg_add wget curl
+
+# sudo
+echo "vagrant ALL=(ALL) NOPASSWD: SETENV: ALL" >> /etc/sudoers

--- a/packer/vagrantfiles/openbsd
+++ b/packer/vagrantfiles/openbsd
@@ -1,0 +1,3 @@
+Vagrant.configure('2') do |config|
+  config.ssh.shell = 'sh'
+end


### PR DESCRIPTION
Catches:
- No VirtualBox Guest Additions nor VMware Tool exist for OpenBSD
- Omnibus Chef doesn't support OpenBSD, so install Chef as gem
- Vagrant <1.5 has some issues with OpenBSD guests
