### PR TITLE
Don't overwrite the vendor cacert.pem.

### DIFF
--- a/packer/http/centos-5.11/ks.cfg
+++ b/packer/http/centos-5.11/ks.cfg
@@ -69,8 +69,6 @@ yum
 -zd1211-firmware
 
 %post
-# update root certs
-wget -O/etc/pki/tls/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem
 # sudo
 echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers

--- a/packer/http/centos-6.6/ks.cfg
+++ b/packer/http/centos-6.6/ks.cfg
@@ -64,8 +64,6 @@ nfs-utils
 %post
 # Force to set SELinux to a permissive mode
 sed -i -e 's/\(^SELINUX=\).*$/\1permissive/' /etc/selinux/config
-# update root certs
-wget -O/etc/pki/tls/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem
 # sudo
 echo "%vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers

--- a/packer/http/centos-7.0/ks.cfg
+++ b/packer/http/centos-7.0/ks.cfg
@@ -74,8 +74,6 @@ bzip2
 %end
 
 %post
-# update root certs
-wget -O/etc/pki/tls/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem
 # sudo
 echo "%vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers

--- a/packer/http/fedora-20/ks.cfg
+++ b/packer/http/fedora-20/ks.cfg
@@ -39,8 +39,6 @@ net-tools
 %end
 
 %post
-# update root certs
-wget -O/etc/pki/tls/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem
 # sudo
 echo 'Defaults:vagrant !requiretty' > /etc/sudoers.d/vagrant
 echo '%vagrant ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/vagrant

--- a/packer/http/fedora-21/ks.cfg
+++ b/packer/http/fedora-21/ks.cfg
@@ -39,8 +39,6 @@ net-tools
 %end
 
 %post
-# update root certs
-wget -O/etc/pki/tls/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem
 # sudo
 echo 'Defaults:vagrant !requiretty' > /etc/sudoers.d/vagrant
 echo '%vagrant ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/vagrant


### PR DESCRIPTION
Fixes #325 
Closes #318 

I tested the box build with CentOS 5 and 6 and it works fine