### PR TITLE
Put vagrant sudo configuration in a separate file

### DIFF
--- a/packer/http/centos-6.5/ks.cfg
+++ b/packer/http/centos-6.5/ks.cfg
@@ -37,5 +37,5 @@ groupadd vagrant -g 999
 useradd vagrant -g vagrant -G wheel -u 900
 echo "vagrant" | passwd --stdin vagrant
 # sudo
-echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
+echo "%vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers


### PR DESCRIPTION
Put vagrant sudo configuration in `/etc/sudoers.d/vagrant` rather than `/etc/sudoers`, so that if, say, Chef writes out a new `/etc/sudoers`, sudo from vagrant continues to work.

Other platform templates already do this.  It's handled a bit inconsistently at the moment.  This is just the platform I was interested in.

Note, I don't know how all the pieces fit together.  There is similar code in `packer/scripts/centos/ks.cfg`, but I don't know if anything uses that.
