### PR TITLE
Update vagrant.sh

### DIFF
--- a/packer/scripts/common/vagrant.sh
+++ b/packer/scripts/common/vagrant.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 mkdir /home/vagrant/.ssh
-curl -o /home/vagrant/.ssh/authorized_keys -L \
-    'https://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub'
+wget --no-check-certificate \
+    'https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub' \
+    -O /home/vagrant/.ssh/authorized_keys
 chown -R vagrant /home/vagrant/.ssh
 chmod -R go-rwsx /home/vagrant/.ssh


### PR DESCRIPTION
Switch back to wget (ubuntu doesn't come with curl) and use the direct URL instead (wget in debian 7.4 was broken. 
See: https://github.com/opscode/bento/pull/203#issuecomment-40037333 and https://github.com/opscode/bento/commit/a96d1b9
