### PR TITLE
Fix mac address issue for ens33 on centos 7

### DIFF
--- a/packer/scripts/centos/cleanup.sh
+++ b/packer/scripts/centos/cleanup.sh
@@ -8,6 +8,10 @@ rm -f /tmp/chef*rpm
 # clean up redhat interface persistence
 rm -f /etc/udev/rules.d/70-persistent-net.rules
 if [ -r /etc/sysconfig/network-scripts/ifcfg-eth0 ]; then
-  sed -i 's/^HWADDR.*$//' /etc/sysconfig/network-scripts/ifcfg-eth0
-  sed -i 's/^UUID.*$//' /etc/sysconfig/network-scripts/ifcfg-eth0
+  sed -i '/^HWADDR/d' /etc/sysconfig/network-scripts/ifcfg-eth0
+  sed -i '/^UUID/d' /etc/sysconfig/network-scripts/ifcfg-eth0
+fi
+if [ -r /etc/sysconfig/network-scripts/ifcfg-ens33 ]; then
+  sed -i '/^HWADDR/d' /etc/sysconfig/network-scripts/ifcfg-ens33
+  sed -i '/^UUID/d' /etc/sysconfig/network-scripts/ifcfg-ens33
 fi

--- a/packer/scripts/centos/cleanup.sh
+++ b/packer/scripts/centos/cleanup.sh
@@ -7,11 +7,10 @@ rm -f /tmp/chef*rpm
 
 # clean up redhat interface persistence
 rm -f /etc/udev/rules.d/70-persistent-net.rules
-if [ -r /etc/sysconfig/network-scripts/ifcfg-eth0 ]; then
-  sed -i '/^HWADDR/d' /etc/sysconfig/network-scripts/ifcfg-eth0
-  sed -i '/^UUID/d' /etc/sysconfig/network-scripts/ifcfg-eth0
-fi
-if [ -r /etc/sysconfig/network-scripts/ifcfg-ens33 ]; then
-  sed -i '/^HWADDR/d' /etc/sysconfig/network-scripts/ifcfg-ens33
-  sed -i '/^UUID/d' /etc/sysconfig/network-scripts/ifcfg-ens33
-fi
+
+for ndev in $(ls /etc/sysconfig/network-scripts/ifcfg-*); do
+  if [ "$(basename ${ndev})" != "ifcfg-lo" ]; then
+    sed -i '/^HWADDR/d' ${ndev}
+    sed -i '/^UUID/d' ${ndev}
+  fi
+done


### PR DESCRIPTION
Before I had an issue using the box with a static ip for NFS sharing in
vagrant, resulting in

```
ERROR: [/etc/sysconfig/network-scripts/ifdown-eth] Device ens33 has MAC
address 00:0C:29:F8:96:74, instead of configured address
00:0C:29:59:C4:97. Ignoring.
```

While the cleanup script already fixed this for `eth0`, CentOS7 seems to
have changed the device naming, therefor it's also needed for `ens33`.

Instead of removing the text of the entries, I opted for deleting the
whole line as there's no need for empty lines in the ifcfg-file.