### PR TITLE
Cleanup inconsistencies in Ubuntu templates.

### DIFF
--- a/packer/ubuntu-13.10-amd64.json
+++ b/packer/ubuntu-13.10-amd64.json
@@ -85,7 +85,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "ubuntu-64",
-      "headless": true,
       "http_directory": "http",
       "iso_checksum": "5dd72c694c3a7e06a3b4dd651ca26cfc70985004",
       "iso_checksum_type": "sha1",

--- a/packer/ubuntu-13.10-i386.json
+++ b/packer/ubuntu-13.10-i386.json
@@ -113,11 +113,6 @@
   ],
   "provisioners": [
     {
-      "destination": "/tmp/shutdown.sh",
-      "source": "scripts/common/shutdown.sh",
-      "type": "file"
-    },
-    {
       "environment_vars": [
         "CHEF_VERSION={{user `chef_version`}}"
       ],

--- a/packer/ubuntu-14.04-amd64.json
+++ b/packer/ubuntu-14.04-amd64.json
@@ -85,7 +85,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "ubuntu-64",
-      "headless": true,
       "http_directory": "http",
       "iso_checksum": "4d94f6111b8fe47da94396180ce499d8c0bb44f3",
       "iso_checksum_type": "sha1",

--- a/packer/ubuntu-14.04-i386.json
+++ b/packer/ubuntu-14.04-i386.json
@@ -113,11 +113,6 @@
   ],
   "provisioners": [
     {
-      "destination": "/tmp/shutdown.sh",
-      "source": "scripts/common/shutdown.sh",
-      "type": "file"
-    },
-    {
       "environment_vars": [
         "CHEF_VERSION={{user `chef_version`}}"
       ],


### PR DESCRIPTION
- Build all templates non-headless so we can see error output
- Remove extraneous provisioner
