### PR TITLE
Normalize Bento templates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ rvm:
 before_install: wget --no-check-certificate https://dl.bintray.com/mitchellh/packer/packer_0.7.5_linux_amd64.zip && unzip -d packer packer_0.7.5_linux_amd64.zip
 before_script: export PATH=$PATH:$PWD/packer
 
-script: bundle exec thor packer:validate
+script: ./bin/bento normalize
 
 sudo: false

--- a/bin/bento
+++ b/bin/bento
@@ -6,9 +6,10 @@ Signal.trap("INT") { exit 1 }
 $stdout.sync = true
 $stderr.sync = true
 
-require 'optparse'
-require 'ostruct'
-require 'benchmark'
+require "benchmark"
+require "digest"
+require "optparse"
+require "ostruct"
 
 class Options
 
@@ -24,10 +25,10 @@ class Options
       opts.banner = "Usage: #{NAME} [SUBCOMMAND [options]]"
       opts.separator ""
       opts.separator <<-COMMANDS.gsub(/^ {8}/, "")
-        build :   build one or more templates
-        fix   :   fix one or more templates
-        help  :   prints this help message
-        list  :   list all templates in project
+        build     :   build one or more templates
+        help      :   prints this help message
+        list      :   list all templates in project
+        normalize :   normalize one or more templates
       COMMANDS
     end
 
@@ -69,10 +70,10 @@ class Options
         },
         argv: templates_argv_proc
       },
-      fix: {
-        class: FixRunner,
+      normalize: {
+        class: NormalizeRunner,
         parser: OptionParser.new { |opts|
-          opts.banner = "Usage: #{NAME} fix TEMPLATE[ TEMPLATE ...]"
+          opts.banner = "Usage: #{NAME} normalize TEMPLATE[ TEMPLATE ...]"
         },
         argv: templates_argv_proc
       },
@@ -110,6 +111,14 @@ module Common
 
   def banner(msg)
     puts "==> #{msg}"
+  end
+
+  def info(msg)
+    puts "    #{msg}"
+  end
+
+  def warn(msg)
+    puts ">>> #{msg}"
   end
 
   def duration(total)
@@ -165,7 +174,7 @@ class BuildRunner
   end
 end
 
-class FixRunner
+class NormalizeRunner
 
   include Common
 
@@ -173,20 +182,54 @@ class FixRunner
 
   def initialize(opts)
     @templates = opts.templates
+    @modified = []
   end
 
   def start
-    banner("Fixing for templates: #{templates}")
+    banner("Normalizing for templates: #{templates}")
     time = Benchmark.measure do
-      templates.each { |template| fix(template) }
+      templates.each do |template|
+        validate(template)
+        fix(template)
+      end
     end
-    banner("Fixing finished in #{duration(time.real)}.")
+    if !@modified.empty?
+      info("")
+      info("The following templates were modified:")
+      @modified.sort.each { |template| info("  * #{template}")}
+    end
+    banner("Normalizing finished in #{duration(time.real)}.")
   end
 
   def fix(template)
-    output = %x{packer fix #{template}.json}
+    file = "#{template}.json"
+
+    banner("[#{template}] Fixing")
+    original_checksum = checksum(file)
+    output = %x{packer fix #{file}}
     raise "[#{template}] Error fixing, exited #{$?}" if $?.exitstatus != 0
-    File.open("#{template}.json", "wb") { |file| file.write(output) }
+    # preserve ampersands in shell commands,
+    # see: https://github.com/mitchellh/packer/issues/784
+    output.gsub!("\\u0026", "&")
+    File.open(file, "wb") { |dest| dest.write(output) }
+    fixed_checksum = checksum(file)
+
+    if original_checksum == fixed_checksum
+      puts("No changes made.")
+    else
+      warn("Template #{template} has been modified.")
+      @modified << template
+    end
+  end
+
+  def validate(template)
+    cmd = %W[packer validate #{template}.json]
+    banner("[#{template}] Validating")
+    system(*cmd) or raise "[#{template}] Error validating, exited #{$?}"
+  end
+
+  def checksum(file)
+    Digest::MD5.file(file).hexdigest
   end
 end
 

--- a/centos-5.11-i386.json
+++ b/centos-5.11-i386.json
@@ -69,19 +69,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "centos",
       "http_directory": "http",
       "iso_checksum": "ec3a89b4edc8e391d13c1ecce4e6ce3917719e39",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/5.11/isos/i386/CentOS-5.11-i386-bin-DVD-1of2.iso",
       "output_directory": "packer-centos-5.11-i386-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -97,9 +91,14 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-centos-5.11-i386"
     }
-
   ],
   "post-processors": [
     {

--- a/centos-5.11-x86_64.json
+++ b/centos-5.11-x86_64.json
@@ -69,19 +69,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "centos",
       "http_directory": "http",
       "iso_checksum": "ebd77f2fdfac8da04f31c508905cf52aa62937cc",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/5.11/isos/x86_64/CentOS-5.11-x86_64-bin-DVD-1of2.iso",
       "output_directory": "packer-centos-5.11-x86_64-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -97,10 +91,14 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-centos-5.11-x86_64"
     }
-
-
   ],
   "post-processors": [
     {

--- a/centos-6.6-i386.json
+++ b/centos-6.6-i386.json
@@ -69,19 +69,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "centos",
       "http_directory": "http",
       "iso_checksum": "d16aa4a8e6f71fb01fcc26d8ae0e3443ed514c8e",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/6.6/isos/i386/CentOS-6.6-i386-bin-DVD1.iso",
       "output_directory": "packer-centos-6.6-i386-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -97,6 +91,12 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-centos-6.6-i386"
     }
   ],

--- a/centos-6.6-x86_64.json
+++ b/centos-6.6-x86_64.json
@@ -69,19 +69,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "centos",
       "http_directory": "http",
       "iso_checksum": "08be09fd7276822bd3468af8f96198279ffc41f0",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/6.6/isos/x86_64/CentOS-6.6-x86_64-bin-DVD1.iso",
       "output_directory": "packer-centos-6.6-x86_64-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -97,9 +91,14 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-centos-6.6-x86_64"
     }
-
   ],
   "post-processors": [
     {

--- a/centos-7.1-x86_64.json
+++ b/centos-7.1-x86_64.json
@@ -69,19 +69,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "centos",
       "http_directory": "http",
       "iso_checksum": "85bcf62462fb678adc0cec159bf8b39ab5515404bc3828c432f743a1b0b30157",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/7.1.1503/isos/x86_64/CentOS-7-x86_64-DVD-1503-01.iso",
       "output_directory": "packer-centos-7.1-x86_64-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -97,6 +91,12 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-centos-7.1-x86_64"
     }
   ],
@@ -129,3 +129,4 @@
     "mirror": "http://mirrors.kernel.org/centos"
   }
 }
+

--- a/debian-6.0.10-amd64.json
+++ b/debian-6.0.10-amd64.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://cdimage.debian.org/cdimage/archive"
-  },
   "builders": [
     {
-      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -38,15 +33,25 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "384"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
       ],
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "packer-debian-6.0.10-amd64"
     },
     {
-      "type": "vmware-iso",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -78,6 +83,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-debian-6.0.10-amd64",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
@@ -86,7 +92,6 @@
       }
     },
     {
-      "type": "parallels-iso",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -111,32 +116,43 @@
       "iso_checksum": "f3e70528664f174a121b26491c59cd66daaf8274",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/6.0.10/amd64/iso-cd/debian-6.0.10-amd64-CD-1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-debian-6.0.10-amd64-parallels",
+      "parallels_tools_flavor": "lin",
+      "prlctl": [
+        [
+          "set",
+          "{{.Name}}",
+          "--memsize",
+          "384"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
+      ],
+      "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
-      "parallels_tools_flavor": "lin",
-      "prlctl_version_file": ".prlctl_version",
-      "vm_name": "packer-debian-6.0.10-amd64",
-      "output_directory": "packer-debian-6.0.10-amd64-parallels",
-      "prlctl": [
-        [ "set", "{{.Name}}", "--memsize", "384" ],
-        [ "set", "{{.Name}}", "--cpus", "1" ]
-      ]
+      "type": "parallels-iso",
+      "vm_name": "packer-debian-6.0.10-amd64"
     }
-
   ],
   "post-processors": [
     {
-      "type": "vagrant",
-      "output": "builds/{{.Provider}}/opscode_debian-6.0.10_chef-{{user `chef_version`}}.box"
+      "output": "builds/{{.Provider}}/opscode_debian-6.0.10_chef-{{user `chef_version`}}.box",
+      "type": "vagrant"
     }
   ],
   "provisioners": [
     {
-      "type": "shell",
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
         "scripts/debian/update.sh",
@@ -148,7 +164,13 @@
         "scripts/common/chef.sh",
         "scripts/debian/cleanup.sh",
         "scripts/common/minimize.sh"
-      ]
+      ],
+      "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://cdimage.debian.org/cdimage/archive"
+  }
 }
+

--- a/debian-6.0.10-i386.json
+++ b/debian-6.0.10-i386.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://cdimage.debian.org/cdimage/archive"
-  },
   "builders": [
     {
-      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -38,15 +33,25 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "384"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
       ],
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "packer-debian-6.0.10-i386"
     },
     {
-      "type": "vmware-iso",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -78,6 +83,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-debian-6.0.10-i386",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
@@ -86,7 +92,6 @@
       }
     },
     {
-      "type": "parallels-iso",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -111,32 +116,43 @@
       "iso_checksum": "e8f77720e30f669e731fe3166ad6c3d2da33d93a",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/6.0.10/i386/iso-cd/debian-6.0.10-i386-CD-1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-debian-6.0.10-i386-parallels",
+      "parallels_tools_flavor": "lin",
+      "prlctl": [
+        [
+          "set",
+          "{{.Name}}",
+          "--memsize",
+          "384"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
+      ],
+      "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
-      "parallels_tools_flavor": "lin",
-      "prlctl_version_file": ".prlctl_version",
-      "vm_name": "packer-debian-6.0.10-i386",
-      "output_directory": "packer-debian-6.0.10-i386-parallels",
-      "prlctl": [
-        [ "set", "{{.Name}}", "--memsize", "384" ],
-        [ "set", "{{.Name}}", "--cpus", "1" ]
-      ]
+      "type": "parallels-iso",
+      "vm_name": "packer-debian-6.0.10-i386"
     }
-
   ],
   "post-processors": [
     {
-      "type": "vagrant",
-      "output": "builds/{{.Provider}}/opscode_debian-6.0.10-i386_chef-{{user `chef_version`}}.box"
+      "output": "builds/{{.Provider}}/opscode_debian-6.0.10-i386_chef-{{user `chef_version`}}.box",
+      "type": "vagrant"
     }
   ],
   "provisioners": [
     {
-      "type": "shell",
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
         "scripts/debian/update.sh",
@@ -148,7 +164,13 @@
         "scripts/common/chef.sh",
         "scripts/debian/cleanup.sh",
         "scripts/common/minimize.sh"
-      ]
+      ],
+      "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://cdimage.debian.org/cdimage/archive"
+  }
 }
+

--- a/debian-7.8-amd64.json
+++ b/debian-7.8-amd64.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://cdimage.debian.org/cdimage/archive"
-  },
   "builders": [
     {
-      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -25,28 +20,38 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "Debian_64",
       "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "5f611b40b0803f8be1180da561cfbc159e381599",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/7.8.0/amd64/iso-cd/debian-7.8.0-amd64-CD-1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-debian-7.8-amd64-virtualbox",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
-      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
-      "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-debian-7.8-amd64",
-      "output_directory": "packer-debian-7.8-amd64-virtualbox",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
-      ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "384"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-debian-7.8-amd64"
     },
     {
-      "type": "vmware-iso",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -71,22 +76,22 @@
       "iso_checksum": "5f611b40b0803f8be1180da561cfbc159e381599",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/7.8.0/amd64/iso-cd/debian-7.8.0-amd64-CD-1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-debian-7.8-amd64-vmware",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-debian-7.8-amd64",
-      "output_directory": "packer-debian-7.8-amd64-vmware",
       "vmx_data": {
+        "cpuid.coresPerSocket": "1",
         "memsize": "384",
-        "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
+        "numvcpus": "1"
       }
     },
     {
-      "type": "parallels-iso",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -111,29 +116,43 @@
       "iso_checksum": "5f611b40b0803f8be1180da561cfbc159e381599",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/7.8.0/amd64/iso-cd/debian-7.8.0-amd64-CD-1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-debian-7.8-amd64-parallels",
+      "parallels_tools_flavor": "lin",
+      "prlctl": [
+        [
+          "set",
+          "{{.Name}}",
+          "--memsize",
+          "384"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
+      ],
+      "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
-      "parallels_tools_flavor": "lin",
-      "prlctl_version_file": ".prlctl_version",
-      "vm_name": "packer-debian-7.8-amd64",
-      "output_directory": "packer-debian-7.8-amd64-parallels",
-      "prlctl": [
-        [ "set", "{{.Name}}", "--memsize", "384" ],
-        [ "set", "{{.Name}}", "--cpus", "1" ]
-      ]
+      "type": "parallels-iso",
+      "vm_name": "packer-debian-7.8-amd64"
     }
   ],
   "post-processors": [
     {
-      "type": "vagrant",
-      "output": "builds/{{.Provider}}/opscode_debian-7.8_chef-{{user `chef_version`}}.box"
+      "output": "builds/{{.Provider}}/opscode_debian-7.8_chef-{{user `chef_version`}}.box",
+      "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
         "scripts/debian/update.sh",
@@ -146,8 +165,12 @@
         "scripts/debian/cleanup.sh",
         "scripts/common/minimize.sh"
       ],
-      "type": "shell",
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ]
+      "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://cdimage.debian.org/cdimage/archive"
+  }
 }
+

--- a/debian-7.8-i386.json
+++ b/debian-7.8-i386.json
@@ -1,11 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://cdimage.debian.org/cdimage/archive"
-  },
   "builders": [
     {
-      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -25,28 +20,38 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "Debian",
       "hard_drive_interface": "sata",
       "http_directory": "http",
       "iso_checksum": "d87664e590f39aba725ec9705dc58a8c75417fef",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/7.8.0/i386/iso-cd/debian-7.8.0-i386-CD-1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-debian-7.8-i386-virtualbox",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
-      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
-      "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-debian-7.8-i386",
-      "output_directory": "packer-debian-7.8-i386-virtualbox",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
-      ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "384"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-debian-7.8-i386"
     },
     {
-      "type": "vmware-iso",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -71,22 +76,22 @@
       "iso_checksum": "d87664e590f39aba725ec9705dc58a8c75417fef",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/7.8.0/i386/iso-cd/debian-7.8.0-i386-CD-1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-debian-7.8-i386-vmware",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
       "vm_name": "packer-debian-7.8-i386",
-      "output_directory": "packer-debian-7.8-i386-vmware",
       "vmx_data": {
+        "cpuid.coresPerSocket": "1",
         "memsize": "384",
-        "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
+        "numvcpus": "1"
       }
     },
     {
-      "type": "parallels-iso",
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
@@ -111,30 +116,43 @@
       "iso_checksum": "d87664e590f39aba725ec9705dc58a8c75417fef",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/7.8.0/i386/iso-cd/debian-7.8.0-i386-CD-1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-debian-7.8-i386-parallels",
+      "parallels_tools_flavor": "lin",
+      "prlctl": [
+        [
+          "set",
+          "{{.Name}}",
+          "--memsize",
+          "384"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
+      ],
+      "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
-      "parallels_tools_flavor": "lin",
-      "prlctl_version_file": ".prlctl_version",
-      "vm_name": "packer-debian-7.8-i386",
-      "output_directory": "packer-debian-7.8-i386-parallels",
-      "prlctl": [
-        [ "set", "{{.Name}}", "--memsize", "384" ],
-        [ "set", "{{.Name}}", "--cpus", "1" ]
-      ]
+      "type": "parallels-iso",
+      "vm_name": "packer-debian-7.8-i386"
     }
-
   ],
   "post-processors": [
     {
-      "type": "vagrant",
-      "output": "builds/{{.Provider}}/opscode_debian-7.8-i386_chef-{{user `chef_version`}}.box"
+      "output": "builds/{{.Provider}}/opscode_debian-7.8-i386_chef-{{user `chef_version`}}.box",
+      "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
         "scripts/debian/update.sh",
@@ -147,8 +165,12 @@
         "scripts/debian/cleanup.sh",
         "scripts/common/minimize.sh"
       ],
-      "type": "shell",
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ]
+      "type": "shell"
     }
-  ]
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://cdimage.debian.org/cdimage/archive"
+  }
 }
+

--- a/fedora-20-i386.json
+++ b/fedora-20-i386.json
@@ -69,19 +69,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "fedora-core",
       "http_directory": "http",
       "iso_checksum": "284ea30ddd50db1b30cd5cd9fae7495dad8714ef1e4428d69a8c8ce80e03b6a9",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/20/Fedora/i386/iso/Fedora-20-i386-DVD.iso",
       "output_directory": "packer-fedora-20-i386-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -97,9 +91,14 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-fedora-20-i386"
     }
-
   ],
   "post-processors": [
     {

--- a/fedora-20-x86_64.json
+++ b/fedora-20-x86_64.json
@@ -69,19 +69,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "fedora-core",
       "http_directory": "http",
       "iso_checksum": "f2eeed5102b8890e9e6f4b9053717fe73031e699c4b76dc7028749ab66e7f917",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/20/Fedora/x86_64/iso/Fedora-20-x86_64-DVD.iso",
       "output_directory": "packer-fedora-20-x86_64-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -97,6 +91,12 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-fedora-20-x86_64"
     }
   ],

--- a/fedora-21-i386.json
+++ b/fedora-21-i386.json
@@ -69,19 +69,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "fedora-core",
       "http_directory": "http",
       "iso_checksum": "85e50a8a938996522bf1605b3578a2d6680362c1aa963d0560d59c2e4fc795ef",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/21/Server/i386/iso/Fedora-Server-DVD-i386-21.iso",
       "output_directory": "packer-fedora-21-i386-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -97,9 +91,14 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-fedora-21-i386"
     }
-
   ],
   "post-processors": [
     {

--- a/fedora-21-x86_64.json
+++ b/fedora-21-x86_64.json
@@ -69,19 +69,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "fedora-core",
       "http_directory": "http",
       "iso_checksum": "a6a2e83bb409d6b8ee3072ad07faac0a54d79c9ecbe3a40af91b773e2d843d8e",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/21/Server/x86_64/iso/Fedora-Server-DVD-x86_64-21.iso",
       "output_directory": "packer-fedora-21-x86_64-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -97,6 +91,12 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-fedora-21-x86_64"
     }
   ],

--- a/freebsd-10.1-amd64.json
+++ b/freebsd-10.1-amd64.json
@@ -1,25 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://ftp.freebsd.org/pub/FreeBSD"
-  },
-  "provisioners": [
-    {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
-      "type": "shell",
-      "scripts": [
-        "scripts/freebsd/postinstall.sh",
-        "scripts/common/chef.sh",
-        "scripts/freebsd/cleanup.sh",
-        "scripts/freebsd/vmtools.sh",
-        "scripts/freebsd/minimize.sh"
-      ],
-      "execute_command": "export {{.Vars}} && cat {{.Path}} | su -m"
-    }
-  ],
   "builders": [
     {
-      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><wait>",
         "boot -s<wait>",
@@ -33,27 +14,37 @@
       ],
       "boot_wait": "10s",
       "disk_size": 10140,
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "FreeBSD_64",
       "http_directory": "http",
       "iso_checksum": "0c3d64ce48c3ef761761d0fea07e1935e296f8c045c249118bc91a7faf053a6b",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/amd64/amd64/ISO-IMAGES/10.1/FreeBSD-10.1-RELEASE-amd64-disc1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-freebsd-10.1-amd64-virtualbox",
+      "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
-      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
-      "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-freebsd-10.1-amd64",
-      "output_directory": "packer-freebsd-10.1-amd64-virtualbox",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "512" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
-      ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "512"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-freebsd-10.1-amd64"
     },
     {
-      "type": "vmware-iso",
       "boot_command": [
         "<esc><wait>",
         "boot -s<wait>",
@@ -73,22 +64,22 @@
       "iso_checksum": "0c3d64ce48c3ef761761d0fea07e1935e296f8c045c249118bc91a7faf053a6b",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/amd64/amd64/ISO-IMAGES/10.1/FreeBSD-10.1-RELEASE-amd64-disc1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-freebsd-10.1-amd64-vmware",
+      "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
-      "vm_name": "packer-freebsd-10.1-amd64",
-      "output_directory": "packer-freebsd-10.1-amd64-vmware",
       "tools_upload_flavor": "freebsd",
+      "type": "vmware-iso",
+      "vm_name": "packer-freebsd-10.1-amd64",
       "vmx_data": {
+        "cpuid.coresPerSocket": "1",
         "memsize": "512",
-        "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
+        "numvcpus": "1"
       }
     },
     {
-      "type": "parallels-iso",
       "boot_command": [
         "<esc><wait>",
         "boot -s<wait>",
@@ -107,22 +98,50 @@
       "iso_checksum": "0c3d64ce48c3ef761761d0fea07e1935e296f8c045c249118bc91a7faf053a6b",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/amd64/amd64/ISO-IMAGES/10.1/FreeBSD-10.1-RELEASE-amd64-disc1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-freebsd-10.1-amd64-parallels",
+      "parallels_tools_mode": "disable",
+      "prlctl": [
+        [
+          "set",
+          "{{.Name}}",
+          "--memsize",
+          "512"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--device-set",
+          "cdrom0",
+          "--iface",
+          "ide"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--device-del",
+          "fdd0"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--device-del",
+          "parallel0"
+        ]
+      ],
+      "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
-      "parallels_tools_mode": "disable",
-      "prlctl_version_file": ".prlctl_version",
-      "vm_name": "packer-freebsd-10.1-amd64",
-      "output_directory": "packer-freebsd-10.1-amd64-parallels",
-      "prlctl": [
-        [ "set", "{{.Name}}", "--memsize", "512" ],
-        [ "set", "{{.Name}}", "--cpus", "1" ],
-        [ "set", "{{.Name}}", "--device-set", "cdrom0", "--iface", "ide" ],
-        [ "set", "{{.Name}}", "--device-del", "fdd0" ],
-        [ "set", "{{.Name}}", "--device-del", "parallel0" ]
-      ]
+      "type": "parallels-iso",
+      "vm_name": "packer-freebsd-10.1-amd64"
     }
   ],
   "post-processors": [
@@ -135,5 +154,26 @@
       },
       "type": "vagrant"
     }
-  ]
+  ],
+  "provisioners": [
+    {
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
+      "execute_command": "export {{.Vars}} && cat {{.Path}} | su -m",
+      "scripts": [
+        "scripts/freebsd/postinstall.sh",
+        "scripts/common/chef.sh",
+        "scripts/freebsd/cleanup.sh",
+        "scripts/freebsd/vmtools.sh",
+        "scripts/freebsd/minimize.sh"
+      ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://ftp.freebsd.org/pub/FreeBSD"
+  }
 }
+

--- a/freebsd-10.1-i386.json
+++ b/freebsd-10.1-i386.json
@@ -1,25 +1,6 @@
 {
-  "variables": {
-    "chef_version": "provisionerless",
-    "mirror": "http://ftp.freebsd.org/pub/FreeBSD"
-  },
-  "provisioners": [
-    {
-      "environment_vars": [ "CHEF_VERSION={{user `chef_version`}}" ],
-      "type": "shell",
-      "scripts": [
-        "scripts/freebsd/postinstall.sh",
-        "scripts/common/chef.sh",
-        "scripts/freebsd/cleanup.sh",
-        "scripts/freebsd/vmtools.sh",
-        "scripts/freebsd/minimize.sh"
-      ],
-      "execute_command": "export {{.Vars}} && cat {{.Path}} | su -m"
-    }
-  ],
   "builders": [
     {
-      "type": "virtualbox-iso",
       "boot_command": [
         "<esc><wait>",
         "boot -s<wait>",
@@ -33,27 +14,37 @@
       ],
       "boot_wait": "10s",
       "disk_size": 10140,
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "FreeBSD",
       "http_directory": "http",
       "iso_checksum": "fe31790b762b01c99791d33e7fd9ab97323654785ce21f588116c8b4eb381cd0",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/i386/i386/ISO-IMAGES/10.1/FreeBSD-10.1-RELEASE-i386-disc1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-freebsd-10.1-i386-virtualbox",
+      "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
-      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
-      "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-freebsd-10.1-i386",
-      "output_directory": "packer-freebsd-10.1-i386-virtualbox",
+      "type": "virtualbox-iso",
       "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "512" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
-      ]
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "512"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-freebsd-10.1-i386"
     },
     {
-      "type": "vmware-iso",
       "boot_command": [
         "<esc><wait>",
         "boot -s<wait>",
@@ -73,22 +64,22 @@
       "iso_checksum": "fe31790b762b01c99791d33e7fd9ab97323654785ce21f588116c8b4eb381cd0",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/i386/i386/ISO-IMAGES/10.1/FreeBSD-10.1-RELEASE-i386-disc1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-freebsd-10.1-i386-vmware",
+      "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
-      "vm_name": "packer-freebsd-10.1-i386",
-      "output_directory": "packer-freebsd-10.1-i386-vmware",
       "tools_upload_flavor": "freebsd",
+      "type": "vmware-iso",
+      "vm_name": "packer-freebsd-10.1-i386",
       "vmx_data": {
+        "cpuid.coresPerSocket": "1",
         "memsize": "512",
-        "numvcpus": "1",
-        "cpuid.coresPerSocket": "1"
+        "numvcpus": "1"
       }
     },
     {
-      "type": "parallels-iso",
       "boot_command": [
         "<esc><wait>",
         "boot -s<wait>",
@@ -107,22 +98,50 @@
       "iso_checksum": "fe31790b762b01c99791d33e7fd9ab97323654785ce21f588116c8b4eb381cd0",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/i386/i386/ISO-IMAGES/10.1/FreeBSD-10.1-RELEASE-i386-disc1.iso",
-      "ssh_username": "vagrant",
+      "output_directory": "packer-freebsd-10.1-i386-parallels",
+      "parallels_tools_mode": "disable",
+      "prlctl": [
+        [
+          "set",
+          "{{.Name}}",
+          "--memsize",
+          "512"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--device-set",
+          "cdrom0",
+          "--iface",
+          "ide"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--device-del",
+          "fdd0"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--device-del",
+          "parallel0"
+        ]
+      ],
+      "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
       "ssh_password": "vagrant",
       "ssh_port": 22,
+      "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
-      "parallels_tools_mode": "disable",
-      "prlctl_version_file": ".prlctl_version",
-      "vm_name": "packer-freebsd-10.1-amd64",
-      "output_directory": "packer-freebsd-10.1-i386-parallels",
-      "prlctl": [
-        [ "set", "{{.Name}}", "--memsize", "512" ],
-        [ "set", "{{.Name}}", "--cpus", "1" ],
-        [ "set", "{{.Name}}", "--device-set", "cdrom0", "--iface", "ide" ],
-        [ "set", "{{.Name}}", "--device-del", "fdd0" ],
-        [ "set", "{{.Name}}", "--device-del", "parallel0" ]
-      ]
+      "type": "parallels-iso",
+      "vm_name": "packer-freebsd-10.1-amd64"
     }
   ],
   "post-processors": [
@@ -135,5 +154,26 @@
       },
       "type": "vagrant"
     }
-  ]
+  ],
+  "provisioners": [
+    {
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
+      "execute_command": "export {{.Vars}} && cat {{.Path}} | su -m",
+      "scripts": [
+        "scripts/freebsd/postinstall.sh",
+        "scripts/common/chef.sh",
+        "scripts/freebsd/cleanup.sh",
+        "scripts/freebsd/vmtools.sh",
+        "scripts/freebsd/minimize.sh"
+      ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "chef_version": "provisionerless",
+    "mirror": "http://ftp.freebsd.org/pub/FreeBSD"
+  }
 }
+

--- a/freebsd-9.3-amd64.json
+++ b/freebsd-9.3-amd64.json
@@ -111,16 +111,43 @@
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/amd64/amd64/ISO-IMAGES/9.3/FreeBSD-9.3-RELEASE-amd64-disc1.iso",
       "output_directory": "packer-freebsd-9.3-amd64-parallels",
-      "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
       "parallels_tools_mode": "disable",
       "prlctl": [
-        [ "set", "{{.Name}}", "--memsize", "512" ],
-        [ "set", "{{.Name}}", "--cpus", "1" ],
-        [ "set", "{{.Name}}", "--device-set", "cdrom0", "--iface", "ide" ],
-        [ "set", "{{.Name}}", "--device-del", "fdd0" ],
-        [ "set", "{{.Name}}", "--device-del", "parallel0" ]
+        [
+          "set",
+          "{{.Name}}",
+          "--memsize",
+          "512"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--device-set",
+          "cdrom0",
+          "--iface",
+          "ide"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--device-del",
+          "fdd0"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--device-del",
+          "parallel0"
+        ]
       ],
-      "prlctl_version_file": ".prlctl_version",      
+      "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",

--- a/freebsd-9.3-i386.json
+++ b/freebsd-9.3-i386.json
@@ -110,15 +110,42 @@
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/i386/i386/ISO-IMAGES/9.3/FreeBSD-9.3-RELEASE-i386-disc1.iso",
       "output_directory": "packer-freebsd-9.3-i386-parallels",
+      "parallels_tools_mode": "disable",
       "prlctl": [
-        [ "set", "{{.Name}}", "--memsize", "512" ],
-        [ "set", "{{.Name}}", "--cpus", "1" ],
-        [ "set", "{{.Name}}", "--device-set", "cdrom0", "--iface", "ide" ],
-        [ "set", "{{.Name}}", "--device-del", "fdd0" ],
-        [ "set", "{{.Name}}", "--device-del", "parallel0" ]
+        [
+          "set",
+          "{{.Name}}",
+          "--memsize",
+          "512"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--device-set",
+          "cdrom0",
+          "--iface",
+          "ide"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--device-del",
+          "fdd0"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--device-del",
+          "parallel0"
+        ]
       ],
       "prlctl_version_file": ".prlctl_version",
-      "parallels_tools_mode": "disable",
       "shutdown_command": "echo 'shutdown -p now' > shutdown.sh; cat 'shutdown.sh' | su -",
       "ssh_password": "vagrant",
       "ssh_port": 22,

--- a/macosx-10.7.json
+++ b/macosx-10.7.json
@@ -1,39 +1,4 @@
 {
-  "min_packer_version": "0.6.0",
-  "variables": {
-    "autologin_vagrant_user": "",
-    "iso_url": "http://fakeurl/OSX_InstallESD_10.7.5_11G63.dmg",
-    "iso_checksum": "e2a48af008ff3c4db6a8235151a1e90ea600fceb",
-    "chef_version": "provisionerless"
-  },
-  "provisioners": [
-    {
-      "type": "file",
-      "destination": "/private/tmp/kcpassword",
-      "source": "scripts/macosx/support/kcpassword"
-    },
-    {
-      "type": "shell",
-      "scripts": [
-        "scripts/macosx/hostname.sh",
-        "scripts/macosx/builder.sh",
-        "scripts/macosx/update.sh",
-        "scripts/macosx/vagrant.sh",
-        "scripts/macosx/cleanup.sh"
-      ],
-      "execute_command": "echo 'vagrant'| {{.Vars}} sudo -E -S sh '{{.Path}}'"
-    },
-    {
-      "type": "shell",
-      "inline": [
-        "[ -z \"{{user `autologin_vagrant_user`}}\" ] && exit",
-        "echo \"Enabling automatic GUI login for the 'vagrant' user..\"",
-        "cp /private/tmp/kcpassword /private/etc/kcpassword",
-        "/usr/bin/defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser vagrant"
-      ],
-      "execute_command": "echo 'vagrant'| {{.Vars}} sudo -E -S sh '{{.Path}}'"
-    }
-  ],
   "builders": [
     {
       "boot_wait": "2s",
@@ -55,14 +20,14 @@
       "vm_name": "packer-macosx-10.7-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
-        "memsize": "2048",
-        "numvcpus": "1",
+        "ehci.present": "TRUE",
         "firmware": "efi",
-        "keyboardAndMouseProfile": "macProfile",
-        "smc.present": "TRUE",
         "hpet0.present": "TRUE",
         "ich7m.present": "TRUE",
-        "ehci.present": "TRUE",
+        "keyboardAndMouseProfile": "macProfile",
+        "memsize": "2048",
+        "numvcpus": "1",
+        "smc.present": "TRUE",
         "usb.present": "TRUE"
       }
     },
@@ -82,49 +47,152 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vm_name": "packer-macosx-10.7-virtualbox",
       "vboxmanage": [
-        ["modifyvm", "{{.Name}}", "--audiocontroller", "hda"],
-        ["modifyvm", "{{.Name}}", "--boot1", "dvd"],
-        ["modifyvm", "{{.Name}}", "--boot2", "disk"],
-        ["modifyvm", "{{.Name}}", "--chipset", "ich9"],
-        ["modifyvm", "{{.Name}}", "--cpus", "1"],
-        ["modifyvm", "{{.Name}}", "--firmware", "efi"],
-        ["modifyvm", "{{.Name}}", "--hpet", "on"],
-        ["modifyvm", "{{.Name}}", "--keyboard", "usb"],
-        ["modifyvm", "{{.Name}}", "--memory", "2048"],
-        ["modifyvm", "{{.Name}}", "--mouse", "usbtablet"],
-        ["modifyvm", "{{.Name}}", "--vram", "9"],
         [
-          "storageattach", "{{.Name}}",
-          "--storagectl", "SATA Controller",
-          "--port", "1",
-          "--type", "dvddrive",
-          "--medium", "{{user `iso_url`}}"
+          "modifyvm",
+          "{{.Name}}",
+          "--audiocontroller",
+          "hda"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--boot1",
+          "dvd"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--boot2",
+          "disk"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--chipset",
+          "ich9"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--firmware",
+          "efi"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--hpet",
+          "on"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--keyboard",
+          "usb"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "2048"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--mouse",
+          "usbtablet"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--vram",
+          "9"
+        ],
+        [
+          "storageattach",
+          "{{.Name}}",
+          "--storagectl",
+          "SATA Controller",
+          "--port",
+          "1",
+          "--type",
+          "dvddrive",
+          "--medium",
+          "{{user `iso_url`}}"
         ]
       ],
       "vboxmanage_post": [
         [
-          "storageattach", "{{.Name}}",
-          "--storagectl", "SATA Controller",
-          "--port", "1",
-          "--type", "dvddrive",
-          "--medium", "none"
+          "storageattach",
+          "{{.Name}}",
+          "--storagectl",
+          "SATA Controller",
+          "--port",
+          "1",
+          "--type",
+          "dvddrive",
+          "--medium",
+          "none"
         ],
         [
-          "storagectl", "{{.Name}}",
-          "--name", "IDE Controller",
+          "storagectl",
+          "{{.Name}}",
+          "--name",
+          "IDE Controller",
           "--remove"
         ]
       ],
-      "virtualbox_version_file": ".vbox_version"
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-macosx-10.7-virtualbox"
     }
   ],
+  "min_packer_version": "0.6.0",
   "post-processors": [
     {
+      "output": "builds/{{.Provider}}/opscode_macosx-10.7_chef-{{user `chef_version`}}.box",
       "type": "vagrant",
-      "vagrantfile_template": "vagrantfile_templates/macosx.rb",
-      "output": "builds/{{.Provider}}/opscode_macosx-10.7_chef-{{user `chef_version`}}.box"
+      "vagrantfile_template": "vagrantfile_templates/macosx.rb"
     }
-  ]
+  ],
+  "provisioners": [
+    {
+      "destination": "/private/tmp/kcpassword",
+      "source": "scripts/macosx/support/kcpassword",
+      "type": "file"
+    },
+    {
+      "execute_command": "echo 'vagrant'| {{.Vars}} sudo -E -S sh '{{.Path}}'",
+      "scripts": [
+        "scripts/macosx/hostname.sh",
+        "scripts/macosx/builder.sh",
+        "scripts/macosx/update.sh",
+        "scripts/macosx/vagrant.sh",
+        "scripts/macosx/cleanup.sh"
+      ],
+      "type": "shell"
+    },
+    {
+      "execute_command": "echo 'vagrant'| {{.Vars}} sudo -E -S sh '{{.Path}}'",
+      "inline": [
+        "[ -z \"{{user `autologin_vagrant_user`}}\" ] && exit",
+        "echo \"Enabling automatic GUI login for the 'vagrant' user..\"",
+        "cp /private/tmp/kcpassword /private/etc/kcpassword",
+        "/usr/bin/defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser vagrant"
+      ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "autologin_vagrant_user": "",
+    "chef_version": "provisionerless",
+    "iso_checksum": "e2a48af008ff3c4db6a8235151a1e90ea600fceb",
+    "iso_url": "http://fakeurl/OSX_InstallESD_10.7.5_11G63.dmg"
+  }
 }
+

--- a/macosx-10.8.json
+++ b/macosx-10.8.json
@@ -1,39 +1,4 @@
 {
-  "min_packer_version": "0.6.0",
-  "variables": {
-    "autologin_vagrant_user": "",
-    "iso_url": "http://fakeurl/OSX_InstallESD_10.8.5_12F45.dmg",
-    "iso_checksum": "e2a48af008ff3c4db6a8235151a1e90ea600fceb",
-    "chef_version": "provisionerless"
-  },
-  "provisioners": [
-    {
-      "type": "file",
-      "destination": "/private/tmp/kcpassword",
-      "source": "scripts/macosx/support/kcpassword"
-    },
-    {
-      "type": "shell",
-      "scripts": [
-        "scripts/macosx/hostname.sh",
-        "scripts/macosx/builder.sh",
-        "scripts/macosx/update.sh",
-        "scripts/macosx/vagrant.sh",
-        "scripts/macosx/cleanup.sh"
-      ],
-      "execute_command": "echo 'vagrant'| {{.Vars}} sudo -E -S sh '{{.Path}}'"
-    },
-    {
-      "type": "shell",
-      "inline": [
-        "[ -z \"{{user `autologin_vagrant_user`}}\" ] && exit",
-        "echo \"Enabling automatic GUI login for the 'vagrant' user..\"",
-        "cp /private/tmp/kcpassword /private/etc/kcpassword",
-        "/usr/bin/defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser vagrant"
-      ],
-      "execute_command": "echo 'vagrant'| {{.Vars}} sudo -E -S sh '{{.Path}}'"
-    }
-  ],
   "builders": [
     {
       "boot_wait": "2s",
@@ -55,14 +20,14 @@
       "vm_name": "packer-macosx-10.8-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
-        "memsize": "2048",
-        "numvcpus": "1",
+        "ehci.present": "TRUE",
         "firmware": "efi",
-        "keyboardAndMouseProfile": "macProfile",
-        "smc.present": "TRUE",
         "hpet0.present": "TRUE",
         "ich7m.present": "TRUE",
-        "ehci.present": "TRUE",
+        "keyboardAndMouseProfile": "macProfile",
+        "memsize": "2048",
+        "numvcpus": "1",
+        "smc.present": "TRUE",
         "usb.present": "TRUE"
       }
     },
@@ -82,49 +47,152 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vm_name": "packer-macosx-10.8-virtualbox",
       "vboxmanage": [
-        ["modifyvm", "{{.Name}}", "--audiocontroller", "hda"],
-        ["modifyvm", "{{.Name}}", "--boot1", "dvd"],
-        ["modifyvm", "{{.Name}}", "--boot2", "disk"],
-        ["modifyvm", "{{.Name}}", "--chipset", "ich9"],
-        ["modifyvm", "{{.Name}}", "--cpus", "1"],
-        ["modifyvm", "{{.Name}}", "--firmware", "efi"],
-        ["modifyvm", "{{.Name}}", "--hpet", "on"],
-        ["modifyvm", "{{.Name}}", "--keyboard", "usb"],
-        ["modifyvm", "{{.Name}}", "--memory", "2048"],
-        ["modifyvm", "{{.Name}}", "--mouse", "usbtablet"],
-        ["modifyvm", "{{.Name}}", "--vram", "9"],
         [
-          "storageattach", "{{.Name}}",
-          "--storagectl", "SATA Controller",
-          "--port", "1",
-          "--type", "dvddrive",
-          "--medium", "{{user `iso_url`}}"
+          "modifyvm",
+          "{{.Name}}",
+          "--audiocontroller",
+          "hda"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--boot1",
+          "dvd"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--boot2",
+          "disk"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--chipset",
+          "ich9"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--firmware",
+          "efi"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--hpet",
+          "on"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--keyboard",
+          "usb"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "2048"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--mouse",
+          "usbtablet"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--vram",
+          "9"
+        ],
+        [
+          "storageattach",
+          "{{.Name}}",
+          "--storagectl",
+          "SATA Controller",
+          "--port",
+          "1",
+          "--type",
+          "dvddrive",
+          "--medium",
+          "{{user `iso_url`}}"
         ]
       ],
       "vboxmanage_post": [
         [
-          "storageattach", "{{.Name}}",
-          "--storagectl", "SATA Controller",
-          "--port", "1",
-          "--type", "dvddrive",
-          "--medium", "none"
+          "storageattach",
+          "{{.Name}}",
+          "--storagectl",
+          "SATA Controller",
+          "--port",
+          "1",
+          "--type",
+          "dvddrive",
+          "--medium",
+          "none"
         ],
         [
-          "storagectl", "{{.Name}}",
-          "--name", "IDE Controller",
+          "storagectl",
+          "{{.Name}}",
+          "--name",
+          "IDE Controller",
           "--remove"
         ]
       ],
-      "virtualbox_version_file": ".vbox_version"
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-macosx-10.8-virtualbox"
     }
   ],
+  "min_packer_version": "0.6.0",
   "post-processors": [
     {
+      "output": "builds/{{.Provider}}/opscode_macosx-10.8_chef-{{user `chef_version`}}.box",
       "type": "vagrant",
-      "vagrantfile_template": "vagrantfile_templates/macosx.rb",
-      "output": "builds/{{.Provider}}/opscode_macosx-10.8_chef-{{user `chef_version`}}.box"
+      "vagrantfile_template": "vagrantfile_templates/macosx.rb"
     }
-  ]
+  ],
+  "provisioners": [
+    {
+      "destination": "/private/tmp/kcpassword",
+      "source": "scripts/macosx/support/kcpassword",
+      "type": "file"
+    },
+    {
+      "execute_command": "echo 'vagrant'| {{.Vars}} sudo -E -S sh '{{.Path}}'",
+      "scripts": [
+        "scripts/macosx/hostname.sh",
+        "scripts/macosx/builder.sh",
+        "scripts/macosx/update.sh",
+        "scripts/macosx/vagrant.sh",
+        "scripts/macosx/cleanup.sh"
+      ],
+      "type": "shell"
+    },
+    {
+      "execute_command": "echo 'vagrant'| {{.Vars}} sudo -E -S sh '{{.Path}}'",
+      "inline": [
+        "[ -z \"{{user `autologin_vagrant_user`}}\" ] && exit",
+        "echo \"Enabling automatic GUI login for the 'vagrant' user..\"",
+        "cp /private/tmp/kcpassword /private/etc/kcpassword",
+        "/usr/bin/defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser vagrant"
+      ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "autologin_vagrant_user": "",
+    "chef_version": "provisionerless",
+    "iso_checksum": "e2a48af008ff3c4db6a8235151a1e90ea600fceb",
+    "iso_url": "http://fakeurl/OSX_InstallESD_10.8.5_12F45.dmg"
+  }
 }
+

--- a/macosx-10.9.json
+++ b/macosx-10.9.json
@@ -1,39 +1,4 @@
 {
-  "min_packer_version": "0.6.0",
-  "variables": {
-    "autologin_vagrant_user": "",
-    "iso_url": "http://fakeurl/OSX_InstallESD_10.9.1_13B42.dmg",
-    "iso_checksum": "e2a48af008ff3c4db6a8235151a1e90ea600fceb",
-    "chef_version": "provisionerless"
-  },
-  "provisioners": [
-    {
-      "type": "file",
-      "destination": "/private/tmp/kcpassword",
-      "source": "scripts/macosx/support/kcpassword"
-    },
-    {
-      "type": "shell",
-      "scripts": [
-        "scripts/macosx/hostname.sh",
-        "scripts/macosx/builder.sh",
-        "scripts/macosx/update.sh",
-        "scripts/macosx/vagrant.sh",
-        "scripts/macosx/cleanup.sh"
-      ],
-      "execute_command": "echo 'vagrant'| {{.Vars}} sudo -E -S sh '{{.Path}}'"
-    },
-    {
-      "type": "shell",
-      "inline": [
-        "[ -z \"{{user `autologin_vagrant_user`}}\" ] && exit",
-        "echo \"Enabling automatic GUI login for the 'vagrant' user..\"",
-        "cp /private/tmp/kcpassword /private/etc/kcpassword",
-        "/usr/bin/defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser vagrant"
-      ],
-      "execute_command": "echo 'vagrant'| {{.Vars}} sudo -E -S sh '{{.Path}}'"
-    }
-  ],
   "builders": [
     {
       "boot_wait": "2s",
@@ -55,14 +20,14 @@
       "vm_name": "packer-macosx-10.9-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
-        "memsize": "2048",
-        "numvcpus": "1",
+        "ehci.present": "TRUE",
         "firmware": "efi",
-        "keyboardAndMouseProfile": "macProfile",
-        "smc.present": "TRUE",
         "hpet0.present": "TRUE",
         "ich7m.present": "TRUE",
-        "ehci.present": "TRUE",
+        "keyboardAndMouseProfile": "macProfile",
+        "memsize": "2048",
+        "numvcpus": "1",
+        "smc.present": "TRUE",
         "usb.present": "TRUE"
       }
     },
@@ -82,49 +47,152 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vm_name": "packer-macosx-10.9-virtualbox",
       "vboxmanage": [
-        ["modifyvm", "{{.Name}}", "--audiocontroller", "hda"],
-        ["modifyvm", "{{.Name}}", "--boot1", "dvd"],
-        ["modifyvm", "{{.Name}}", "--boot2", "disk"],
-        ["modifyvm", "{{.Name}}", "--chipset", "ich9"],
-        ["modifyvm", "{{.Name}}", "--cpus", "1"],
-        ["modifyvm", "{{.Name}}", "--firmware", "efi"],
-        ["modifyvm", "{{.Name}}", "--hpet", "on"],
-        ["modifyvm", "{{.Name}}", "--keyboard", "usb"],
-        ["modifyvm", "{{.Name}}", "--memory", "2048"],
-        ["modifyvm", "{{.Name}}", "--mouse", "usbtablet"],
-        ["modifyvm", "{{.Name}}", "--vram", "9"],
         [
-          "storageattach", "{{.Name}}",
-          "--storagectl", "SATA Controller",
-          "--port", "1",
-          "--type", "dvddrive",
-          "--medium", "{{user `iso_url`}}"
+          "modifyvm",
+          "{{.Name}}",
+          "--audiocontroller",
+          "hda"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--boot1",
+          "dvd"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--boot2",
+          "disk"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--chipset",
+          "ich9"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--firmware",
+          "efi"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--hpet",
+          "on"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--keyboard",
+          "usb"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "2048"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--mouse",
+          "usbtablet"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--vram",
+          "9"
+        ],
+        [
+          "storageattach",
+          "{{.Name}}",
+          "--storagectl",
+          "SATA Controller",
+          "--port",
+          "1",
+          "--type",
+          "dvddrive",
+          "--medium",
+          "{{user `iso_url`}}"
         ]
       ],
       "vboxmanage_post": [
         [
-          "storageattach", "{{.Name}}",
-          "--storagectl", "SATA Controller",
-          "--port", "1",
-          "--type", "dvddrive",
-          "--medium", "none"
+          "storageattach",
+          "{{.Name}}",
+          "--storagectl",
+          "SATA Controller",
+          "--port",
+          "1",
+          "--type",
+          "dvddrive",
+          "--medium",
+          "none"
         ],
         [
-          "storagectl", "{{.Name}}",
-          "--name", "IDE Controller",
+          "storagectl",
+          "{{.Name}}",
+          "--name",
+          "IDE Controller",
           "--remove"
         ]
       ],
-      "virtualbox_version_file": ".vbox_version"
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-macosx-10.9-virtualbox"
     }
   ],
+  "min_packer_version": "0.6.0",
   "post-processors": [
     {
+      "output": "builds/{{.Provider}}/opscode_macosx-10.9_chef-{{user `chef_version`}}.box",
       "type": "vagrant",
-      "vagrantfile_template": "vagrantfile_templates/macosx.rb",
-      "output": "builds/{{.Provider}}/opscode_macosx-10.9_chef-{{user `chef_version`}}.box"
+      "vagrantfile_template": "vagrantfile_templates/macosx.rb"
     }
-  ]
+  ],
+  "provisioners": [
+    {
+      "destination": "/private/tmp/kcpassword",
+      "source": "scripts/macosx/support/kcpassword",
+      "type": "file"
+    },
+    {
+      "execute_command": "echo 'vagrant'| {{.Vars}} sudo -E -S sh '{{.Path}}'",
+      "scripts": [
+        "scripts/macosx/hostname.sh",
+        "scripts/macosx/builder.sh",
+        "scripts/macosx/update.sh",
+        "scripts/macosx/vagrant.sh",
+        "scripts/macosx/cleanup.sh"
+      ],
+      "type": "shell"
+    },
+    {
+      "execute_command": "echo 'vagrant'| {{.Vars}} sudo -E -S sh '{{.Path}}'",
+      "inline": [
+        "[ -z \"{{user `autologin_vagrant_user`}}\" ] && exit",
+        "echo \"Enabling automatic GUI login for the 'vagrant' user..\"",
+        "cp /private/tmp/kcpassword /private/etc/kcpassword",
+        "/usr/bin/defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser vagrant"
+      ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "autologin_vagrant_user": "",
+    "chef_version": "provisionerless",
+    "iso_checksum": "e2a48af008ff3c4db6a8235151a1e90ea600fceb",
+    "iso_url": "http://fakeurl/OSX_InstallESD_10.9.1_13B42.dmg"
+  }
 }
+

--- a/omnios-r151010j.json
+++ b/omnios-r151010j.json
@@ -148,23 +148,33 @@
       ],
       "boot_wait": "30s",
       "disk_size": 40960,
-      "hard_drive_interface": "ide",
       "guest_os_type": "opensolaris",
+      "hard_drive_interface": "ide",
       "iso_checksum": "bc3f4c0d29a5da75174de62da00294e5ef826b5e",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/OmniOS_Text_r151010j.iso",
       "output_directory": "packer-omnios-r151010j-parallels",
+      "parallels_tools_mode": "disable",
+      "prlctl": [
+        [
+          "set",
+          "{{.Name}}",
+          "--memsize",
+          "512"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
+      ],
       "shutdown_command": "/usr/sbin/shutdown -g 0 -y -i 5",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "root",
-      "parallels_tools_mode": "disable",
       "type": "parallels-iso",
-      "vm_name": "packer-omnios-r151010j",
-      "prlctl": [
-        [ "set", "{{.Name}}", "--memsize", "512" ],
-        [ "set", "{{.Name}}", "--cpus", "1" ]
-      ]
+      "vm_name": "packer-omnios-r151010j"
     }
   ],
   "post-processors": [
@@ -184,7 +194,7 @@
       "environment_vars": [
         "CHEF_VERSION={{user `chef_version`}}"
       ],
-      "execute_command": "export {{.Vars}} \u0026\u0026 sh '{{.Path}}'",
+      "execute_command": "export {{.Vars}} && sh '{{.Path}}'",
       "scripts": [
         "scripts/omnios/vmtools.sh",
         "scripts/common/chef.sh",
@@ -198,3 +208,4 @@
     "mirror": "http://omnios.omniti.com/media"
   }
 }
+

--- a/opensuse-13.2-i386.json
+++ b/opensuse-13.2-i386.json
@@ -86,12 +86,6 @@
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/13.2/iso/openSUSE-13.2-DVD-i586.iso",
       "output_directory": "packer-opensuse-13.2-i386-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
       "parallels_tools_flavor": "lin",
       "prlctl": [
         [
@@ -108,6 +102,12 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-opensuse-13.2-i386"
     }
   ],
@@ -142,3 +142,4 @@
     "mirror": "http://download.opensuse.org/distribution"
   }
 }
+

--- a/opensuse-13.2-x86_64.json
+++ b/opensuse-13.2-x86_64.json
@@ -86,12 +86,6 @@
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/13.2/iso/openSUSE-13.2-DVD-x86_64.iso",
       "output_directory": "packer-opensuse-13.2-x86_64-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
       "parallels_tools_flavor": "lin",
       "prlctl": [
         [
@@ -108,6 +102,12 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-opensuse-13.2-x86_64"
     }
   ],

--- a/oracle-5.11-i386.json
+++ b/oracle-5.11-i386.json
@@ -69,19 +69,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "centos",
       "http_directory": "http",
       "iso_checksum": "f4ef2b868a0cccb736664136eca798ec",
       "iso_checksum_type": "md5",
       "iso_url": "{{user `mirror`}}/Enterprise-R5-U11-Server-i386-dvd.iso",
       "output_directory": "packer-oracle-5.11-i386-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -97,9 +91,14 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-oracle-5.11-i386"
     }
-
   ],
   "post-processors": [
     {

--- a/oracle-5.11-x86_64.json
+++ b/oracle-5.11-x86_64.json
@@ -69,19 +69,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "centos",
       "http_directory": "http",
       "iso_checksum": "8af2121088c7e6f5ebdb6d5900403240",
       "iso_checksum_type": "md5",
       "iso_url": "{{user `mirror`}}/Enterprise-R5-U11-Server-x86_64-dvd.iso",
       "output_directory": "packer-oracle-5.11-x86_64-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -97,9 +91,14 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-oracle-5.11-x86_64"
     }
-
   ],
   "post-processors": [
     {

--- a/oracle-6.6-i386.json
+++ b/oracle-6.6-i386.json
@@ -10,9 +10,9 @@
       "guest_os_type": "Oracle",
       "hard_drive_interface": "sata",
       "http_directory": "http",
-      "iso_url": "{{user `mirror`}}/OracleLinux-R6-U6-Server-i386-dvd.iso",
       "iso_checksum": "81f0c85217f40763dea5053ec5594e4958498bbc",
       "iso_checksum_type": "sha1",
+      "iso_url": "{{user `mirror`}}/OracleLinux-R6-U6-Server-i386-dvd.iso",
       "output_directory": "packer-oracle-6.6-i386-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
@@ -45,9 +45,9 @@
       "disk_size": 40960,
       "guest_os_type": "oraclelinux",
       "http_directory": "http",
-      "iso_url": "{{user `mirror`}}/OracleLinux-R6-U6-Server-i386-dvd.iso",
       "iso_checksum": "81f0c85217f40763dea5053ec5594e4958498bbc",
       "iso_checksum_type": "sha1",
+      "iso_url": "{{user `mirror`}}/OracleLinux-R6-U6-Server-i386-dvd.iso",
       "output_directory": "packer-oracle-6.6-i386-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
@@ -69,19 +69,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "centos",
       "http_directory": "http",
-      "iso_url": "{{user `mirror`}}/OracleLinux-R6-U6-Server-i386-dvd.iso",
       "iso_checksum": "81f0c85217f40763dea5053ec5594e4958498bbc",
       "iso_checksum_type": "sha1",
+      "iso_url": "{{user `mirror`}}/OracleLinux-R6-U6-Server-i386-dvd.iso",
       "output_directory": "packer-oracle-6.6-i386-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -97,9 +91,14 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-oracle-6.6-i386"
     }
-
   ],
   "post-processors": [
     {
@@ -130,3 +129,4 @@
     "mirror": "http://mirrors.dotsrc.org/oracle-linux/OL6/U6/i386"
   }
 }
+

--- a/oracle-6.6-x86_64.json
+++ b/oracle-6.6-x86_64.json
@@ -69,19 +69,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "centos",
       "http_directory": "http",
       "iso_checksum": "5738f10a506d3630edfd297ef179b553091c6a48",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/OracleLinux-R6-U6-Server-x86_64-dvd.iso",
       "output_directory": "packer-oracle-6.6-x86_64-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -97,6 +91,12 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-oracle-6.6-x86_64"
     }
   ],
@@ -129,3 +129,4 @@
     "mirror": "http://mirrors.dotsrc.org/oracle-linux/OL6/U6/x86_64"
   }
 }
+

--- a/rhel-5.11-i386.json
+++ b/rhel-5.11-i386.json
@@ -69,19 +69,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "rhel",
       "http_directory": "http",
       "iso_checksum": "4e38e4ed06d83efb10446e7db19d96761715cdbdbf0bbfacb978b44ce368bbe2",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/rhel-server-5.11-i386-dvd.iso",
       "output_directory": "packer-rhel-5.11-i386-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -97,9 +91,14 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-rhel-5.11-i386"
     }
-
   ],
   "post-processors": [
     {

--- a/rhel-5.11-x86_64.json
+++ b/rhel-5.11-x86_64.json
@@ -69,19 +69,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "rhel",
       "http_directory": "http",
       "iso_checksum": "36565fe0c8a97207d63234d10123daeedb29d509576dbd7b34e71958ac2f9050",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/rhel-server-5.11-x86_64-dvd.iso",
       "output_directory": "packer-rhel-5.11-x86_64-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -97,9 +91,14 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-rhel-5.11-x86_64"
     }
-
   ],
   "post-processors": [
     {

--- a/rhel-6.6-i386.json
+++ b/rhel-6.6-i386.json
@@ -69,19 +69,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "rhel",
       "http_directory": "http",
       "iso_checksum": "0a14ed1f7d7ea7b831739ed8e71719d9cb7c294bf801e8db39358651768547ad",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/rhel-server-6.6-i386-dvd.iso",
       "output_directory": "packer-rhel-6.6-i386-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -97,9 +91,14 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-rhel-6.6-i386"
     }
-
   ],
   "post-processors": [
     {

--- a/rhel-6.6-x86_64.json
+++ b/rhel-6.6-x86_64.json
@@ -69,19 +69,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "rhel",
       "http_directory": "http",
       "iso_checksum": "16044cb7264f4bc0150f5b6f3f66936ccf2d36e0a4152c00d9236fb7dcae5f32",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/rhel-server-6.6-x86_64-dvd.iso",
       "output_directory": "packer-rhel-6.6-x86_64-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -97,6 +91,12 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-rhel-6.6-x86_64"
     }
   ],

--- a/rhel-7.1-x86_64.json
+++ b/rhel-7.1-x86_64.json
@@ -69,19 +69,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "rhel",
       "http_directory": "http",
       "iso_checksum": "3685468ec6cdcb70dfc85ebbc164da427dc2d762644c3c2ee1520f4f661c15ce",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/rhel-server-7.1-x86_64-dvd.iso",
       "output_directory": "packer-rhel-7.1-x86_64-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -97,9 +91,14 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-rhel-7.1-x86_64"
     }
-
   ],
   "post-processors": [
     {

--- a/sles-11-sp2-i386.json
+++ b/sles-11-sp2-i386.json
@@ -81,19 +81,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 20480,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "suse",
       "http_directory": "http",
       "iso_checksum": "a0b34f6237b2b2a6b2174c82b40ed326",
       "iso_checksum_type": "md5",
       "iso_url": "{{user `mirror`}}/SLES-11-SP2-DVD-i586-GM-DVD1.iso",
       "output_directory": "packer-sles-11-sp2-i386-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -109,9 +103,14 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-sles-11-sp2-i386"
     }
-
   ],
   "post-processors": [
     {

--- a/sles-11-sp2-x86_64.json
+++ b/sles-11-sp2-x86_64.json
@@ -81,19 +81,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 20480,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "suse",
       "http_directory": "http",
       "iso_checksum": "461d82ae6e15062b0807c1338f040497",
       "iso_checksum_type": "md5",
       "iso_url": "{{user `mirror`}}/SLES-11-SP2-DVD-x86_64-GM-DVD1.iso",
       "output_directory": "packer-sles-11-sp2-x86_64-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -109,9 +103,14 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-sles-11-sp2-x86_64"
     }
-
   ],
   "post-processors": [
     {

--- a/sles-11-sp3-i386.json
+++ b/sles-11-sp3-i386.json
@@ -81,19 +81,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 20480,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "suse",
       "http_directory": "http",
       "iso_checksum": "5c30a409fc8fb3343b4dc90d93ff2c89",
       "iso_checksum_type": "md5",
       "iso_url": "{{user `mirror`}}/SLES-11-SP3-DVD-i586-GM-DVD1.iso",
       "output_directory": "packer-sles-11-sp3-i386-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -109,9 +103,14 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-sles-11-sp3-i386"
     }
-
   ],
   "post-processors": [
     {

--- a/sles-11-sp3-x86_64.json
+++ b/sles-11-sp3-x86_64.json
@@ -81,19 +81,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 20480,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "suse",
       "http_directory": "http",
       "iso_checksum": "480b70d50cbb538382dc2b9325221e1b",
       "iso_checksum_type": "md5",
       "iso_url": "{{user `mirror`}}/SLES-11-SP3-DVD-x86_64-GM-DVD1.iso",
       "output_directory": "packer-sles-11-sp3-x86_64-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -109,6 +103,12 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-sles-11-sp3-x86_64"
     }
   ],

--- a/sles-12-x86_64.json
+++ b/sles-12-x86_64.json
@@ -81,19 +81,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 20480,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "suse",
       "http_directory": "http",
       "iso_checksum": "58086fca0441b1d44c7a51c5ee64e1bd4365466fcee48ec92c4f39d07739aeed",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/SLE-12-Server-DVD-x86_64-GM-DVD1.iso",
       "output_directory": "packer-sles-12-x86_64-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -109,6 +103,12 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-sles-12-x86_64"
     }
   ],

--- a/solaris-10.11-x86.json
+++ b/solaris-10.11-x86.json
@@ -1,23 +1,6 @@
 {
-  "variables": {
-    "README": "You must download the automated installer iso from the following page, and then place it somewhere that packer can fetch it",
-    "DOWNLOAD_SITE": "http://www.oracle.com/technetwork/server-storage/solaris10/downloads/index.html",
-    "mirror": "./packer_cache",
-    "chef_version": "provisionerless"
-  },
-  "provisioners": [
-    {
-      "type": "shell",
-      "execute_command": "/usr/local/bin/sudo {{.Path}}",
-      "scripts": [
-        "scripts/solaris10/vmtools.sh",
-        "scripts/solaris10/minimize.sh"
-      ]
-    }
-  ],
   "builders": [
     {
-      "type": "virtualbox-iso",
       "boot_command": [
         "e",
         "e",
@@ -27,6 +10,8 @@
         " - install<enter>",
         "b"
       ],
+      "boot_wait": "5s",
+      "disk_size": 20000,
       "floppy_files": [
         "floppy/solaris10/sysidcfg",
         "floppy/solaris10/awesome_prof",
@@ -34,23 +19,20 @@
         "floppy/solaris10/S99startup.sh",
         "floppy/solaris10/finish.sh"
       ],
-      "boot_wait": "5s",
-      "disk_size": 20000,
+      "guest_additions_mode": "upload",
       "guest_os_type": "Solaris_64",
       "http_directory": "http/solaris-10",
       "iso_checksum": "aae1452bb3d56baa3dcb8866ce7e4a08",
       "iso_checksum_type": "md5",
       "iso_url": "{{user `mirror`}}/sol-10-u11-ga-x86-dvd.iso",
-      "ssh_username": "vagrant",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_wait_timeout": "50000s",
+      "output_directory": "packer-solaris-10u11-x86_64-virtualbox",
       "shutdown_command": "/usr/local/bin/sudo /usr/sbin/init 5",
       "shutdown_timeout": "10m",
-      "guest_additions_mode": "upload",
-      "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-solaris-10u11-x86_64",
-      "output_directory": "packer-solaris-10u11-x86_64-virtualbox",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "50000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
         [
           "modifyvm",
@@ -64,10 +46,11 @@
           "--cpus",
           "1"
         ]
-      ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-solaris-10u11-x86_64"
     },
     {
-      "type": "vmware-iso",
       "boot_command": [
         "e",
         "e",
@@ -77,6 +60,8 @@
         " - install<enter>",
         "b"
       ],
+      "boot_wait": "5s",
+      "disk_size": 20000,
       "floppy_files": [
         "floppy/solaris10/sysidcfg",
         "floppy/solaris10/awesome_prof",
@@ -84,23 +69,22 @@
         "floppy/solaris10/S99startup.sh",
         "floppy/solaris10/finish.sh"
       ],
-      "boot_wait": "5s",
-      "disk_size": 20000,
       "guest_os_type": "solaris10-64",
       "http_directory": "http/solaris-10",
       "iso_checksum": "aae1452bb3d56baa3dcb8866ce7e4a08",
       "iso_checksum_type": "md5",
       "iso_url": "{{user `mirror`}}/sol-10-u11-ga-x86-dvd.iso",
-      "ssh_username": "vagrant",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_wait_timeout": "50000s",
+      "output_directory": "packer-solaris-10u11-x86_64-vmware",
       "shutdown_command": "/usr/local/bin/sudo /usr/sbin/init 5",
       "shutdown_timeout": "10m",
-      "vm_name": "packer-solaris-10u11-x86_64",
-      "output_directory": "packer-solaris-10u11-x86_64-vmware",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "50000s",
       "tools_upload_flavor": "solaris",
       "tools_upload_path": "/home/vagrant/solaris.iso",
+      "type": "vmware-iso",
+      "vm_name": "packer-solaris-10u11-x86_64",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "1536",
@@ -113,5 +97,22 @@
       "output": "builds/{{.Provider}}/opscode_solaris-10.11_chef-{{user `chef_version`}}.box",
       "type": "vagrant"
     }
-  ]
+  ],
+  "provisioners": [
+    {
+      "execute_command": "/usr/local/bin/sudo {{.Path}}",
+      "scripts": [
+        "scripts/solaris10/vmtools.sh",
+        "scripts/solaris10/minimize.sh"
+      ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "DOWNLOAD_SITE": "http://www.oracle.com/technetwork/server-storage/solaris10/downloads/index.html",
+    "README": "You must download the automated installer iso from the following page, and then place it somewhere that packer can fetch it",
+    "chef_version": "provisionerless",
+    "mirror": "./packer_cache"
+  }
 }
+

--- a/solaris-11-x86.json
+++ b/solaris-11-x86.json
@@ -1,28 +1,6 @@
 {
-  "variables": {
-    "README": "You must download the automated installer iso from the following page, and then place it somewhere that packer can fetch it",
-    "DOWNLOAD_SITE": "http://www.oracle.com/technetwork/server-storage/solaris11/downloads/index.html",
-    "mirror": "./packer_cache",
-    "chef_version": "provisionerless"
-  },
-  "provisioners": [
-    {
-      "type": "shell",
-      "environment_vars": [
-        "CHEF_VERSION={{user `chef_version`}}"
-      ],
-      "scripts": [
-        "scripts/solaris/update.sh",
-        "scripts/solaris/vmtools.sh",
-        "scripts/common/vagrant.sh",
-        "scripts/solaris/minimize.sh"
-      ],
-      "execute_command": "echo 'vagrant'|sudo -S bash {{.Path}}"
-    }
-  ],
   "builders": [
     {
-      "type": "virtualbox-iso",
       "boot_command": [
         "e<wait>",
         "<down><down><down><down><down><wait>",
@@ -47,26 +25,25 @@
         "cp profile.xml /system/volatile/profile/profile.xml;<wait>",
         "svcadm enable svc:/application/auto-installer:default;<wait>",
         "<enter><wait10><wait><wait>",
-	"<enter><wait>",
+        "<enter><wait>",
         "tail -f /var/svc/log/application-auto-installer\\:default.log<enter><wait>"
       ],
       "boot_wait": "5s",
       "disk_size": 10360,
+      "guest_additions_mode": "attach",
       "guest_os_type": "Solaris11_64",
       "http_directory": "http/solaris-11",
       "iso_checksum": "2b3859bb7532cfe42214349dff9fcc23",
       "iso_checksum_type": "md5",
       "iso_url": "{{user `mirror`}}/sol-11_2-ai-x86.iso",
-      "ssh_username": "vagrant",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_wait_timeout": "10000s",
+      "output_directory": "packer-solaris-11.2-x86_64-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -i init 5",
       "shutdown_timeout": "10m",
-      "guest_additions_mode": "attach",
-      "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-solaris-11.2-x86_64",
-      "output_directory": "packer-solaris-11.2-x86_64-virtualbox",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
       "vboxmanage": [
         [
           "modifyvm",
@@ -80,10 +57,11 @@
           "--cpus",
           "1"
         ]
-      ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-solaris-11.2-x86_64"
     },
     {
-      "type": "vmware-iso",
       "boot_command": [
         "e<wait>",
         "<down><down><down><down><down><wait>",
@@ -108,7 +86,7 @@
         "cp profile.xml /system/volatile/profile/profile.xml;<wait>",
         "svcadm enable svc:/application/auto-installer:default;<wait>",
         "<enter><wait10><wait><wait>",
-	"<enter><wait>",
+        "<enter><wait>",
         "tail -f /var/svc/log/application-auto-installer\\:default.log<enter><wait>"
       ],
       "boot_wait": "5s",
@@ -118,18 +96,19 @@
       "iso_checksum": "2b3859bb7532cfe42214349dff9fcc23",
       "iso_checksum_type": "md5",
       "iso_url": "{{user `mirror`}}/sol-11_2-ai-x86.iso",
-      "ssh_username": "vagrant",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_wait_timeout": "10000s",
+      "output_directory": "packer-solaris-11.2-x86_64-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -i init 5",
       "shutdown_timeout": "10m",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "vmware-iso",
       "vm_name": "packer-solaris-11.2-x86_64",
-      "output_directory": "packer-solaris-11.2-x86_64-vmware",
       "vmx_data": {
-          "memsize": "2048",
-          "cpuid.coresPerSocket": "1",
-	  "numvcpus": "1"
+        "cpuid.coresPerSocket": "1",
+        "memsize": "2048",
+        "numvcpus": "1"
       }
     }
   ],
@@ -138,5 +117,27 @@
       "output": "builds/{{.Provider}}/opscode_solaris-11.2_chef-{{user `chef_version`}}.box",
       "type": "vagrant"
     }
-  ]
+  ],
+  "provisioners": [
+    {
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}"
+      ],
+      "execute_command": "echo 'vagrant'|sudo -S bash {{.Path}}",
+      "scripts": [
+        "scripts/solaris/update.sh",
+        "scripts/solaris/vmtools.sh",
+        "scripts/common/vagrant.sh",
+        "scripts/solaris/minimize.sh"
+      ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "DOWNLOAD_SITE": "http://www.oracle.com/technetwork/server-storage/solaris11/downloads/index.html",
+    "README": "You must download the automated installer iso from the following page, and then place it somewhere that packer can fetch it",
+    "chef_version": "provisionerless",
+    "mirror": "./packer_cache"
+  }
 }
+

--- a/ubuntu-10.04-amd64.json
+++ b/ubuntu-10.04-amd64.json
@@ -132,19 +132,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "ubuntu",
       "http_directory": "http",
       "iso_checksum": "796e80702d65f2ee96e88874a1ab437e24df9cd6",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/10.04.4/ubuntu-10.04.4-server-amd64.iso",
       "output_directory": "packer-ubuntu-10.04-amd64-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -160,9 +154,14 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-ubuntu-10.04-amd64"
     }
-
   ],
   "post-processors": [
     {

--- a/ubuntu-10.04-i386.json
+++ b/ubuntu-10.04-i386.json
@@ -132,19 +132,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "ubuntu",
       "http_directory": "http",
       "iso_checksum": "5695d8b6b914269d1374ac8d4c3dd3786e92d3fe",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/10.04.4/ubuntu-10.04.4-server-i386.iso",
       "output_directory": "packer-ubuntu-10.04-i386-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -160,9 +154,14 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-ubuntu-10.04-i386"
     }
-
   ],
   "post-processors": [
     {

--- a/ubuntu-12.04-amd64.json
+++ b/ubuntu-12.04-amd64.json
@@ -132,19 +132,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "ubuntu",
       "http_directory": "http",
       "iso_checksum": "7540ace2d6cdee264432f5ed987236d32edef798",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/12.04.5/ubuntu-12.04.5-server-amd64.iso",
       "output_directory": "packer-ubuntu-12.04-amd64-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -160,9 +154,14 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-ubuntu-12.04-amd64"
     }
-
   ],
   "post-processors": [
     {

--- a/ubuntu-12.04-i386.json
+++ b/ubuntu-12.04-i386.json
@@ -132,19 +132,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "ubuntu",
       "http_directory": "http",
       "iso_checksum": "3bae12e315c89d42d7bf571e4e35efce585c7624",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/12.04.5/ubuntu-12.04.4-server-i386.iso",
       "output_directory": "packer-ubuntu-12.04-i386-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -160,9 +154,14 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-ubuntu-12.04-i386"
     }
-
   ],
   "post-processors": [
     {

--- a/ubuntu-14.04-amd64.json
+++ b/ubuntu-14.04-amd64.json
@@ -132,19 +132,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "ubuntu",
       "http_directory": "http",
       "iso_checksum": "8acd2f56bfcba2f7ac74a7e4a5e565ce68c024c38525c0285573e41c86ae90c0",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/14.04.2/ubuntu-14.04.2-server-amd64.iso",
       "output_directory": "packer-ubuntu-14.04-amd64-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -160,9 +154,14 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-ubuntu-14.04-amd64"
     }
-
   ],
   "post-processors": [
     {
@@ -195,3 +194,4 @@
     "mirror": "http://releases.ubuntu.com"
   }
 }
+

--- a/ubuntu-14.04-i386.json
+++ b/ubuntu-14.04-i386.json
@@ -132,19 +132,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "ubuntu",
       "http_directory": "http",
       "iso_checksum": "76524ab9502a34b983ed56af2d5a72835ce41aec1e2b4c0cb7788ef596958ed6",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/14.04.2/ubuntu-14.04.2-server-i386.iso",
       "output_directory": "packer-ubuntu-14.04-i386-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -160,9 +154,14 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-ubuntu-14.04-i386"
     }
-
   ],
   "post-processors": [
     {
@@ -195,3 +194,4 @@
     "mirror": "http://releases.ubuntu.com"
   }
 }
+

--- a/ubuntu-14.10-amd64.json
+++ b/ubuntu-14.10-amd64.json
@@ -132,19 +132,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "ubuntu",
       "http_directory": "http",
       "iso_checksum": "0c1ebea31c3523cfe9a4ffed8bcf6c7d23dfb97b",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/14.10/ubuntu-14.10-server-amd64.iso",
       "output_directory": "packer-ubuntu-14.10-amd64-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -160,9 +154,14 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-ubuntu-14.10-amd64"
     }
-
   ],
   "post-processors": [
     {
@@ -195,3 +194,4 @@
     "mirror": "http://releases.ubuntu.com"
   }
 }
+

--- a/ubuntu-14.10-i386.json
+++ b/ubuntu-14.10-i386.json
@@ -132,19 +132,13 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "parallels_tools_flavor": "lin",
       "guest_os_type": "ubuntu",
       "http_directory": "http",
       "iso_checksum": "26faf47df2162f4ff83e38e6831dd169da6db95f",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/14.10/ubuntu-14.10-server-i386.iso",
       "output_directory": "packer-ubuntu-14.10-i386-parallels",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_username": "vagrant",
-      "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso",
+      "parallels_tools_flavor": "lin",
       "prlctl": [
         [
           "set",
@@ -160,9 +154,14 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
       "vm_name": "packer-ubuntu-14.10-i386"
     }
-
   ],
   "post-processors": [
     {
@@ -195,3 +194,4 @@
     "mirror": "http://releases.ubuntu.com"
   }
 }
+


### PR DESCRIPTION
This PR introduces a modified subcommand called `normalize` (formerly `fix`) which will validate each template and then runs it through `packer fix` to normalize the JSON output formatting. The subcommand creates a report at the end containing a list of all templates that were modified in the normalize execution, making this a candidate for running in CI.