### PR TITLE
Add build metadata to boxes and build artifacts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ packer.log
 .DS_Store
 /packer-*/
 *.variables.json
+/builds/

--- a/bin/bento
+++ b/bin/bento
@@ -8,8 +8,10 @@ $stderr.sync = true
 
 require "benchmark"
 require "digest"
+require "json"
 require "optparse"
 require "ostruct"
+require "tempfile"
 
 class Options
 
@@ -133,25 +135,37 @@ class BuildRunner
 
   include Common
 
-  attr_reader :templates, :dry_run, :debug, :builds
+  attr_reader :templates, :dry_run, :debug, :builds, :build_timestamp
 
   def initialize(opts)
     @templates = opts.templates
     @dry_run = opts.dry_run
     @debug = opts.debug
     @builds = opts.builds
+    @build_timestamp = Time.now.gmtime.strftime("%Y%m%d%H%M%S")
   end
 
   def start
     banner("Starting build for templates: #{templates}")
     time = Benchmark.measure do
-      templates.each { |template| packer(template) }
+      templates.each { |template| build_template(template) }
     end
     banner("Build finished in #{duration(time.real)}.")
   end
 
-  def packer(template)
-    cmd = packer_cmd(template)
+  def build_template(template)
+    Tempfile.open("#{template}-metadata.json") do |md_file|
+      Tempfile.open("#{template}-metadata-var-file") do |var_file|
+        write_box_metadata(template, md_file)
+        write_var_file(template, md_file.path, var_file)
+        packer(template, var_file.path)
+        write_final_metadata(template)
+      end
+    end
+  end
+
+  def packer(template, var_file)
+    cmd = packer_cmd(template, var_file)
     banner("[#{template}] Running: '#{cmd.join(' ')}'")
     time = Benchmark.measure do
       system(*cmd) or raise "[#{template}] Error building, exited #{$?}"
@@ -159,9 +173,9 @@ class BuildRunner
     banner("[#{template}] Finished in #{duration(time.real)}.")
   end
 
-  def packer_cmd(template)
+  def packer_cmd(template, var_file)
     vars = "#{template}.variables.json"
-    cmd = %W[packer build #{template}.json]
+    cmd = %W[packer build -var-file=#{var_file} #{template}.json]
     cmd.insert(2, "-var-file=#{vars}") if File.exist?(vars)
     cmd.insert(2, "-only=#{builds}") if builds
     cmd.insert(2, "-debug") if debug
@@ -169,8 +183,139 @@ class BuildRunner
     cmd
   end
 
-  def git_sha
-    %x{git rev-parse --short HEAD}.strip
+  def write_box_metadata(template, io)
+    md = BuildMetadata.new(template, build_timestamp).read
+
+    io.write(JSON.pretty_generate(md))
+    io.close
+  end
+
+  def write_final_metadata(template)
+    md = BuildMetadata.new(template, build_timestamp).read
+    path = File.join(File.dirname(__FILE__), "..", "builds")
+    filename = File.join(path, "#{md[:box_basename]}.metadata.json")
+    checksums = ChecksumMetadata.new(path, md[:box_basename]).read
+
+    md[:md5] = checksums[:md5]
+    md[:sha256] = checksums[:sha256]
+
+    File.open(filename, "wb") { |file| file.write(JSON.pretty_generate(md)) }
+  end
+
+  def write_var_file(template, md_file, io)
+    md = BuildMetadata.new(template, build_timestamp).read
+
+    io.write(JSON.pretty_generate({
+      box_basename:     md[:box_basename],
+      build_timestamp:  md[:build_timestamp],
+      git_revision:     md[:git_revision],
+      metadata:         md_file,
+      version:          md[:version]
+    }))
+    io.close
+  end
+end
+
+class ChecksumMetadata
+
+  def initialize(path, box_basename)
+    @base = File.join(path, box_basename)
+  end
+
+  def read
+    {
+      md5:    md5_checksums,
+      sha256: sha256_checksums
+    }
+  end
+
+  private
+
+  attr_reader :base
+
+  def md5_checksums
+    Hash[Dir.glob("#{base}.*.box").map { |box|
+      [File.basename(box), Digest::MD5.file(box).hexdigest]
+    }]
+  end
+
+  def sha256_checksums
+    Hash[Dir.glob("#{base}.*.box").map { |box|
+      [File.basename(box), Digest::SHA256.file(box).hexdigest]
+    }]
+  end
+end
+
+class BuildMetadata
+
+  def initialize(template, build_timestamp)
+    @template = template
+    @build_timestamp = build_timestamp
+  end
+
+  def read
+    {
+      name:             name,
+      version:          version,
+      build_timestamp:  build_timestamp,
+      git_revision:     git_revision,
+      box_basename:     box_basename,
+      atlas_org:        atlas_org,
+      arch:             template_vars.fetch("arch", UNKNOWN),
+      template:         template_vars.fetch("template", UNKNOWN),
+    }
+  end
+
+  private
+
+  UNKNOWN = "__unknown__".freeze
+  DEFAULT_ATLAS_ORG = "chef".freeze
+
+  attr_reader :template, :build_timestamp
+
+  def atlas_org
+    merged_vars.fetch("atlas_org", DEFAULT_ATLAS_ORG)
+  end
+
+  def box_basename
+    "#{atlas_org}__#{name}-#{version}.git.#{git_revision}"
+  end
+
+  def git_revision
+    sha = %x{git rev-parse HEAD}.strip
+
+    git_clean? ? sha : "#{sha}_dirty"
+  end
+
+  def git_clean?
+    %{git status --porcelain}.strip.empty?
+  end
+
+  def merged_vars
+    @merged_vars ||= begin
+      if File.exist?("#{template}.variables.json")
+        template_vars.merge(JSON.load(IO.read("#{template}.variables.json")))
+      else
+        template_vars
+      end
+    end
+  end
+
+  def name
+    merged_vars.fetch("name", template)
+  end
+
+  def template_vars
+    @template_vars ||= JSON.load(IO.read("#{template}.json")).fetch("variables")
+  end
+
+  def user_prefix
+    merged_vars.fetch("user_prefix", DEFAULT_USER_PREFIX)
+  end
+
+  def version
+    merged_vars.fetch("version", "#{UNKNOWN}.TIMESTAMP").
+      rpartition(".").first.concat(".#{build_timestamp}")
   end
 end
 

--- a/centos-5.11-i386.json
+++ b/centos-5.11-i386.json
@@ -102,15 +102,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_centos-5.11-i386.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/common/vagrant.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",
@@ -121,7 +127,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://mirrors.kernel.org/centos"
+    "arch": "32",
+    "box_basename": "centos-5.11-i386",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://mirrors.kernel.org/centos",
+    "name": "centos-5.11-i386",
+    "template": "centos-5.11-i386",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/centos-5.11-x86_64.json
+++ b/centos-5.11-x86_64.json
@@ -102,15 +102,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_centos-5.11.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/common/vagrant.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",
@@ -121,7 +127,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://mirrors.kernel.org/centos"
+    "arch": "64",
+    "box_basename": "centos-5.11",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://mirrors.kernel.org/centos",
+    "name": "centos-5.11",
+    "template": "centos-5.11-x86_64",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/centos-6.6-i386.json
+++ b/centos-6.6-i386.json
@@ -102,15 +102,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_centos-6.6-i386.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/centos/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",
@@ -122,7 +128,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://mirrors.kernel.org/centos"
+    "arch": "32",
+    "box_basename": "centos-6.6-i386",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://mirrors.kernel.org/centos",
+    "name": "centos-6.6-i386",
+    "template": "centos-6.6-i386",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/centos-6.6-x86_64.json
+++ b/centos-6.6-x86_64.json
@@ -102,15 +102,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_centos-6.6.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/centos/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",
@@ -122,7 +128,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://mirrors.kernel.org/centos"
+    "arch": "64",
+    "box_basename": "centos-6.6",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://mirrors.kernel.org/centos",
+    "name": "centos-6.6",
+    "template": "centos-6.6-x86_64",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/centos-7.1-x86_64.json
+++ b/centos-7.1-x86_64.json
@@ -102,15 +102,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_centos-7.1.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/centos/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",
@@ -122,7 +128,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://mirrors.kernel.org/centos"
+    "arch": "64",
+    "box_basename": "centos-7.1",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://mirrors.kernel.org/centos",
+    "name": "centos-7.1",
+    "template": "centos-7.1-x86_64",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/debian-6.0.10-amd64.json
+++ b/debian-6.0.10-amd64.json
@@ -144,15 +144,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_debian-6.0.10.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/debian/update.sh",
         "scripts/common/sshd.sh",
         "scripts/debian/networking.sh",
@@ -166,7 +172,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://cdimage.debian.org/cdimage/archive"
+    "arch": "64",
+    "box_basename": "debian-6.0.10",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://cdimage.debian.org/cdimage/archive",
+    "name": "debian-6.0.10",
+    "template": "debian-6.0.10-amd64",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/debian-6.0.10-i386.json
+++ b/debian-6.0.10-i386.json
@@ -144,15 +144,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_debian-6.0.10-i386.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/debian/update.sh",
         "scripts/common/sshd.sh",
         "scripts/debian/networking.sh",
@@ -166,7 +172,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://cdimage.debian.org/cdimage/archive"
+    "arch": "32",
+    "box_basename": "debian-6.0.10-i386",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://cdimage.debian.org/cdimage/archive",
+    "name": "debian-6.0.10-i386",
+    "template": "debian-6.0.10-i386",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/debian-7.8-amd64.json
+++ b/debian-7.8-amd64.json
@@ -144,15 +144,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_debian-7.8.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/debian/update.sh",
         "scripts/common/sshd.sh",
         "scripts/debian/networking.sh",
@@ -166,7 +172,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://cdimage.debian.org/cdimage/archive"
+    "arch": "64",
+    "box_basename": "debian-7.8",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://cdimage.debian.org/cdimage/archive",
+    "name": "debian-7.8",
+    "template": "debian-7.8-amd64",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/debian-7.8-i386.json
+++ b/debian-7.8-i386.json
@@ -144,15 +144,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_debian-7.8-i386.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/debian/update.sh",
         "scripts/common/sshd.sh",
         "scripts/debian/networking.sh",
@@ -166,7 +172,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://cdimage.debian.org/cdimage/archive"
+    "arch": "32",
+    "box_basename": "debian-7.8-i386",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://cdimage.debian.org/cdimage/archive",
+    "name": "debian-7.8-i386",
+    "template": "debian-7.8-i386",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/fedora-20-i386.json
+++ b/fedora-20-i386.json
@@ -102,15 +102,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_fedora-20-i386.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/fedora/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",
@@ -122,7 +128,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://download.fedoraproject.org/pub/fedora/linux"
+    "arch": "32",
+    "box_basename": "fedora-20-i386",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://download.fedoraproject.org/pub/fedora/linux",
+    "name": "fedora-20-i386",
+    "template": "fedora-20-i386",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/fedora-20-x86_64.json
+++ b/fedora-20-x86_64.json
@@ -102,15 +102,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_fedora-20.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/fedora/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",
@@ -122,7 +128,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://download.fedoraproject.org/pub/fedora/linux"
+    "arch": "64",
+    "box_basename": "fedora-20",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://download.fedoraproject.org/pub/fedora/linux",
+    "name": "fedora-20",
+    "template": "fedora-20-x86_64",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/fedora-21-i386.json
+++ b/fedora-21-i386.json
@@ -102,15 +102,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_fedora-21-i386.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/fedora/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",
@@ -122,7 +128,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://download.fedoraproject.org/pub/fedora/linux"
+    "arch": "32",
+    "box_basename": "fedora-21-i386",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://download.fedoraproject.org/pub/fedora/linux",
+    "name": "fedora-21-i386",
+    "template": "fedora-21-i386",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/fedora-21-x86_64.json
+++ b/fedora-21-x86_64.json
@@ -102,15 +102,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_fedora-21.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/fedora/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",
@@ -122,7 +128,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://download.fedoraproject.org/pub/fedora/linux"
+    "arch": "64",
+    "box_basename": "fedora-21",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://download.fedoraproject.org/pub/fedora/linux",
+    "name": "fedora-21",
+    "template": "fedora-21-x86_64",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/floppy/dummy_metadata.json
+++ b/floppy/dummy_metadata.json
@@ -1,0 +1,3 @@
+{
+  "metadata": "not provided"
+}

--- a/freebsd-10.1-amd64.json
+++ b/freebsd-10.1-amd64.json
@@ -146,7 +146,7 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_freebsd-10.1.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "override": {
         "parallels": {
           "vagrantfile_template": "vagrantfile_templates/parallels/freebsd.rb"
@@ -157,9 +157,15 @@
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "export {{.Vars}} && cat {{.Path}} | su -m",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/freebsd/postinstall.sh",
         "scripts/freebsd/cleanup.sh",
         "scripts/freebsd/vmtools.sh",
@@ -169,7 +175,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://ftp.freebsd.org/pub/FreeBSD"
+    "arch": "64",
+    "box_basename": "freebsd-10.1",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://ftp.freebsd.org/pub/FreeBSD",
+    "name": "freebsd-10.1",
+    "template": "freebsd-10.1-amd64",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/freebsd-10.1-i386.json
+++ b/freebsd-10.1-i386.json
@@ -146,7 +146,7 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_freebsd-10.1-i386.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "override": {
         "parallels": {
           "vagrantfile_template": "vagrantfile_templates/parallels/freebsd.rb"
@@ -157,9 +157,15 @@
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "export {{.Vars}} && cat {{.Path}} | su -m",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/freebsd/postinstall.sh",
         "scripts/freebsd/cleanup.sh",
         "scripts/freebsd/vmtools.sh",
@@ -169,7 +175,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://ftp.freebsd.org/pub/FreeBSD"
+    "arch": "32",
+    "box_basename": "freebsd-10.1-i386",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://ftp.freebsd.org/pub/FreeBSD",
+    "name": "freebsd-10.1-i386",
+    "template": "freebsd-10.1-i386",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/freebsd-9.3-amd64.json
+++ b/freebsd-9.3-amd64.json
@@ -158,7 +158,7 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_freebsd-9.3.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "override": {
         "parallels": {
           "vagrantfile_template": "vagrantfile_templates/parallels/freebsd.rb"
@@ -169,9 +169,15 @@
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "export {{.Vars}} && cat {{.Path}} | su -m",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/freebsd/postinstall.sh",
         "scripts/freebsd/vmtools.sh",
         "scripts/freebsd/cleanup.sh",
@@ -181,7 +187,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://ftp.freebsd.org/pub/FreeBSD"
+    "arch": "64",
+    "box_basename": "freebsd-9.3",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://ftp.freebsd.org/pub/FreeBSD",
+    "name": "freebsd-9.3",
+    "template": "freebsd-9.3-amd64",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/freebsd-9.3-i386.json
+++ b/freebsd-9.3-i386.json
@@ -157,7 +157,7 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_freebsd-9.3-i386.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "override": {
         "parallels": {
           "vagrantfile_template": "vagrantfile_templates/parallels/freebsd.rb"
@@ -168,8 +168,14 @@
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "execute_command": "export {{.Vars}} && cat {{.Path}} | su -m",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/freebsd/postinstall.sh",
         "scripts/freebsd/vmtools.sh",
         "scripts/freebsd/cleanup.sh",
@@ -179,7 +185,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://ftp.freebsd.org/pub/FreeBSD"
+    "arch": "32",
+    "box_basename": "freebsd-9.3-i386",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://ftp.freebsd.org/pub/FreeBSD",
+    "name": "freebsd-9.3-i386",
+    "template": "freebsd-9.3-i386",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/macosx-10.7.json
+++ b/macosx-10.7.json
@@ -155,12 +155,17 @@
   "min_packer_version": "0.6.0",
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_macosx-10.7.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant",
       "vagrantfile_template": "vagrantfile_templates/macosx.rb"
     }
   ],
   "provisioners": [
+    {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
     {
       "destination": "/private/tmp/kcpassword",
       "source": "scripts/macosx/support/kcpassword",
@@ -169,6 +174,7 @@
     {
       "execute_command": "echo 'vagrant'| {{.Vars}} sudo -E -S sh '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/macosx/hostname.sh",
         "scripts/macosx/builder.sh",
         "scripts/macosx/update.sh",
@@ -189,9 +195,17 @@
     }
   ],
   "variables": {
+    "arch": "64",
     "autologin_vagrant_user": "",
+    "box_basename": "macosx-10.7",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
     "iso_checksum": "e2a48af008ff3c4db6a8235151a1e90ea600fceb",
-    "iso_url": "http://fakeurl/OSX_InstallESD_10.7.5_11G63.dmg"
+    "iso_url": "http://fakeurl/OSX_InstallESD_10.7.5_11G63.dmg",
+    "metadata": "floppy/dummy_metadata.json",
+    "name": "macosx-10.7",
+    "template": "macosx-10.7",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/macosx-10.8.json
+++ b/macosx-10.8.json
@@ -155,12 +155,17 @@
   "min_packer_version": "0.6.0",
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_macosx-10.8.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant",
       "vagrantfile_template": "vagrantfile_templates/macosx.rb"
     }
   ],
   "provisioners": [
+    {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
     {
       "destination": "/private/tmp/kcpassword",
       "source": "scripts/macosx/support/kcpassword",
@@ -169,6 +174,7 @@
     {
       "execute_command": "echo 'vagrant'| {{.Vars}} sudo -E -S sh '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/macosx/hostname.sh",
         "scripts/macosx/builder.sh",
         "scripts/macosx/update.sh",
@@ -189,9 +195,17 @@
     }
   ],
   "variables": {
+    "arch": "64",
     "autologin_vagrant_user": "",
+    "box_basename": "macosx-10.8",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
     "iso_checksum": "e2a48af008ff3c4db6a8235151a1e90ea600fceb",
-    "iso_url": "http://fakeurl/OSX_InstallESD_10.8.5_12F45.dmg"
+    "iso_url": "http://fakeurl/OSX_InstallESD_10.8.5_12F45.dmg",
+    "metadata": "floppy/dummy_metadata.json",
+    "name": "macosx-10.8",
+    "template": "macosx-10.8",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/macosx-10.9.json
+++ b/macosx-10.9.json
@@ -155,12 +155,17 @@
   "min_packer_version": "0.6.0",
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_macosx-10.9.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant",
       "vagrantfile_template": "vagrantfile_templates/macosx.rb"
     }
   ],
   "provisioners": [
+    {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
     {
       "destination": "/private/tmp/kcpassword",
       "source": "scripts/macosx/support/kcpassword",
@@ -169,6 +174,7 @@
     {
       "execute_command": "echo 'vagrant'| {{.Vars}} sudo -E -S sh '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/macosx/hostname.sh",
         "scripts/macosx/builder.sh",
         "scripts/macosx/update.sh",
@@ -189,9 +195,17 @@
     }
   ],
   "variables": {
+    "arch": "64",
     "autologin_vagrant_user": "",
+    "box_basename": "macosx-10.9",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
     "iso_checksum": "e2a48af008ff3c4db6a8235151a1e90ea600fceb",
-    "iso_url": "http://fakeurl/OSX_InstallESD_10.9.1_13B42.dmg"
+    "iso_url": "http://fakeurl/OSX_InstallESD_10.9.1_13B42.dmg",
+    "metadata": "floppy/dummy_metadata.json",
+    "name": "macosx-10.9",
+    "template": "macosx-10.9",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/omnios-r151010j.json
+++ b/omnios-r151010j.json
@@ -180,7 +180,7 @@
   "post-processors": [
     {
       "compression_level": 9,
-      "output": "builds/{{.Provider}}/opscode_omnios-r151010j.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "override": {
         "parallels": {
           "vagrantfile_template": "vagrantfile_templates/parallels/omnios.rb"
@@ -191,9 +191,15 @@
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "export {{.Vars}} && sh '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/omnios/vmtools.sh",
         "scripts/omnios/postinstall.sh"
       ],
@@ -201,7 +207,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://omnios.omniti.com/media"
+    "arch": "64",
+    "box_basename": "omnios-r151010j",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://omnios.omniti.com/media",
+    "name": "omnios-r151010j",
+    "template": "omnios-r151010j",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/opensuse-13.2-i386.json
+++ b/opensuse-13.2-i386.json
@@ -113,15 +113,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_opensuse-13.2-i386.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",
         "scripts/common/vmtools.sh",
@@ -135,7 +141,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://download.opensuse.org/distribution"
+    "arch": "32",
+    "box_basename": "opensuse-13.2-i386",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://download.opensuse.org/distribution",
+    "name": "opensuse-13.2-i386",
+    "template": "opensuse-13.2-i386",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/opensuse-13.2-x86_64.json
+++ b/opensuse-13.2-x86_64.json
@@ -113,15 +113,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_opensuse-13.2-x86_64.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",
         "scripts/common/vmtools.sh",
@@ -135,7 +141,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://download.opensuse.org/distribution"
+    "arch": "64",
+    "box_basename": "opensuse-13.2-x86_64",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://download.opensuse.org/distribution",
+    "name": "opensuse-13.2-x86_64",
+    "template": "opensuse-13.2-x86_64",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/oracle-5.11-i386.json
+++ b/oracle-5.11-i386.json
@@ -102,15 +102,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_oracle-5.11-i386.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/common/vagrant.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",
@@ -121,7 +127,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://mirrors.dotsrc.org/oracle-linux/EL5/U11/i386"
+    "arch": "32",
+    "box_basename": "oracle-5.11-i386",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://mirrors.dotsrc.org/oracle-linux/EL5/U11/i386",
+    "name": "oracle-5.11-i386",
+    "template": "oracle-5.11-i386",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/oracle-5.11-x86_64.json
+++ b/oracle-5.11-x86_64.json
@@ -102,15 +102,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_oracle-5.11.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/common/vagrant.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",
@@ -121,7 +127,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://mirrors.dotsrc.org/oracle-linux/EL5/U11/x86_64"
+    "arch": "64",
+    "box_basename": "oracle-5.11",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://mirrors.dotsrc.org/oracle-linux/EL5/U11/x86_64",
+    "name": "oracle-5.11",
+    "template": "oracle-5.11-x86_64",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/oracle-6.6-i386.json
+++ b/oracle-6.6-i386.json
@@ -102,15 +102,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_oracle-6.6-i386.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/centos/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",
@@ -122,7 +128,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://mirrors.dotsrc.org/oracle-linux/OL6/U6/i386"
+    "arch": "32",
+    "box_basename": "oracle-6.6-i386",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://mirrors.dotsrc.org/oracle-linux/OL6/U6/i386",
+    "name": "oracle-6.6-i386",
+    "template": "oracle-6.6-i386",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/oracle-6.6-x86_64.json
+++ b/oracle-6.6-x86_64.json
@@ -102,15 +102,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_oracle-6.6.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/centos/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",
@@ -122,7 +128,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://mirrors.dotsrc.org/oracle-linux/OL6/U6/x86_64"
+    "arch": "64",
+    "box_basename": "oracle-6.6",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://mirrors.dotsrc.org/oracle-linux/OL6/U6/x86_64",
+    "name": "oracle-6.6",
+    "template": "oracle-6.6-x86_64",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/rhel-5.11-i386.json
+++ b/rhel-5.11-i386.json
@@ -102,15 +102,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_rhel-5.11-i386.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/common/vagrant.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",
@@ -121,7 +127,15 @@
     }
   ],
   "variables": {
-    "mirror": "https://content-web.rhn.redhat.com/rhn/isos/rhel-5.11/md5sum/1ab756241a4a209b8d39abe6bace84a9"
+    "arch": "32",
+    "box_basename": "rhel-5.11-i386",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "https://content-web.rhn.redhat.com/rhn/isos/rhel-5.11/md5sum/1ab756241a4a209b8d39abe6bace84a9",
+    "name": "rhel-5.11-i386",
+    "template": "rhel-5.11-i386",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/rhel-5.11-x86_64.json
+++ b/rhel-5.11-x86_64.json
@@ -102,15 +102,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_rhel-5.11.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/common/vagrant.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",
@@ -121,7 +127,15 @@
     }
   ],
   "variables": {
-    "mirror": "https://content-web.rhn.redhat.com/rhn/isos/rhel-5.11/md5sum/86cc2d5548ee2ff9c8d3e2b4db3e6001"
+    "arch": "64",
+    "box_basename": "rhel-5.11",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "https://content-web.rhn.redhat.com/rhn/isos/rhel-5.11/md5sum/86cc2d5548ee2ff9c8d3e2b4db3e6001",
+    "name": "rhel-5.11",
+    "template": "rhel-5.11-x86_64",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/rhel-6.6-i386.json
+++ b/rhel-6.6-i386.json
@@ -102,15 +102,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_rhel-6.6-i386.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/centos/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",
@@ -122,7 +128,15 @@
     }
   ],
   "variables": {
-    "mirror": "https://content-web.rhn.redhat.com/rhn/isos/rhel-6.6/md5sum/64e687f958db92feccc3f7701a8771f8"
+    "arch": "32",
+    "box_basename": "rhel-6.6-i386",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "https://content-web.rhn.redhat.com/rhn/isos/rhel-6.6/md5sum/64e687f958db92feccc3f7701a8771f8",
+    "name": "rhel-6.6-i386",
+    "template": "rhel-6.6-i386",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/rhel-6.6-x86_64.json
+++ b/rhel-6.6-x86_64.json
@@ -102,15 +102,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_rhel-6.6.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/centos/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",
@@ -122,7 +128,15 @@
     }
   ],
   "variables": {
-    "mirror": "https://content-web.rhn.redhat.com/rhn/isos/rhel-6.6/md5sum/ef031b0ae8458d6489eb277ba1dcb5de"
+    "arch": "64",
+    "box_basename": "rhel-6.6",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "https://content-web.rhn.redhat.com/rhn/isos/rhel-6.6/md5sum/ef031b0ae8458d6489eb277ba1dcb5de",
+    "name": "rhel-6.6",
+    "template": "rhel-6.6-x86_64",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/rhel-7.1-x86_64.json
+++ b/rhel-7.1-x86_64.json
@@ -102,15 +102,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_rhel-7.1.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/centos/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",
@@ -122,7 +128,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://put-your-mirror-here/"
+    "arch": "64",
+    "box_basename": "rhel-7.1",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://put-your-mirror-here/",
+    "name": "rhel-7.1",
+    "template": "rhel-7.1-x86_64",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/scripts/common/metadata.sh
+++ b/scripts/common/metadata.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -eux
+
+mkdir -p /etc
+cp /tmp/bento-metadata.json /etc/bento-metadata.json
+chmod 0444 /etc/bento-metadata.json
+rm -f /tmp/bento-metadata.json

--- a/sles-11-sp2-i386.json
+++ b/sles-11-sp2-i386.json
@@ -114,15 +114,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_sles-11sp2-i386.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",
         "scripts/common/vmtools.sh",
@@ -135,7 +141,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://cdn2.novell.com/prot/FkjGyLMMiss~"
+    "arch": "32",
+    "box_basename": "sles-11-sp2-i386",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://cdn2.novell.com/prot/FkjGyLMMiss~",
+    "name": "sles-11-sp2-i386",
+    "template": "sles-11-sp2-i386",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/sles-11-sp2-x86_64.json
+++ b/sles-11-sp2-x86_64.json
@@ -114,15 +114,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_sles-11sp2.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",
         "scripts/common/vmtools.sh",
@@ -134,7 +140,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://cdn.novell.com/free/h0AOp5AT-18~"
+    "arch": "64",
+    "box_basename": "sles-11-sp2",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://cdn.novell.com/free/h0AOp5AT-18~",
+    "name": "sles-11-sp2",
+    "template": "sles-11-sp2-x86_64",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/sles-11-sp3-i386.json
+++ b/sles-11-sp3-i386.json
@@ -114,15 +114,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_sles-11sp3-i386.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",
         "scripts/common/vmtools.sh",
@@ -135,7 +141,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://cdn2.novell.com/prot/4uiuDMzX0ck~"
+    "arch": "32",
+    "box_basename": "sles-11-sp3-i386",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://cdn2.novell.com/prot/4uiuDMzX0ck~",
+    "name": "sles-11-sp3-i386",
+    "template": "sles-11-sp3-i386",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/sles-11-sp3-x86_64.json
+++ b/sles-11-sp3-x86_64.json
@@ -114,15 +114,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_sles-11sp3.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",
         "scripts/common/vmtools.sh",
@@ -135,7 +141,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://cdn2.novell.com/prot/Q_VbW21BiB4~"
+    "arch": "64",
+    "box_basename": "sles-11-sp3",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://cdn2.novell.com/prot/Q_VbW21BiB4~",
+    "name": "sles-11-sp3",
+    "template": "sles-11-sp3-x86_64",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/sles-12-x86_64.json
+++ b/sles-12-x86_64.json
@@ -114,15 +114,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_sles-12.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",
         "scripts/sles/unsupported-modules.sh",
@@ -137,7 +143,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://cdn2.novell.com/prot/Q_VbW21BiB4~"
+    "arch": "64",
+    "box_basename": "sles-12",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://cdn2.novell.com/prot/Q_VbW21BiB4~",
+    "name": "sles-12",
+    "template": "sles-12-x86_64",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/solaris-10.11-x86.json
+++ b/solaris-10.11-x86.json
@@ -94,14 +94,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_solaris-10.11.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
+      "environment_vars": [],
       "execute_command": "/usr/local/bin/sudo {{.Path}}",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/solaris10/vmtools.sh",
         "scripts/solaris10/minimize.sh"
       ],
@@ -109,9 +116,17 @@
     }
   ],
   "variables": {
-    "DOWNLOAD_SITE": "http://www.oracle.com/technetwork/server-storage/solaris10/downloads/index.html",
-    "README": "You must download the automated installer iso from the following page, and then place it somewhere that packer can fetch it",
-    "mirror": "./packer_cache"
+    "_DOWNLOAD_SITE": "http://www.oracle.com/technetwork/server-storage/solaris10/downloads/index.html",
+    "_README": "You must download the automated installer iso from the following page, and then place it somewhere that packer can fetch it",
+    "arch": "64",
+    "box_basename": "solaris-10.11",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "./packer_cache",
+    "name": "solaris-10.11",
+    "template": "solaris-10.11-x86",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/solaris-11-x86.json
+++ b/solaris-11-x86.json
@@ -114,15 +114,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_solaris-11.2.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant'|sudo -S bash {{.Path}}",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/solaris/update.sh",
         "scripts/solaris/vmtools.sh",
         "scripts/common/vagrant.sh",
@@ -132,9 +138,17 @@
     }
   ],
   "variables": {
-    "DOWNLOAD_SITE": "http://www.oracle.com/technetwork/server-storage/solaris11/downloads/index.html",
-    "README": "You must download the automated installer iso from the following page, and then place it somewhere that packer can fetch it",
-    "mirror": "./packer_cache"
+    "_DOWNLOAD_SITE": "http://www.oracle.com/technetwork/server-storage/solaris11/downloads/index.html",
+    "_README": "You must download the automated installer iso from the following page, and then place it somewhere that packer can fetch it",
+    "arch": "64",
+    "box_basename": "solaris-11.2",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "./packer_cache",
+    "name": "solaris-11.2",
+    "template": "solaris-11.2-x86",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/ubuntu-10.04-amd64.json
+++ b/ubuntu-10.04-amd64.json
@@ -165,15 +165,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_ubuntu-10.04.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/ubuntu/update.sh",
         "scripts/common/sshd.sh",
         "scripts/ubuntu/networking.sh",
@@ -187,7 +193,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://releases.ubuntu.com"
+    "arch": "64",
+    "box_basename": "ubuntu-10.04",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://releases.ubuntu.com",
+    "name": "ubuntu-10.04",
+    "template": "ubuntu-10.04-amd64",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/ubuntu-10.04-i386.json
+++ b/ubuntu-10.04-i386.json
@@ -165,15 +165,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_ubuntu-10.04-i386.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/ubuntu/update.sh",
         "scripts/common/sshd.sh",
         "scripts/ubuntu/networking.sh",
@@ -187,7 +193,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://releases.ubuntu.com"
+    "arch": "32",
+    "box_basename": "ubuntu-10.04-i386",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://releases.ubuntu.com",
+    "name": "ubuntu-10.04-i386",
+    "template": "ubuntu-10.04-i386",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/ubuntu-12.04-amd64.json
+++ b/ubuntu-12.04-amd64.json
@@ -165,15 +165,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_ubuntu-12.04.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/ubuntu/update.sh",
         "scripts/common/sshd.sh",
         "scripts/ubuntu/networking.sh",
@@ -187,7 +193,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://releases.ubuntu.com"
+    "arch": "64",
+    "box_basename": "ubuntu-12.04",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://releases.ubuntu.com",
+    "name": "ubuntu-12.04",
+    "template": "ubuntu-12.04-amd64",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/ubuntu-12.04-i386.json
+++ b/ubuntu-12.04-i386.json
@@ -134,9 +134,9 @@
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
       "http_directory": "http",
-      "iso_checksum": "3bae12e315c89d42d7bf571e4e35efce585c7624",
+      "iso_checksum": "a34c224b7fe72a2f5c768be5afee5c53817743fd",
       "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/12.04.5/ubuntu-12.04.4-server-i386.iso",
+      "iso_url": "{{user `mirror`}}/12.04.5/ubuntu-12.04.5-server-i386.iso",
       "output_directory": "packer-ubuntu-12.04-i386-parallels",
       "parallels_tools_flavor": "lin",
       "prlctl": [
@@ -165,15 +165,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_ubuntu-12.04-i386.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/ubuntu/update.sh",
         "scripts/common/sshd.sh",
         "scripts/ubuntu/networking.sh",
@@ -187,7 +193,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://releases.ubuntu.com"
+    "arch": "32",
+    "box_basename": "ubuntu-12.04-i386",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://releases.ubuntu.com",
+    "name": "ubuntu-12.04-i386",
+    "template": "ubuntu-12.04-i386",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/ubuntu-14.04-amd64.json
+++ b/ubuntu-14.04-amd64.json
@@ -165,15 +165,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_ubuntu-14.04.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/ubuntu/update.sh",
         "scripts/common/sshd.sh",
         "scripts/ubuntu/networking.sh",
@@ -187,7 +193,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://releases.ubuntu.com"
+    "arch": "64",
+    "box_basename": "ubuntu-14.04",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://releases.ubuntu.com",
+    "name": "ubuntu-14.04",
+    "template": "ubuntu-14.04-amd64",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/ubuntu-14.04-i386.json
+++ b/ubuntu-14.04-i386.json
@@ -165,15 +165,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_ubuntu-14.04-i386.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/ubuntu/update.sh",
         "scripts/common/sshd.sh",
         "scripts/ubuntu/networking.sh",
@@ -187,7 +193,16 @@
     }
   ],
   "variables": {
-    "mirror": "http://releases.ubuntu.com"
+    "arch": "32",
+    "box_basename": "ubuntu-14.04-i386",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "chef_version": "provisionerless",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://releases.ubuntu.com",
+    "name": "ubuntu-14.04-i386",
+    "template": "ubuntu-14.04-i386",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/ubuntu-14.10-amd64.json
+++ b/ubuntu-14.10-amd64.json
@@ -165,15 +165,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_ubuntu-14.10.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/ubuntu/update.sh",
         "scripts/common/sshd.sh",
         "scripts/ubuntu/networking.sh",
@@ -187,7 +193,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://releases.ubuntu.com"
+    "arch": "64",
+    "box_basename": "ubuntu-14.10",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://releases.ubuntu.com",
+    "name": "ubuntu-14.10",
+    "template": "ubuntu-14.10-amd64",
+    "version": "2.0.TIMESTAMP"
   }
 }
 

--- a/ubuntu-14.10-i386.json
+++ b/ubuntu-14.10-i386.json
@@ -165,15 +165,21 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{.Provider}}/opscode_ubuntu-14.10-i386.box",
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
     {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
       "environment_vars": [],
       "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
+        "scripts/common/metadata.sh",
         "scripts/ubuntu/update.sh",
         "scripts/common/sshd.sh",
         "scripts/ubuntu/networking.sh",
@@ -187,7 +193,15 @@
     }
   ],
   "variables": {
-    "mirror": "http://releases.ubuntu.com"
+    "arch": "32",
+    "box_basename": "ubuntu-14.10-i386",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://releases.ubuntu.com",
+    "name": "ubuntu-14.10-i386",
+    "template": "ubuntu-14.10-i386",
+    "version": "2.0.TIMESTAMP"
   }
 }
 


### PR DESCRIPTION
For each Packer template that is run via `bin/bento`, a JSON file of
build metadata will be written to the `builds/` directory, which looks
like the following (using the `ubuntu-14.100i386` template as an example):

    {
      "name": "ubuntu-14.10-i386",
      "version": "2.0.20150528211301",
      "build_timestamp": "20150528211301",
      "git_revision": "6b23dd8d8ff0fb9cc4473f510bc3c54f0b415d1b",
      "box_basename": "chef__ubuntu-14.10-i386-2.0.20150528211301.git.6b23dd8d8ff0fb9cc4473f510bc3c54f0b415d1b",
      "atlas_org": "chef",
      "arch": "32",
      "template": "ubuntu-14.10-i386",
      "md5": {
        "chef__ubuntu-14.10-i386-2.0.20150528211301.git.6b23dd8d8ff0fb9cc4473f510bc3c54f0b415d1b.parallels.box": "e3a18b096cddc73384f0912c3a65ebad",
        "chef__ubuntu-14.10-i386-2.0.20150528211301.git.6b23dd8d8ff0fb9cc4473f510bc3c54f0b415d1b.virtualbox.box": "106f2ca4e6da18663e7216a72dd62e56",
        "chef__ubuntu-14.10-i386-2.0.20150528211301.git.6b23dd8d8ff0fb9cc4473f510bc3c54f0b415d1b.vmware.box": "8990550bc2a0e2e7515ed3433ec54b46"
      },
      "sha256": {
        "chef__ubuntu-14.10-i386-2.0.20150528211301.git.6b23dd8d8ff0fb9cc4473f510bc3c54f0b415d1b.parallels.box": "0a0e3c9369de005a456f0cd7d94ba4d4b562d7231c11d9c5af8e40ef77131d3d",
        "chef__ubuntu-14.10-i386-2.0.20150528211301.git.6b23dd8d8ff0fb9cc4473f510bc3c54f0b415d1b.virtualbox.box": "0c23480a99294aea8f42daea2576a41820ec3bebb99a9d0a8ab72a3de1b24137",
        "chef__ubuntu-14.10-i386-2.0.20150528211301.git.6b23dd8d8ff0fb9cc4473f510bc3c54f0b415d1b.vmware.box": "9128b66ef4bae323a123fcdd0be5a598bb538f822295ab6bf043e7630a49b608"
      }
    }

In addition to the "sidecar" metadata file, a trimmed down version will
is added to each Vagrant box in `/etc/bento-metadata.json`. Using the
example above, here is what the file would look like:

    {
      "name": "ubuntu-14.10-i386",
      "version": "2.0.20150528211301",
      "build_timestamp": "20150528211301",
      "git_revision": "6b23dd8d8ff0fb9cc4473f510bc3c54f0b415d1b_dirty",
      "box_basename": "chef__ubuntu-14.10-i386-2.0.20150528211301.git.6b23dd8d8ff0fb9cc4473f510bc3c54f0b415d1b_dirty",
      "atlas_org": "chef",
      "arch": "32",
      "template": "ubuntu-14.10-i386"
    }

Also note that this changes the file naming scheme of the resulting box
artifacts in an effort to host multiple builds of the same templates in
one directory while maintaining enough information about the box within
the filename itself.

Using the same example as above, the VirtualBox provider box name is:

    chef__ubuntu-14.10-i386-2.0.20150528211301.git.6b23dd8d8ff0fb9cc4473f510bc3c54f0b415d1b.virtualbox.box

Which uses the following recipe to construct the filename:

* `atlas_org` value (default: `"chef"`)
* double underscore, which could be later interpreted as a slash (`/`)
  for an Atalas box name
* `name` value which may or may not equal the name of the template
  (captured as the `template` value)
* a dash
* `version` value, which removes the last digit in a version string and
  replaces it with the `build_timestamp` (a
  Year/Month/Day/Hour/Minute/Second format in UTC timezone)
* a period
* the string `"git"`
* a period
* `git_revision` value, which will append `"_dirty"` if the current
  state of the git repository is not completely clean (i.e., there are
  uncommitted changes which happens in active development)
* a period
* the value of the `{{.Provider}}` Packer variable, being one of
  `"virtualbox"`, `"vmware"`, or `"parallels"`
* finished with `".box"`

Closes #364