### PR TITLE
Guard for empty vagrant authorized_keys file

### DIFF
--- a/packer/scripts/common/vagrant.sh
+++ b/packer/scripts/common/vagrant.sh
@@ -4,5 +4,12 @@ mkdir /home/vagrant/.ssh
 wget --no-check-certificate \
     'https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub' \
     -O /home/vagrant/.ssh/authorized_keys
+
+# Guard for empty authorized_keys file, wget with error creates an empty file
+if [ ! -s /home/vagrant/.ssh/authorized_keys ]; then
+  echo "Unable to download Vagrant public key"
+  exit 1
+fi
+
 chown -R vagrant /home/vagrant/.ssh
 chmod -R go-rwsx /home/vagrant/.ssh


### PR DESCRIPTION
It could be possible the `wget` command runs in an error and creates an empty `authorized_keys` file. The exit code is 0 and doesn't stop the build process. See example below by having issues resolving the raw.githubusercontent.com address:

    Provisioning with shell script: scripts/common/vagrant.sh
    virtualbox-iso: --2014-08-25 10:18:06--  https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub
    virtualbox-iso:   Resolving raw.githubusercontent.com... failed: Name or service not known.
    virtualbox-iso: wget: unable to resolve host address "raw.githubusercontent.com"
    virtualbox-iso: Provisioning with shell script: scripts/common/vmtools.sh
    virtualbox-iso: Verifying archive integrity... All good.