### PR TITLE
Bugfixes for FreeBSD 10

### DIFF
--- a/packer/freebsd-10.0-amd64.json
+++ b/packer/freebsd-10.0-amd64.json
@@ -88,6 +88,7 @@
       "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
       "vm_name": "packer-freebsd-10.0-amd64",
       "output_directory": "packer-freebsd-10.0-amd64-vmware",
+      "tools_upload_flavor": "freebsd",
       "vmx_data": {
         "memsize": "512",
         "numvcpus": "1",

--- a/packer/freebsd-10.0-i386.json
+++ b/packer/freebsd-10.0-i386.json
@@ -88,6 +88,7 @@
       "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
       "vm_name": "packer-freebsd-10.0-i386",
       "output_directory": "packer-freebsd-10.0-i386-vmware",
+      "tools_upload_flavor": "freebsd",
       "vmx_data": {
         "memsize": "512",
         "numvcpus": "1",

--- a/packer/scripts/freebsd/vmtools.sh
+++ b/packer/scripts/freebsd/vmtools.sh
@@ -9,7 +9,7 @@ else
   perl_pkg="perl"
 fi
 
-if [ $PACKER_BUILDER_TYPE == 'virtualbox' ]; then
+if [ $PACKER_BUILDER_TYPE == 'virtualbox-iso' ]; then
   # disable X11 because vagrants are (usually) headless
   echo 'WITHOUT_X11="YES"' >> /etc/make.conf
 
@@ -34,7 +34,7 @@ if [ $PACKER_BUILDER_TYPE == 'virtualbox' ]; then
   echo 'ifconfig_vtnet3_name="em3"' >> /etc/rc.conf
 fi
 
-if [ $PACKER_BUILDER_TYPE == 'vmware' ]; then
+if [ $PACKER_BUILDER_TYPE == 'vmware-iso' ]; then
   mkdir /tmp/vmfusion
   mkdir /tmp/vmfusion-archive
   mdconfig -a -t vnode -f /home/vagrant/freebsd.iso -u 0


### PR DESCRIPTION
`tools_upload_flavor` went missing from VMWare templates so that breaks the VMWare build and builder names changed in Packer.
