### PR TITLE
Restore purged curl to ubuntu boxes

### DIFF
--- a/packer/scripts/ubuntu/cleanup.sh
+++ b/packer/scripts/ubuntu/cleanup.sh
@@ -4,7 +4,7 @@
 dpkg --list | awk '{ print $2 }' | grep linux-headers | xargs apt-get -y purge
 
 # this removes specific linux kernels, such as
-# linux-image-3.11.0-15-generic but 
+# linux-image-3.11.0-15-generic but
 # * keeps the current kernel
 # * does not touch the virtual packages, e.g.'linux-image-generic', etc.
 #
@@ -28,6 +28,8 @@ apt-get -y purge ppp pppconfig pppoeconf
 # delete oddities
 apt-get -y purge popularity-contest
 
+# ensure curl wasn't removed
+apt-get -y install curl
 apt-get -y autoremove
 apt-get -y clean
 rm -rf VBoxGuestAdditions_*.iso VBoxGuestAdditions_*.iso.?


### PR DESCRIPTION
Despite sharing a post-install script with Debian, purge on Ubuntu removes curl. This is a clumsy workaround, but it does ensure that curl is available on the box, which provides parity with other platforms.

Also removes a trailing space in an unrelated file.
