### PR TITLE
WIP - Add initial support for Wind River Linux 5.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ packer.log
 /packer-*/
 *.variables.json
 /builds/
+http/windriver-5.1/*.rpm

--- a/scripts/windriver/5.1/install.sh
+++ b/scripts/windriver/5.1/install.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# The ISO install doesn't set a timeout or default
+mount /dev/sda1 /boot
+chmod +w /boot/boot/grub/grub.cfg
+sed -i '1i timeout=1' /boot/boot/grub/grub.cfg
+chmod -w /boot/boot/grub/grub.cfg
+
+# Add vagrant
+groupadd vagrant
+useradd -g vagrant vagrant
+passwd -d vagrant
+
+echo "vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant
+
+# Vagrant detects windriver as being redhat so it attempts to update networking.
+# Unless we patch vagrant we'll just have to rely on this hackery
+mkdir -p /etc/sysconfig/network-scripts || true
+touch /etc/sysconfig/network-scripts/ifcfg-fake
+touch /etc/sysconfig/network
+ln -s /etc/init.d/networking /etc/init.d/network
+
+# Setup SSH
+mkdir -p /home/vagrant/.ssh
+wget --no-check-certificate "https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub" -O /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh
+chmod -R go-rwsx /home/vagrant/.ssh
+echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config
+echo 'AuthorizedKeysFile /home/%u/.ssh/authorized_keys' >> /etc/ssh/sshd_config
+
+# Until install.sh supports cisco we gotta bundle it in
+rpm -Uvh /tmp/chef-12.4.0.dev.x86_64.rpm
+rm /tmp/chef-12.4.0.dev.x86_64.rpm

--- a/windriver-5.1-x86_64.json
+++ b/windriver-5.1-x86_64.json
@@ -1,0 +1,107 @@
+{
+  "builders": [
+    {
+      "boot_command": [
+        "<enter>",
+        "<wait10>",
+        "y<enter>",
+        "<wait10>",
+        "<enter>",
+        "<wait10>",
+        "<enter>",
+        "<wait10>",
+        "<wait5>",
+        "root<enter><wait><wait>",
+        "root<enter><wait><wait>",
+        "wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/chef-12.4.0.dev.x86_64.rpm -O /tmp/chef-12.4.0.dev.x86_64.rpm<enter><wait5>"
+      ],
+      "boot_wait": "5s",
+      "disk_size": 10360,
+      "guest_additions_mode": "attach",
+      "guest_os_type": "Linux_64",
+      "http_directory": "http/windriver-5.1",
+      "iso_checksum": "abd48162b1cceb412727867519c22df1",
+      "iso_checksum_type": "md5",
+      "iso_url": "{{user `mirror`}}/satori-vm-chef-intel-xeon-core.0501.iso",
+      "output_directory": "packer-windriver-5.1_64",
+      "shutdown_command": "init 0",
+      "shutdown_timeout": "10m",
+      "ssh_password": "root",
+      "ssh_port": 22,
+      "ssh_username": "root",
+      "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
+      "vboxmanage": [
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "4096"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-windriver-5.1_64"
+    },
+    {
+      "boot_command": [
+        "<enter>",
+        "<wait10>",
+        "y<enter>",
+        "<wait10>",
+        "<enter>",
+        "<wait10>",
+        "<enter>",
+        "<wait10>",
+        "<wait5>",
+        "root<enter><wait><wait>",
+        "root<enter><wait><wait>",
+        "wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/chef-12.4.0.dev.x86_64.rpm -O /tmp/chef-12.4.0.dev.x86_64.rpm<enter><wait5>"
+      ],
+      "boot_wait": "5s",
+      "disk_size": 10360,
+      "guest_os_type": "Linux_64",
+      "http_directory": "http/windriver-5.1",
+      "iso_checksum": "abd48162b1cceb412727867519c22df1",
+      "iso_checksum_type": "md5",
+      "iso_url": "{{user `mirror`}}/satori-vm-chef-intel-xeon-core.0501.iso",
+      "output_directory": "packer-windriver-5.1_64",
+      "shutdown_command": "init 0",
+      "shutdown_timeout": "10m",
+      "ssh_password": "root",
+      "ssh_port": 22,
+      "ssh_username": "root",
+      "ssh_wait_timeout": "10000s",
+      "type": "vmware-iso",
+      "vm_name": "packer-windriver-5.1_64",
+      "vmx_data": {
+        "cpuid.coresPerSocket": "1",
+        "memsize": "4096",
+        "numvcpus": "1"
+      }
+    }
+  ],
+  "post-processors": [
+    {
+      "output": "builds/{{.Provider}}/opscode-windriver-5.1.box",
+      "type": "vagrant"
+    }
+  ],
+  "provisioners": [
+    {
+      "scripts": [
+        "scripts/windriver/5.1/install.sh"
+      ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "mirror": "./packer_cache"
+  }
+}
+


### PR DESCRIPTION
This is a WIP PR.  After upstream chef supports Nexus we can yank out the chef RPM bits and get this merged.  Ideally we could get upstream Vagrant to support Wind River and yank out the networking hacks.