### PR TITLE
Move single-request-reopen into OS specific scripts

### DIFF
--- a/packer/centos-6.5-i386.json
+++ b/packer/centos-6.5-i386.json
@@ -76,6 +76,7 @@
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/centos/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",
         "scripts/common/vmtools.sh",

--- a/packer/centos-6.5-x86_64.json
+++ b/packer/centos-6.5-x86_64.json
@@ -76,6 +76,7 @@
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/centos/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",
         "scripts/common/vmtools.sh",

--- a/packer/fedora-19-i386.json
+++ b/packer/fedora-19-i386.json
@@ -76,6 +76,7 @@
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
+        "scripts/fedora/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",
         "scripts/common/chef.sh",

--- a/packer/fedora-19-x86_64.json
+++ b/packer/fedora-19-x86_64.json
@@ -76,6 +76,7 @@
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
+        "scripts/fedora/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",
         "scripts/common/chef.sh",

--- a/packer/fedora-20-i386.json
+++ b/packer/fedora-20-i386.json
@@ -76,6 +76,7 @@
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
+        "scripts/fedora/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",
         "scripts/common/chef.sh",

--- a/packer/fedora-20-x86_64.json
+++ b/packer/fedora-20-x86_64.json
@@ -76,6 +76,7 @@
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
+        "scripts/fedora/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",
         "scripts/common/chef.sh",

--- a/packer/rhel-6.5-i386.json
+++ b/packer/rhel-6.5-i386.json
@@ -76,6 +76,7 @@
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/centos/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",
         "scripts/common/vmtools.sh",

--- a/packer/rhel-6.5-x86_64.json
+++ b/packer/rhel-6.5-x86_64.json
@@ -76,6 +76,7 @@
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/centos/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",
         "scripts/common/vmtools.sh",

--- a/packer/scripts/centos/fix-slow-dns.sh
+++ b/packer/scripts/centos/fix-slow-dns.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -eux
+
+if [[ "$PACKER_BUILDER_TYPE" == virtualbox* ]]; then
+  ## https://access.redhat.com/site/solutions/58625 (subscription required)
+  # add 'single-request-reopen' so it is included when /etc/resolv.conf is generated
+  echo 'RES_OPTIONS="single-request-reopen"' >> /etc/sysconfig/network
+  service network restart
+  echo 'Slow DNS fix applied (single-request-reopen)'
+else
+  echo 'Slow DNS fix not required for this platform, skipping'
+fi

--- a/packer/scripts/centos/ks.cfg
+++ b/packer/scripts/centos/ks.cfg
@@ -12,7 +12,7 @@ text
 skipx
 zerombr
 clearpart --all --initlabel
-autopart  
+autopart
 auth --enableshadow --passalgo=sha512 --kickstart
 firstboot --disabled
 reboot
@@ -39,4 +39,3 @@ echo "vagrant" | passwd --stdin vagrant
 # sudo
 echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
-echo "options single-request-reopen" >> /etc/resolv.conf

--- a/packer/scripts/fedora/fix-slow-dns.sh
+++ b/packer/scripts/fedora/fix-slow-dns.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -eux
+
+if [[ "$PACKER_BUILDER_TYPE" == virtualbox* ]]; then
+  # fix bug to enable nm-dispatcher on Fedora 19 https://bugzilla.redhat.com/show_bug.cgi?id=974811
+  if [[ $(rpm -q --queryformat '%{VERSION}\n' fedora-release) == 19 ]]; then
+    yum -y upgrade NetworkManager
+    systemctl enable NetworkManager-dispatcher.service
+  fi
+
+  ## https://access.redhat.com/site/solutions/58625 (subscription required)
+  # add 'single-request-reopen' so it is included when /etc/resolv.conf is generated
+  cat >> /etc/NetworkManager/dispatcher.d/fix-slow-dns <<EOF
+#!/bin/bash
+echo "options single-request-reopen" >> /etc/resolv.conf
+EOF
+  chmod +x /etc/NetworkManager/dispatcher.d/fix-slow-dns
+  service NetworkManager restart
+  echo 'Slow DNS fix applied (single-request-reopen)'
+else
+  echo 'Slow DNS fix not required for this platform, skipping'
+fi


### PR DESCRIPTION
related to #171

@juliandunn I've completed this move/change.

I established that Fedora 19 and 20 show the same issue under virtualbox.
1. I removed the line from `packer/scripts/centos/ks.cfg`
2. Added discrete `fix-slow-dns.sh` scripts for Fedora and Centos/RHEL. These are at the start of post-install script execution incase any later post-install scripts download things so they'll benefit from the fix.
3. Limited the execution of this post-install script to virtualbox only.
4. I moved the Centos into `/etc/sysconfig/network`, this is used when `resolv.conf` is generated when dhclient runs. `resolv.conf` can be overwritten and the change lost otherwise.
5. Fedora uses NetworkManager to generate `resolv.conf`, added a script to hook into that to add the required line to `resolv.conf`
6. Fedora 19 has a known bug with the install media version of NetworkManager that prevents dispatchers (the hook I'm using) from running so on F19 updated NM to mitigate this.
7. I built new boxes with the changes applied and verified that they were showing the desired behaviour, as below.

In short this should apply only the the effected operating systems and persist past network changes/reboots.

_How to reproduce:_

To reproduce this issue I set up a basic Vagrant test: https://gist.github.com/rjocoleman/9161682

Bad:

``` shell
[default] Running: inline script
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   220  100   220    0     0     26      0  0:00:08  0:00:08 --:--:--    47
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   220  100   220    0     0     34      0  0:00:06  0:00:06 --:--:--    57
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   220  100   220    0     0     34      0  0:00:06  0:00:06 --:--:--    58
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   220  100   220    0     0     33      0  0:00:06  0:00:06 --:--:--    54
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   220  100   220    0     0     34      0  0:00:06  0:00:06 --:--:--    58
```

Fixed

``` shell
[default] Running: inline script
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   220  100   220    0     0    323      0 --:--:-- --:--:-- --:--:--   323
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   220  100   220    0     0    305      0 --:--:-- --:--:-- --:--:--   305
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   220  100   220    0     0    289      0 --:--:-- --:--:-- --:--:--   289
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   220  100   220    0     0    274      0 --:--:-- --:--:-- --:--:--   274
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   220  100   220    0     0    326      0 --:--:-- --:--:-- --:--:--   326
```
