### PR TITLE
Reduce Linux box size by not packing a swap partition gubbish

### DIFF
--- a/packer/freebsd-10.0-amd64.json
+++ b/packer/freebsd-10.0-amd64.json
@@ -12,7 +12,7 @@
         "scripts/common/chef.sh",
         "scripts/freebsd/cleanup.sh",
         "scripts/freebsd/vmtools.sh",
-        "scripts/common/minimize.sh"
+        "scripts/freebsd/minimize.sh"
       ],
       "execute_command": "export {{.Vars}} && cat {{.Path}} | su -m"
     }

--- a/packer/freebsd-10.0-i386.json
+++ b/packer/freebsd-10.0-i386.json
@@ -12,7 +12,7 @@
         "scripts/common/chef.sh",
         "scripts/freebsd/cleanup.sh",
         "scripts/freebsd/vmtools.sh",
-        "scripts/common/minimize.sh"
+        "scripts/freebsd/minimize.sh"
       ],
       "execute_command": "export {{.Vars}} && cat {{.Path}} | su -m"
     }

--- a/packer/freebsd-9.3-amd64.json
+++ b/packer/freebsd-9.3-amd64.json
@@ -105,7 +105,7 @@
         "scripts/freebsd/vmtools.sh",
         "scripts/common/chef.sh",
         "scripts/freebsd/cleanup.sh",
-        "scripts/common/minimize.sh"
+        "scripts/freebsd/minimize.sh"
       ],
       "type": "shell"
     }

--- a/packer/freebsd-9.3-i386.json
+++ b/packer/freebsd-9.3-i386.json
@@ -102,7 +102,7 @@
         "scripts/freebsd/vmtools.sh",
         "scripts/common/chef.sh",
         "scripts/freebsd/cleanup.sh",
-        "scripts/common/minimize.sh"
+        "scripts/freebsd/minimize.sh"
       ],
       "type": "shell"
     }

--- a/packer/scripts/common/minimize.sh
+++ b/packer/scripts/common/minimize.sh
@@ -1,5 +1,13 @@
 #!/bin/sh -eux
 
+# Whiteout the swap partition to reduce box size 
+# Swap is disabled till reboot 
+readonly swapuuid=$(/sbin/blkid -o value -l -s UUID -t TYPE=swap)
+readonly swappart=$(readlink -f /dev/disk/by-uuid/"$swapuuid")
+/sbin/swapoff "$swappart"
+dd if=/dev/zero of="$swappart" bs=1M || echo "dd exit code $? is suppressed" 
+/sbin/mkswap -U "$swapuuid" "$swappart"
+
 dd if=/dev/zero of=/EMPTY bs=1M
 rm -f /EMPTY
 # Block until the empty file has been removed, otherwise, Packer

--- a/packer/scripts/freebsd/minimize.sh
+++ b/packer/scripts/freebsd/minimize.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -eux
+
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY
+# Block until the empty file has been removed, otherwise, Packer
+# will try to kill the box while the disk is still full and that's bad
+sync


### PR DESCRIPTION
Current boxes are redistributed with the swap partition filled by gubbish -- if clean it the box size is reduced by 100-200 MB.
One more point that there also a little bit less chance of sensitive information leakage.
- Whiteout swap partition for CentOS, Debian, Fedora, OpenSUSE, Oracle,
  RHEL, SLES, Ubuntu
- FreeBSD has no support for blkid, left it as is
