### PR TITLE
Fixes #325, #318 - don't download cacert.pem

### DIFF
--- a/packer/http/centos-5.11/ks.cfg
+++ b/packer/http/centos-5.11/ks.cfg
@@ -69,8 +69,6 @@ yum
 -zd1211-firmware
 
 %post
-# update root certs
-wget -O/etc/pki/tls/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem
 # sudo
 echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers

--- a/packer/http/centos-6.6/ks.cfg
+++ b/packer/http/centos-6.6/ks.cfg
@@ -64,8 +64,6 @@ nfs-utils
 %post
 # Force to set SELinux to a permissive mode
 sed -i -e 's/\(^SELINUX=\).*$/\1permissive/' /etc/selinux/config
-# update root certs
-wget -O/etc/pki/tls/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem
 # sudo
 echo "%vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers

--- a/packer/http/centos-7.0/ks.cfg
+++ b/packer/http/centos-7.0/ks.cfg
@@ -74,8 +74,6 @@ bzip2
 %end
 
 %post
-# update root certs
-wget -O/etc/pki/tls/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem
 # sudo
 echo "%vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers

--- a/packer/http/fedora-20/ks.cfg
+++ b/packer/http/fedora-20/ks.cfg
@@ -39,8 +39,6 @@ net-tools
 %end
 
 %post
-# update root certs
-wget -O/etc/pki/tls/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem
 # sudo
 echo 'Defaults:vagrant !requiretty' > /etc/sudoers.d/vagrant
 echo '%vagrant ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/vagrant

--- a/packer/http/fedora-21/ks.cfg
+++ b/packer/http/fedora-21/ks.cfg
@@ -39,8 +39,6 @@ net-tools
 %end
 
 %post
-# update root certs
-wget -O/etc/pki/tls/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem
 # sudo
 echo 'Defaults:vagrant !requiretty' > /etc/sudoers.d/vagrant
 echo '%vagrant ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/vagrant

--- a/packer/scripts/fedora/ks.cfg
+++ b/packer/scripts/fedora/ks.cfg
@@ -38,8 +38,6 @@ nfs-utils
 %end
 
 %post
-# update root certs
-wget -O /etc/pki/tls/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem
 # vagrant
 groupadd vagrant
 useradd vagrant -g vagrant -G wheel -u 900


### PR DESCRIPTION
This addresses both concerns of #318 and #325. We were downloading the
SSL CA bundle over http because at the point in time when we wanted to
even do that we might not have been in a state where the SSL
certificates from curl.haxx.se could be verified. Using http is just
as good at that point as using SSL without verification. However...

This addresses the concern raised in #325, whereby the upstream
cacert.pem removed certificates used by services such as AWS S3,
causing SSL connections to those sites to fail to verify. We should
rely on the ca-bundle.crt that comes with the openssl package on the
platforms in question (centos/fedora).