### PR TITLE
#299 OpenSUSE 13.2 should specify netdevice=eth0

### DIFF
--- a/packer/opensuse-13.2-i386.json
+++ b/packer/opensuse-13.2-i386.json
@@ -73,7 +73,7 @@
     {
       "boot_command": [
         "<esc><enter><wait>",
-        "linux netsetup=dhcp install=cd:/<wait>",
+        "linux netsetup=dhcp netdevice=eth0 install=cd:/<wait>",
         " lang=en_US autoyast=http://{{ .HTTPIP }}:{{ .HTTPPort }}/opensuse-13.2/autoinst.xml<wait>",
         " textmode=1<wait>",
         "<enter><wait>"

--- a/packer/opensuse-13.2-x86_64.json
+++ b/packer/opensuse-13.2-x86_64.json
@@ -73,7 +73,7 @@
     {
       "boot_command": [
         "<esc><enter><wait>",
-        "linux netsetup=dhcp install=cd:/<wait>",
+        "linux netsetup=dhcp netdevice=eth0 install=cd:/<wait>",
         " lang=en_US autoyast=http://{{ .HTTPIP }}:{{ .HTTPPort }}/opensuse-13.2/autoinst.xml<wait>",
         " textmode=1<wait>",
         "<enter><wait>"


### PR DESCRIPTION
Fixes #299 
