### PR TITLE
Add update script for CentOS and Fedora

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ virtualfloppy.vfd
 packer_cache
 packer.log
 .DS_Store
+packer/crash.log

--- a/packer/centos-5.10-i386.json
+++ b/packer/centos-5.10-i386.json
@@ -76,6 +76,7 @@
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/centos/update.sh",
         "scripts/common/vagrant.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",

--- a/packer/centos-5.10-x86_64.json
+++ b/packer/centos-5.10-x86_64.json
@@ -76,6 +76,7 @@
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/centos/update.sh",
         "scripts/common/vagrant.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",

--- a/packer/centos-6.5-i386.json
+++ b/packer/centos-6.5-i386.json
@@ -76,6 +76,7 @@
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/centos/update.sh",
         "scripts/centos/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",

--- a/packer/centos-6.5-x86_64.json
+++ b/packer/centos-6.5-x86_64.json
@@ -76,6 +76,7 @@
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/centos/update.sh",
         "scripts/centos/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",

--- a/packer/centos-7.0-x86_64.json
+++ b/packer/centos-7.0-x86_64.json
@@ -76,6 +76,7 @@
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/centos/update.sh",
         "scripts/centos/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",

--- a/packer/fedora-19-i386.json
+++ b/packer/fedora-19-i386.json
@@ -76,6 +76,7 @@
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
+        "scripts/fedora/update.sh",
         "scripts/fedora/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",

--- a/packer/fedora-19-x86_64.json
+++ b/packer/fedora-19-x86_64.json
@@ -76,6 +76,7 @@
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
+        "scripts/fedora/update.sh",
         "scripts/fedora/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",

--- a/packer/fedora-20-i386.json
+++ b/packer/fedora-20-i386.json
@@ -76,6 +76,7 @@
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
+        "scripts/fedora/update.sh",
         "scripts/fedora/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",

--- a/packer/fedora-20-x86_64.json
+++ b/packer/fedora-20-x86_64.json
@@ -76,6 +76,7 @@
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
+        "scripts/fedora/update.sh",
         "scripts/fedora/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",

--- a/packer/scripts/centos/update.sh
+++ b/packer/scripts/centos/update.sh
@@ -1,0 +1,3 @@
+yum clean all
+yum -y upgrade
+reboot

--- a/packer/scripts/debian/update.sh
+++ b/packer/scripts/debian/update.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -eux
 
+apt-get clean
 apt-get update
 apt-get -y upgrade

--- a/packer/scripts/fedora/update.sh
+++ b/packer/scripts/fedora/update.sh
@@ -1,0 +1,3 @@
+yum clean all
+yum -y upgrade
+reboot


### PR DESCRIPTION
Add update script for CentOS and Fedora, and modify respective templates to match Debian/Ubuntu. Also adds crash_log to .gitignore
