### PR TITLE
fedora-22 support

### DIFF
--- a/fedora-22-i386.json
+++ b/fedora-22-i386.json
@@ -1,0 +1,143 @@
+
+{
+  "builders": [
+    {
+      "boot_command": [
+        "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-22/ks.cfg<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 40960,
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_os_type": "Fedora",
+      "hard_drive_interface": "sata",
+      "http_directory": "http",
+      "iso_checksum": "5e3dfdff30667f3339d8b4e6ac0651c2e00c9417987848bef772cb92dbc823a5",
+      "iso_checksum_type": "sha256",
+      "iso_url": "{{user `mirror`}}/releases/22/Server/i386/iso/Fedora-Server-DVD-i386-22.iso",
+      "output_directory": "packer-fedora-22-i386-virtualbox",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
+      "vboxmanage": [
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "512"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-fedora-22-i386"
+    },
+    {
+      "boot_command": [
+        "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-22/ks.cfg<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 40960,
+      "guest_os_type": "fedora",
+      "http_directory": "http",
+      "iso_checksum": "5e3dfdff30667f3339d8b4e6ac0651c2e00c9417987848bef772cb92dbc823a5",
+      "iso_checksum_type": "sha256",
+      "iso_url": "{{user `mirror`}}/releases/22/Server/i386/iso/Fedora-Server-DVD-i386-22.iso",
+      "output_directory": "packer-fedora-22-i386-vmware",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
+      "vm_name": "packer-fedora-22-i386",
+      "vmx_data": {
+        "cpuid.coresPerSocket": "1",
+        "memsize": "512",
+        "numvcpus": "1"
+      }
+    },
+    {
+      "boot_command": [
+        "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-22/ks.cfg<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 40960,
+      "guest_os_type": "fedora-core",
+      "http_directory": "http",
+      "iso_checksum": "5e3dfdff30667f3339d8b4e6ac0651c2e00c9417987848bef772cb92dbc823a5",
+      "iso_checksum_type": "sha256",
+      "iso_url": "{{user `mirror`}}/releases/22/Server/i386/iso/Fedora-Server-DVD-i386-22.iso",
+      "output_directory": "packer-fedora-22-i386-parallels",
+      "parallels_tools_flavor": "lin",
+      "prlctl": [
+        [
+          "set",
+          "{{.Name}}",
+          "--memsize",
+          "512"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
+      ],
+      "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
+      "vm_name": "packer-fedora-22-i386"
+    }
+  ],
+  "post-processors": [
+    {
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "type": "vagrant"
+    }
+  ],
+  "provisioners": [
+    {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
+      "environment_vars": [],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
+      "scripts": [
+        "scripts/common/metadata.sh",
+        "scripts/fedora/fix-slow-dns.sh",
+        "scripts/common/sshd.sh",
+        "scripts/common/vmtools.sh",
+        "scripts/common/vagrant.sh",
+        "scripts/fedora/cleanup.sh",
+        "scripts/common/minimize.sh"
+      ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "arch": "32",
+    "box_basename": "fedora-22-i386",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://download.fedoraproject.org/pub/fedora/linux",
+    "name": "fedora-22-i386",
+    "template": "fedora-22-i386",
+    "version": "2.0.TIMESTAMP"
+  }
+}
+

--- a/fedora-22-x86_64.json
+++ b/fedora-22-x86_64.json
@@ -1,0 +1,142 @@
+{
+  "builders": [
+    {
+      "boot_command": [
+        "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-22/ks.cfg<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 40960,
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_os_type": "Fedora_64",
+      "hard_drive_interface": "sata",
+      "http_directory": "http",
+      "iso_checksum": "b2acfa7c7c6b5d2f51d3337600c2e52eeaa1a1084991181c28ca30343e52e0df",
+      "iso_checksum_type": "sha256",
+      "iso_url": "{{user `mirror`}}/releases/22/Server/x86_64/iso/Fedora-Server-DVD-x86_64-22.iso",
+      "output_directory": "packer-fedora-22-x86_64-virtualbox",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
+      "vboxmanage": [
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "512"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "packer-fedora-22-x86_64"
+    },
+    {
+      "boot_command": [
+        "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-22/ks.cfg<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 40960,
+      "guest_os_type": "fedora-64",
+      "http_directory": "http",
+      "iso_checksum": "b2acfa7c7c6b5d2f51d3337600c2e52eeaa1a1084991181c28ca30343e52e0df",
+      "iso_checksum_type": "sha256",
+      "iso_url": "{{user `mirror`}}/releases/22/Server/x86_64/iso/Fedora-Server-DVD-x86_64-22.iso",
+      "output_directory": "packer-fedora-22-x86_64-vmware",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
+      "vm_name": "packer-fedora-22-x86_64",
+      "vmx_data": {
+        "cpuid.coresPerSocket": "1",
+        "memsize": "512",
+        "numvcpus": "1"
+      }
+    },
+    {
+      "boot_command": [
+        "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora-22/ks.cfg<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 40960,
+      "guest_os_type": "fedora-core",
+      "http_directory": "http",
+      "iso_checksum": "b2acfa7c7c6b5d2f51d3337600c2e52eeaa1a1084991181c28ca30343e52e0df",
+      "iso_checksum_type": "sha256",
+      "iso_url": "{{user `mirror`}}/releases/22/Server/x86_64/iso/Fedora-Server-DVD-x86_64-22.iso",
+      "output_directory": "packer-fedora-22-x86_64-parallels",
+      "parallels_tools_flavor": "lin",
+      "prlctl": [
+        [
+          "set",
+          "{{.Name}}",
+          "--memsize",
+          "512"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
+      ],
+      "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
+      "vm_name": "packer-fedora-22-x86_64"
+    }
+  ],
+  "post-processors": [
+    {
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "type": "vagrant"
+    }
+  ],
+  "provisioners": [
+    {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
+      "environment_vars": [],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
+      "scripts": [
+        "scripts/common/metadata.sh",
+        "scripts/fedora/fix-slow-dns.sh",
+        "scripts/common/sshd.sh",
+        "scripts/common/vmtools.sh",
+        "scripts/common/vagrant.sh",
+        "scripts/fedora/cleanup.sh",
+        "scripts/common/minimize.sh"
+      ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "arch": "64",
+    "box_basename": "fedora-22",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "git_revision": "__unknown_git_revision__",
+    "metadata": "floppy/dummy_metadata.json",
+    "mirror": "http://download.fedoraproject.org/pub/fedora/linux",
+    "name": "fedora-22",
+    "template": "fedora-22-x86_64",
+    "version": "2.0.TIMESTAMP"
+  }
+}
+

--- a/http/fedora-22/ks.cfg
+++ b/http/fedora-22/ks.cfg
@@ -1,0 +1,46 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw vagrant
+firewall --disabled
+authconfig --enableshadow --passalgo=sha512
+selinux --permissive
+timezone UTC
+bootloader --location=mbr
+text
+skipx
+zerombr
+clearpart --all --initlabel
+part /boot --fstype=ext4 --size=500
+part pv.2 --grow --size=500
+volgroup vg_vagrant --pesize=32768 pv.2
+logvol / --fstype=ext4 --name=lv_root --vgname=vg_vagrant --size=1024 --grow
+logvol swap --fstype=swap --name=lv_swap --vgname=vg_vagrant --size=528 --grow --maxsize=1056
+bootloader --location=mbr --append="norhgb biosdevname=0"
+auth  --useshadow  --enablemd5
+firstboot --disabled
+reboot
+user --name=vagrant --plaintext --password vagrant
+
+%packages --nobase --ignoremissing --excludedocs
+bzip2
+gcc
+kernel-devel
+kernel-headers
+tar
+wget
+nfs-utils
+net-tools
+-linux-firmware
+-plymouth
+-plymouth-core-libs
+%end
+
+%post
+# sudo
+echo 'Defaults:vagrant !requiretty' > /etc/sudoers.d/vagrant
+echo '%vagrant ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/vagrant
+chmod 440 /etc/sudoers.d/vagrant
+%end


### PR DESCRIPTION
fedora-22 boxes.

- fedora-22-x86_64:  built OK on virtualbox. Don't have vmware or parallels to test.
- fedora-22-i386: this does not build. Instead I get the following error. Omitting the `--pesize=32768` from the ks.cfg doesn't help either, it just changes the message from 32 MiB to 4 MiB. Not sure what's up with this one and can't find anything from some brief google searching, and we only need the 64b box.

![image](https://cloud.githubusercontent.com/assets/377603/7952029/03295e94-0964-11e5-9678-ec925347f6d4.png)
