### PR TITLE
Remove "requiretty" in /etc/sudoers in fedora

### DIFF
--- a/packer/fedora-19-i386.json
+++ b/packer/fedora-19-i386.json
@@ -81,6 +81,7 @@
         "scripts/common/vmtools.sh",
         "scripts/common/chef.sh",
         "scripts/common/vagrant.sh",
+        "scripts/fedora/sudoers.sh",
         "scripts/fedora/cleanup.sh",
         "scripts/common/minimize.sh"
       ],

--- a/packer/fedora-19-x86_64.json
+++ b/packer/fedora-19-x86_64.json
@@ -81,6 +81,7 @@
         "scripts/common/vmtools.sh",
         "scripts/common/chef.sh",
         "scripts/common/vagrant.sh",
+        "scripts/fedora/sudoers.sh",
         "scripts/fedora/cleanup.sh",
         "scripts/common/minimize.sh"
       ],

--- a/packer/fedora-20-i386.json
+++ b/packer/fedora-20-i386.json
@@ -81,6 +81,7 @@
         "scripts/common/vmtools.sh",
         "scripts/common/chef.sh",
         "scripts/common/vagrant.sh",
+        "scripts/fedora/sudoers.sh",
         "scripts/fedora/cleanup.sh",
         "scripts/common/minimize.sh"
       ],

--- a/packer/fedora-20-x86_64.json
+++ b/packer/fedora-20-x86_64.json
@@ -81,6 +81,7 @@
         "scripts/common/vmtools.sh",
         "scripts/common/chef.sh",
         "scripts/common/vagrant.sh",
+        "scripts/fedora/sudoers.sh",
         "scripts/fedora/cleanup.sh",
         "scripts/common/minimize.sh"
       ],

--- a/packer/scripts/fedora/sudoers.sh
+++ b/packer/scripts/fedora/sudoers.sh
@@ -2,3 +2,5 @@
 
 sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=sudo' /etc/sudoers
 sed -i -e 's/%admin ALL=(ALL) ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers
+sed -i -r -e 's/Defaults\s+(.*)requiretty(.*)/Defaults \1\2/' /etc/sudoers
+sed -i -r -e 's/Defaults\s*$//g' /etc/sudoers


### PR DESCRIPTION
"requiretty" prevents vagrant provisioners from becoming root during
provisioning, since the script runs without a tty.