### PR TITLE
Switch to SATA HDD for Linux VMs on virtualbox

### DIFF
--- a/packer/centos-5.11-i386.json
+++ b/packer/centos-5.11-i386.json
@@ -8,6 +8,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "RedHat",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "ec3a89b4edc8e391d13c1ecce4e6ce3917719e39",
       "iso_checksum_type": "sha1",

--- a/packer/centos-5.11-x86_64.json
+++ b/packer/centos-5.11-x86_64.json
@@ -8,6 +8,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "RedHat_64",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "ebd77f2fdfac8da04f31c508905cf52aa62937cc",
       "iso_checksum_type": "sha1",

--- a/packer/centos-6.6-i386.json
+++ b/packer/centos-6.6-i386.json
@@ -8,6 +8,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "RedHat",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "d16aa4a8e6f71fb01fcc26d8ae0e3443ed514c8e",
       "iso_checksum_type": "sha1",

--- a/packer/centos-6.6-x86_64.json
+++ b/packer/centos-6.6-x86_64.json
@@ -8,6 +8,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "RedHat_64",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "08be09fd7276822bd3468af8f96198279ffc41f0",
       "iso_checksum_type": "sha1",

--- a/packer/centos-7.0-x86_64.json
+++ b/packer/centos-7.0-x86_64.json
@@ -8,6 +8,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "RedHat_64",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "ee505335bcd4943ffc7e6e6e55e5aaa8da09710b6ceecda82a5619342f1d24d9",
       "iso_checksum_type": "sha256",

--- a/packer/debian-6.0.10-amd64.json
+++ b/packer/debian-6.0.10-amd64.json
@@ -27,6 +27,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "Debian_64",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "f3e70528664f174a121b26491c59cd66daaf8274",
       "iso_checksum_type": "sha1",

--- a/packer/debian-6.0.10-i386.json
+++ b/packer/debian-6.0.10-i386.json
@@ -27,6 +27,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "Debian",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "e8f77720e30f669e731fe3166ad6c3d2da33d93a",
       "iso_checksum_type": "sha1",

--- a/packer/debian-7.8-amd64.json
+++ b/packer/debian-7.8-amd64.json
@@ -26,6 +26,7 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "Debian_64",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "5f611b40b0803f8be1180da561cfbc159e381599",
       "iso_checksum_type": "sha1",

--- a/packer/debian-7.8-i386.json
+++ b/packer/debian-7.8-i386.json
@@ -26,6 +26,7 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "Debian",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "d87664e590f39aba725ec9705dc58a8c75417fef",
       "iso_checksum_type": "sha1",

--- a/packer/fedora-20-i386.json
+++ b/packer/fedora-20-i386.json
@@ -8,6 +8,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "Fedora",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "284ea30ddd50db1b30cd5cd9fae7495dad8714ef1e4428d69a8c8ce80e03b6a9",
       "iso_checksum_type": "sha256",

--- a/packer/fedora-20-x86_64.json
+++ b/packer/fedora-20-x86_64.json
@@ -8,6 +8,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "Fedora_64",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "f2eeed5102b8890e9e6f4b9053717fe73031e699c4b76dc7028749ab66e7f917",
       "iso_checksum_type": "sha256",

--- a/packer/fedora-21-i386.json
+++ b/packer/fedora-21-i386.json
@@ -8,6 +8,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "Fedora",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "85e50a8a938996522bf1605b3578a2d6680362c1aa963d0560d59c2e4fc795ef",
       "iso_checksum_type": "sha256",

--- a/packer/fedora-21-x86_64.json
+++ b/packer/fedora-21-x86_64.json
@@ -8,6 +8,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "Fedora_64",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "a6a2e83bb409d6b8ee3072ad07faac0a54d79c9ecbe3a40af91b773e2d843d8e",
       "iso_checksum_type": "sha256",

--- a/packer/oracle-5.11-i386.json
+++ b/packer/oracle-5.11-i386.json
@@ -8,6 +8,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "Oracle",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "f4ef2b868a0cccb736664136eca798ec",
       "iso_checksum_type": "md5",

--- a/packer/oracle-5.11-x86_64.json
+++ b/packer/oracle-5.11-x86_64.json
@@ -8,6 +8,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "Oracle_64",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "8af2121088c7e6f5ebdb6d5900403240",
       "iso_checksum_type": "md5",

--- a/packer/oracle-6.6-i386.json
+++ b/packer/oracle-6.6-i386.json
@@ -8,6 +8,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "Oracle",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_url": "{{user `mirror`}}/OracleLinux-R6-U6-Server-i386-dvd.iso",
       "iso_checksum": "81f0c85217f40763dea5053ec5594e4958498bbc",

--- a/packer/oracle-6.6-x86_64.json
+++ b/packer/oracle-6.6-x86_64.json
@@ -8,6 +8,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "Oracle_64",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "5738f10a506d3630edfd297ef179b553091c6a48",
       "iso_checksum_type": "sha1",

--- a/packer/rhel-5.11-i386.json
+++ b/packer/rhel-5.11-i386.json
@@ -8,6 +8,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "RedHat",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "4e38e4ed06d83efb10446e7db19d96761715cdbdbf0bbfacb978b44ce368bbe2",
       "iso_checksum_type": "sha256",

--- a/packer/rhel-5.11-x86_64.json
+++ b/packer/rhel-5.11-x86_64.json
@@ -8,6 +8,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "RedHat_64",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "36565fe0c8a97207d63234d10123daeedb29d509576dbd7b34e71958ac2f9050",
       "iso_checksum_type": "sha256",

--- a/packer/rhel-6.6-i386.json
+++ b/packer/rhel-6.6-i386.json
@@ -8,6 +8,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "RedHat",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "0a14ed1f7d7ea7b831739ed8e71719d9cb7c294bf801e8db39358651768547ad",
       "iso_checksum_type": "sha256",

--- a/packer/rhel-6.6-x86_64.json
+++ b/packer/rhel-6.6-x86_64.json
@@ -8,6 +8,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "RedHat_64",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "16044cb7264f4bc0150f5b6f3f66936ccf2d36e0a4152c00d9236fb7dcae5f32",
       "iso_checksum_type": "sha256",

--- a/packer/rhel-7.0-x86_64.json
+++ b/packer/rhel-7.0-x86_64.json
@@ -8,6 +8,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "RedHat_64",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "85a9fedc2bf0fc825cc7817056aa00b3ea87d7e111e0cf8de77d3ba643f8646c",
       "iso_checksum_type": "sha256",

--- a/packer/sles-11-sp2-i386.json
+++ b/packer/sles-11-sp2-i386.json
@@ -12,6 +12,7 @@
       "disk_size": 20480,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "OpenSUSE",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "a0b34f6237b2b2a6b2174c82b40ed326",
       "iso_checksum_type": "md5",

--- a/packer/sles-11-sp2-x86_64.json
+++ b/packer/sles-11-sp2-x86_64.json
@@ -12,6 +12,7 @@
       "disk_size": 20480,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "OpenSUSE_64",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "461d82ae6e15062b0807c1338f040497",
       "iso_checksum_type": "md5",

--- a/packer/sles-11-sp3-i386.json
+++ b/packer/sles-11-sp3-i386.json
@@ -12,6 +12,7 @@
       "disk_size": 20480,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "OpenSUSE",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "5c30a409fc8fb3343b4dc90d93ff2c89",
       "iso_checksum_type": "md5",

--- a/packer/sles-11-sp3-x86_64.json
+++ b/packer/sles-11-sp3-x86_64.json
@@ -12,6 +12,7 @@
       "disk_size": 20480,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "OpenSUSE_64",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "480b70d50cbb538382dc2b9325221e1b",
       "iso_checksum_type": "md5",

--- a/packer/sles-12-x86_64.json
+++ b/packer/sles-12-x86_64.json
@@ -12,6 +12,7 @@
       "disk_size": 20480,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "OpenSUSE_64",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "58086fca0441b1d44c7a51c5ee64e1bd4365466fcee48ec92c4f39d07739aeed",
       "iso_checksum_type": "sha256",

--- a/packer/ubuntu-10.04-amd64.json
+++ b/packer/ubuntu-10.04-amd64.json
@@ -29,6 +29,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "Ubuntu_64",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "796e80702d65f2ee96e88874a1ab437e24df9cd6",
       "iso_checksum_type": "sha1",

--- a/packer/ubuntu-10.04-i386.json
+++ b/packer/ubuntu-10.04-i386.json
@@ -29,6 +29,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "Ubuntu",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "5695d8b6b914269d1374ac8d4c3dd3786e92d3fe",
       "iso_checksum_type": "sha1",

--- a/packer/ubuntu-12.04-amd64.json
+++ b/packer/ubuntu-12.04-amd64.json
@@ -29,6 +29,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{ .Version }}.iso",
       "guest_os_type": "Ubuntu_64",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "7540ace2d6cdee264432f5ed987236d32edef798",
       "iso_checksum_type": "sha1",

--- a/packer/ubuntu-12.04-i386.json
+++ b/packer/ubuntu-12.04-i386.json
@@ -29,6 +29,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "Ubuntu",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "a34c224b7fe72a2f5c768be5afee5c53817743fd",
       "iso_checksum_type": "sha1",

--- a/packer/ubuntu-14.04-amd64.json
+++ b/packer/ubuntu-14.04-amd64.json
@@ -29,6 +29,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "Ubuntu_64",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "8acd2f56bfcba2f7ac74a7e4a5e565ce68c024c38525c0285573e41c86ae90c0",
       "iso_checksum_type": "sha256",

--- a/packer/ubuntu-14.04-i386.json
+++ b/packer/ubuntu-14.04-i386.json
@@ -29,6 +29,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "Ubuntu",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "76524ab9502a34b983ed56af2d5a72835ce41aec1e2b4c0cb7788ef596958ed6",
       "iso_checksum_type": "sha256",

--- a/packer/ubuntu-14.10-amd64.json
+++ b/packer/ubuntu-14.10-amd64.json
@@ -29,6 +29,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "Ubuntu_64",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "0c1ebea31c3523cfe9a4ffed8bcf6c7d23dfb97b",
       "iso_checksum_type": "sha1",

--- a/packer/ubuntu-14.10-i386.json
+++ b/packer/ubuntu-14.10-i386.json
@@ -29,6 +29,7 @@
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "Ubuntu",
+      "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "26faf47df2162f4ff83e38e6831dd169da6db95f",
       "iso_checksum_type": "sha1",


### PR DESCRIPTION
As described in: https://github.com/chef/bento/issues/324

Switch all of the Linux bento boxes to use SATA HDDs, which will boost disk performance.   This change has already been implemented in boxcutter: https://github.com/boxcutter/ubuntu/commit/352cf873bad33f859f93460e6a73bbda22fc236b