### PR TITLE
CentOS kickstarts: Change sed to not rewrite sudo comments

### DIFF
--- a/http/centos-5.11/ks.cfg
+++ b/http/centos-5.11/ks.cfg
@@ -71,4 +71,4 @@ yum
 %post
 # sudo
 echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
-sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+sed -i "s/^[^#].*requiretty/#Defaults requiretty/" /etc/sudoers

--- a/http/centos-6.7/ks.cfg
+++ b/http/centos-6.7/ks.cfg
@@ -66,4 +66,4 @@ nfs-utils
 sed -i -e 's/\(^SELINUX=\).*$/\1permissive/' /etc/selinux/config
 # sudo
 echo "%vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
-sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+sed -i "s/^[^#].*requiretty/#Defaults requiretty/" /etc/sudoers

--- a/http/centos-7.1/ks.cfg
+++ b/http/centos-7.1/ks.cfg
@@ -76,5 +76,5 @@ bzip2
 %post
 # sudo
 echo "%vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
-sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+sed -i "s/^[^#].*requiretty/#Defaults requiretty/" /etc/sudoers
 %end


### PR DESCRIPTION
Cosmetic fix to avoid matching and rewriting the comment:

```
# changed in order to be able to use sudo without a tty. See requiretty above.
```
in the `/etc/sudoers` file.