### PR TITLE
Dependency Fix

### DIFF
--- a/packer/http/fedora-20/ks.cfg
+++ b/packer/http/fedora-20/ks.cfg
@@ -32,6 +32,7 @@ kernel-headers
 tar
 wget
 nfs-utils
+net-tools
 -linux-firmware
 -plymouth
 -plymouth-core-libs


### PR DESCRIPTION
VMware Tools seems to be dependent upon ifconfig being present.  package 'net-tools' provides ifconfig, as well as others.
https://admin.fedoraproject.org/pkgdb/acls/name/net-tools
