### PR TITLE
[macosx-*] Improve DRYness & correctness of Mac templates.

### DIFF
--- a/macosx-10.10.json
+++ b/macosx-10.10.json
@@ -5,10 +5,10 @@
       "disk_size": 20480,
       "guest_os_type": "darwin12-64",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "iso_checksum_type": "md5",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",
-      "output_directory": "packer-macosx-10.10-vmware",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+      "output_directory": "packer-{{user `template`}}-vmware",
+      "shutdown_command": "echo 'vagrant'| sudo -S shutdown -h now",
       "skip_compaction": true,
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -17,7 +17,7 @@
       "tools_upload_flavor": "darwin",
       "tools_upload_path": "/tmp/vmtools.iso",
       "type": "vmware-iso",
-      "vm_name": "packer-macosx-10.10-vmware",
+      "vm_name": "packer-{{user `template`}}-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "ehci.present": "TRUE",
@@ -38,10 +38,10 @@
       "guest_os_type": "MacOS109_64",
       "hard_drive_interface": "sata",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "iso_checksum_type": "md5",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",
-      "output_directory": "packer-macosx-10.10-virtualbox",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+      "output_directory": "packer-{{user `template`}}-virtualbox",
+      "shutdown_command": "echo 'vagrant'| sudo -S shutdown -h now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -149,10 +149,10 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-macosx-10.10-virtualbox"
+      "vm_name": "packer-{{user `template`}}-virtualbox"
     }
   ],
-  "min_packer_version": "0.6.0",
+  "min_packer_version": "0.7.0",
   "post-processors": [
     {
       "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
@@ -167,12 +167,10 @@
       "type": "file"
     },
     {
-      "destination": "/private/tmp/kcpassword",
-      "source": "scripts/macosx/support/kcpassword",
-      "type": "file"
-    },
-    {
-      "execute_command": "echo 'vagrant'| {{.Vars}} sudo -E -S sh '{{.Path}}'",
+      "environment_vars": [
+        "HOME_DIR=/Users/vagrant"
+      ],
+      "execute_command": "echo 'vagrant'| {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/common/metadata.sh",
         "scripts/macosx/hostname.sh",
@@ -184,31 +182,20 @@
         "scripts/macosx/minimize.sh"
       ],
       "type": "shell"
-    },
-    {
-      "execute_command": "echo 'vagrant'| {{.Vars}} sudo -E -S sh '{{.Path}}'",
-      "inline": [
-        "[ -z \"{{user `autologin_vagrant_user`}}\" ] && exit",
-        "echo \"Enabling automatic GUI login for the 'vagrant' user..\"",
-        "cp /private/tmp/kcpassword /private/etc/kcpassword",
-        "/usr/bin/defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser vagrant"
-      ],
-      "type": "shell"
     }
   ],
   "variables": {
-    "arch": "64",
-    "autologin_vagrant_user": "",
-    "box_basename": "macosx-10.10",
+    "_README": "You must provide a prepared Mac disk image (from https://github.com/timsutton/osx-vm-templates) and checksum value for this template to work. For more details, consult this project's README.md",
+    "box_basename": "__unset_box_basename__",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
-    "iso_checksum": "6d878aeb58aad23d2be00774d4da3b3d",
+    "iso_checksum": "__unset_iso_checksum__",
     "iso_checksum_type": "md5",
-    "iso_url": "http://fakeurl/OSX_InstallESD_10.10.3_14D136.dmg",
+    "iso_url": "http://YOU-MUST-PROVIDE-YOUR-OWN-DMG.sorry",
     "metadata": "floppy/dummy_metadata.json",
-    "name": "macosx-10.10",
+    "name": "chef/macosx-10.10",
     "template": "macosx-10.10",
-    "version": "2.0.TIMESTAMP"
+    "version": "2.1.TIMESTAMP"
   }
 }
 

--- a/macosx-10.7.json
+++ b/macosx-10.7.json
@@ -5,19 +5,19 @@
       "disk_size": 20480,
       "guest_os_type": "darwin12-64",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "iso_checksum_type": "md5",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",
-      "output_directory": "packer-macosx-10.7-vmware",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+      "output_directory": "packer-{{user `template`}}-vmware",
+      "shutdown_command": "echo 'vagrant'| sudo -S shutdown -h now",
       "skip_compaction": true,
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "darwin",
-      "tools_upload_path": "/Users/vagrant/{{.Flavor}}.iso",
+      "tools_upload_path": "/tmp/vmtools.iso",
       "type": "vmware-iso",
-      "vm_name": "packer-macosx-10.7-vmware",
+      "vm_name": "packer-{{user `template`}}-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "ehci.present": "TRUE",
@@ -38,10 +38,10 @@
       "guest_os_type": "MacOS107_64",
       "hard_drive_interface": "sata",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "iso_checksum_type": "md5",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",
-      "output_directory": "packer-macosx-10.7-virtualbox",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+      "output_directory": "packer-{{user `template`}}-virtualbox",
+      "shutdown_command": "echo 'vagrant'| sudo -S shutdown -h now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -149,10 +149,10 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-macosx-10.7-virtualbox"
+      "vm_name": "packer-{{user `template`}}-virtualbox"
     }
   ],
-  "min_packer_version": "0.6.0",
+  "min_packer_version": "0.7.0",
   "post-processors": [
     {
       "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
@@ -167,45 +167,35 @@
       "type": "file"
     },
     {
-      "destination": "/private/tmp/kcpassword",
-      "source": "scripts/macosx/support/kcpassword",
-      "type": "file"
-    },
-    {
-      "execute_command": "echo 'vagrant'| {{.Vars}} sudo -E -S sh '{{.Path}}'",
+      "environment_vars": [
+        "HOME_DIR=/Users/vagrant"
+      ],
+      "execute_command": "echo 'vagrant'| {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/common/metadata.sh",
         "scripts/macosx/hostname.sh",
-        "scripts/macosx/builder.sh",
         "scripts/macosx/update.sh",
+        "scripts/macosx/networking.sh",
         "scripts/macosx/vagrant.sh",
-        "scripts/macosx/cleanup.sh"
-      ],
-      "type": "shell"
-    },
-    {
-      "execute_command": "echo 'vagrant'| {{.Vars}} sudo -E -S sh '{{.Path}}'",
-      "inline": [
-        "[ -z \"{{user `autologin_vagrant_user`}}\" ] && exit",
-        "echo \"Enabling automatic GUI login for the 'vagrant' user..\"",
-        "cp /private/tmp/kcpassword /private/etc/kcpassword",
-        "/usr/bin/defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser vagrant"
+        "scripts/macosx/vmtools.sh",
+        "scripts/macosx/cleanup.sh",
+        "scripts/macosx/minimize.sh"
       ],
       "type": "shell"
     }
   ],
   "variables": {
-    "arch": "64",
-    "autologin_vagrant_user": "",
-    "box_basename": "macosx-10.7",
+    "_README": "You must provide a prepared Mac disk image (from https://github.com/timsutton/osx-vm-templates) and checksum value for this template to work. For more details, consult this project's README.md",
+    "box_basename": "__unset_box_basename__",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
-    "iso_checksum": "e2a48af008ff3c4db6a8235151a1e90ea600fceb",
-    "iso_url": "http://fakeurl/OSX_InstallESD_10.7.5_11G63.dmg",
+    "iso_checksum": "__unset_iso_checksum__",
+    "iso_checksum_type": "md5",
+    "iso_url": "http://YOU-MUST-PROVIDE-YOUR-OWN-DMG.sorry",
     "metadata": "floppy/dummy_metadata.json",
-    "name": "macosx-10.7",
+    "name": "chef/macosx-10.7",
     "template": "macosx-10.7",
-    "version": "2.0.TIMESTAMP"
+    "version": "2.1.TIMESTAMP"
   }
 }
 

--- a/macosx-10.8.json
+++ b/macosx-10.8.json
@@ -5,19 +5,19 @@
       "disk_size": 20480,
       "guest_os_type": "darwin12-64",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "iso_checksum_type": "md5",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",
-      "output_directory": "packer-macosx-10.8-vmware",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+      "output_directory": "packer-{{user `template`}}-vmware",
+      "shutdown_command": "echo 'vagrant'| sudo -S shutdown -h now",
       "skip_compaction": true,
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "darwin",
-      "tools_upload_path": "/Users/vagrant/{{.Flavor}}.iso",
+      "tools_upload_path": "/tmp/vmtools.iso",
       "type": "vmware-iso",
-      "vm_name": "packer-macosx-10.8-vmware",
+      "vm_name": "packer-{{user `template`}}-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "ehci.present": "TRUE",
@@ -38,10 +38,10 @@
       "guest_os_type": "MacOS108_64",
       "hard_drive_interface": "sata",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "iso_checksum_type": "md5",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",
-      "output_directory": "packer-macosx-10.8-virtualbox",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+      "output_directory": "packer-{{user `template`}}-virtualbox",
+      "shutdown_command": "echo 'vagrant'| sudo -S shutdown -h now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -149,10 +149,10 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-macosx-10.8-virtualbox"
+      "vm_name": "packer-{{user `template`}}-virtualbox"
     }
   ],
-  "min_packer_version": "0.6.0",
+  "min_packer_version": "0.7.0",
   "post-processors": [
     {
       "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
@@ -167,45 +167,35 @@
       "type": "file"
     },
     {
-      "destination": "/private/tmp/kcpassword",
-      "source": "scripts/macosx/support/kcpassword",
-      "type": "file"
-    },
-    {
-      "execute_command": "echo 'vagrant'| {{.Vars}} sudo -E -S sh '{{.Path}}'",
+      "environment_vars": [
+        "HOME_DIR=/Users/vagrant"
+      ],
+      "execute_command": "echo 'vagrant'| {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/common/metadata.sh",
         "scripts/macosx/hostname.sh",
-        "scripts/macosx/builder.sh",
         "scripts/macosx/update.sh",
+        "scripts/macosx/networking.sh",
         "scripts/macosx/vagrant.sh",
-        "scripts/macosx/cleanup.sh"
-      ],
-      "type": "shell"
-    },
-    {
-      "execute_command": "echo 'vagrant'| {{.Vars}} sudo -E -S sh '{{.Path}}'",
-      "inline": [
-        "[ -z \"{{user `autologin_vagrant_user`}}\" ] && exit",
-        "echo \"Enabling automatic GUI login for the 'vagrant' user..\"",
-        "cp /private/tmp/kcpassword /private/etc/kcpassword",
-        "/usr/bin/defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser vagrant"
+        "scripts/macosx/vmtools.sh",
+        "scripts/macosx/cleanup.sh",
+        "scripts/macosx/minimize.sh"
       ],
       "type": "shell"
     }
   ],
   "variables": {
-    "arch": "64",
-    "autologin_vagrant_user": "",
-    "box_basename": "macosx-10.8",
+    "_README": "You must provide a prepared Mac disk image (from https://github.com/timsutton/osx-vm-templates) and checksum value for this template to work. For more details, consult this project's README.md",
+    "box_basename": "__unset_box_basename__",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
-    "iso_checksum": "e2a48af008ff3c4db6a8235151a1e90ea600fceb",
-    "iso_url": "http://fakeurl/OSX_InstallESD_10.8.5_12F45.dmg",
+    "iso_checksum": "__unset_iso_checksum__",
+    "iso_checksum_type": "md5",
+    "iso_url": "http://YOU-MUST-PROVIDE-YOUR-OWN-DMG.sorry",
     "metadata": "floppy/dummy_metadata.json",
-    "name": "macosx-10.8",
+    "name": "chef/macosx-10.8",
     "template": "macosx-10.8",
-    "version": "2.0.TIMESTAMP"
+    "version": "2.1.TIMESTAMP"
   }
 }
 

--- a/macosx-10.9.json
+++ b/macosx-10.9.json
@@ -5,19 +5,19 @@
       "disk_size": 20480,
       "guest_os_type": "darwin12-64",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "iso_checksum_type": "md5",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",
-      "output_directory": "packer-macosx-10.9-vmware",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+      "output_directory": "packer-{{user `template`}}-vmware",
+      "shutdown_command": "echo 'vagrant'| sudo -S shutdown -h now",
       "skip_compaction": true,
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "darwin",
-      "tools_upload_path": "/Users/vagrant/{{.Flavor}}.iso",
+      "tools_upload_path": "/tmp/vmtools.iso",
       "type": "vmware-iso",
-      "vm_name": "packer-macosx-10.9-vmware",
+      "vm_name": "packer-{{user `template`}}-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "ehci.present": "TRUE",
@@ -38,10 +38,10 @@
       "guest_os_type": "MacOS109_64",
       "hard_drive_interface": "sata",
       "iso_checksum": "{{user `iso_checksum`}}",
-      "iso_checksum_type": "md5",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",
-      "output_directory": "packer-macosx-10.9-virtualbox",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+      "output_directory": "packer-{{user `template`}}-virtualbox",
+      "shutdown_command": "echo 'vagrant'| sudo -S shutdown -h now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -149,10 +149,10 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-macosx-10.9-virtualbox"
+      "vm_name": "packer-{{user `template`}}-virtualbox"
     }
   ],
-  "min_packer_version": "0.6.0",
+  "min_packer_version": "0.7.0",
   "post-processors": [
     {
       "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
@@ -167,45 +167,35 @@
       "type": "file"
     },
     {
-      "destination": "/private/tmp/kcpassword",
-      "source": "scripts/macosx/support/kcpassword",
-      "type": "file"
-    },
-    {
-      "execute_command": "echo 'vagrant'| {{.Vars}} sudo -E -S sh '{{.Path}}'",
+      "environment_vars": [
+        "HOME_DIR=/Users/vagrant"
+      ],
+      "execute_command": "echo 'vagrant'| {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/common/metadata.sh",
         "scripts/macosx/hostname.sh",
-        "scripts/macosx/builder.sh",
         "scripts/macosx/update.sh",
+        "scripts/macosx/networking.sh",
         "scripts/macosx/vagrant.sh",
-        "scripts/macosx/cleanup.sh"
-      ],
-      "type": "shell"
-    },
-    {
-      "execute_command": "echo 'vagrant'| {{.Vars}} sudo -E -S sh '{{.Path}}'",
-      "inline": [
-        "[ -z \"{{user `autologin_vagrant_user`}}\" ] && exit",
-        "echo \"Enabling automatic GUI login for the 'vagrant' user..\"",
-        "cp /private/tmp/kcpassword /private/etc/kcpassword",
-        "/usr/bin/defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser vagrant"
+        "scripts/macosx/vmtools.sh",
+        "scripts/macosx/cleanup.sh",
+        "scripts/macosx/minimize.sh"
       ],
       "type": "shell"
     }
   ],
   "variables": {
-    "arch": "64",
-    "autologin_vagrant_user": "",
-    "box_basename": "macosx-10.9",
+    "_README": "You must provide a prepared Mac disk image (from https://github.com/timsutton/osx-vm-templates) and checksum value for this template to work. For more details, consult this project's README.md",
+    "box_basename": "__unset_box_basename__",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
-    "iso_checksum": "e2a48af008ff3c4db6a8235151a1e90ea600fceb",
-    "iso_url": "http://fakeurl/OSX_InstallESD_10.9.1_13B42.dmg",
+    "iso_checksum": "__unset_iso_checksum__",
+    "iso_checksum_type": "md5",
+    "iso_url": "http://YOU-MUST-PROVIDE-YOUR-OWN-DMG.sorry",
     "metadata": "floppy/dummy_metadata.json",
-    "name": "macosx-10.9",
+    "name": "chef/macosx-10.9",
     "template": "macosx-10.9",
-    "version": "2.0.TIMESTAMP"
+    "version": "2.1.TIMESTAMP"
   }
 }
 

--- a/scripts/macosx/cleanup.sh
+++ b/scripts/macosx/cleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eux
+#!/bin/sh -eux
 
 # eject installer disc
-drutil eject
+drutil eject;

--- a/scripts/macosx/hostname.sh
+++ b/scripts/macosx/hostname.sh
@@ -1,10 +1,10 @@
-#!/bin/bash -eux
+#!/bin/sh -eux
 # Major thanks to @timsutton's osx-vm-templates:
 # https://github.com/timsutton/osx-vm-templates
 
-osx_minor_version=$(sw_vers -productVersion | awk -F "." '{print $2}')
+osx_minor_version="`sw_vers -productVersion | awk -F '.' '{print $2}'`";
 
 # Set computer/hostname
-computer_name=macosx-10-${osx_minor_version}
-scutil --set ComputerName $computer_name
-scutil --set HostName ${computer_name}.vagrantup.com
+computer_name="macosx-10-${osx_minor_version}";
+scutil --set ComputerName "$computer_name";
+scutil --set HostName "${computer_name}.vagrantup.com";

--- a/scripts/macosx/minimize.sh
+++ b/scripts/macosx/minimize.sh
@@ -1,16 +1,27 @@
 #!/bin/sh -eux
 
-# disable swap
-launchctl unload -wF /System/Library/LaunchDaemons/com.apple.dynamic_pager.plist;
-
-rm -f /private/var/vm/swapfile*;
+# Remove any sleepimage--a file the same size as the RAM footprint
 rm -f /private/var/vm/sleepimage;
+
+# Stop the pager process and drop swap files. These will be re-created on boot
+launchctl unload /System/Library/LaunchDaemons/com.apple.dynamic_pager.plist;
+sleep 5;
+rm -rf /private/var/vm/swap*;
 
 dd if=/dev/zero of=/EMPTY bs=1000000 || echo "dd exit code $? is suppressed";
 rm -f /EMPTY;
 # Block until the empty file has been removed, otherwise, Packer
 # will try to kill the box while the disk is still full and that's bad
 sync;
+
+
+case "$PACKER_BUILDER_TYPE" in
+
+vmware-iso|vmware-vmx)
+    sudo /Library/Application\ Support/VMware\ Tools/vmware-tools-cli disk shrink /;
+    ;;
+
+esac
 
 # re-enable swap
 launchctl load -wF /System/Library/LaunchDaemons/com.apple.dynamic_pager.plist;

--- a/scripts/macosx/networking.sh
+++ b/scripts/macosx/networking.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -eux
 
 # Thank you to https://github.com/timsutton/osx-vm-templates
 # for the implementation
@@ -6,8 +6,9 @@
 # This script adds a Mac OS Launch Daemon, which runs every time the
 # machine is booted. The daemon will re-detect the attached network
 # interfaces. If this is not done, network devices may not work.
-PLIST=/Library/LaunchDaemons/com.github.timsutton.osx-vm-templates.detectnewhardware.plist
-cat <<EOF > "${PLIST}"
+plist=/Library/LaunchDaemons/com.github.timsutton.osx-vm-templates.detectnewhardware.plist;
+
+cat <<PLIST >"$plist";
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -23,9 +24,9 @@ cat <<EOF > "${PLIST}"
     <true/>
 </dict>
 </plist>
-EOF
+PLIST
 
 # These should be already set as follows, but since they're required
 # in order to load properly, we set them explicitly.
-/bin/chmod 644 "${PLIST}"
-/usr/sbin/chown root:wheel "${PLIST}"
+chmod 644 "$plist";
+chown root:wheel "$plist";

--- a/scripts/macosx/update.sh
+++ b/scripts/macosx/update.sh
@@ -1,3 +1,3 @@
-#!/bin/bash -eux
+#!/bin/sh -eux
 
-softwareupdate --install --all
+softwareupdate --install --all;

--- a/scripts/macosx/vagrant.sh
+++ b/scripts/macosx/vagrant.sh
@@ -1,38 +1,14 @@
 #!/bin/bash -eux
 
-home_dir="$(python -c 'import pwd; print pwd.getpwnam("vagrant").pw_dir')"
-
-if [ -f $home_dir/.vbox_version ]; then
-    echo "VirtualBox not currently supported, sadface"
-fi
-
-if [ -f $home_dir/.vmfusion_version ]; then
-    iso_name="$(uname | tr [[:upper:]] [[:lower:]]).iso"
-    mount_point="$(mktemp -d /tmp/vmware-tools.XXXX)"
-    #Run install, unmount ISO and remove it
-    cd $home_dir
-    hdiutil attach $iso_name -mountpoint "$mount_point"
-    installer -pkg "$mount_point/Install VMware Tools.app/Contents/Resources/VMware Tools.pkg" -target /
-    # This usually fails
-    hdiutil detach "$mount_point" || true
-    rm -rf $home_dir/$iso_name
-    rmdir $mount_point
-
-    # Point Linux shared folder root to that used by OS X guests,
-    # useful for the Hashicorp vmware_fusion Vagrant provider plugin
-    mkdir /mnt
-    ln -sf /Volumes/VMware\ Shared\ Folders /mnt/hgfs
-fi
-
-pubkey_url='https://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub'
-mkdir $home_dir/.ssh
-if command -v wget >/dev/null ; then
-    wget --no-check-certificate "$pubkey_url" -O $home_dir/.ssh/authorized_keys
-elif command -v curl >/dev/null ; then
-    curl --insecure --location "$pubkey_url" > $home_dir/.ssh/authorized_keys
+pubkey_url="https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub";
+mkdir -p $HOME_DIR/.ssh;
+if command -v wget >/dev/null 2>&1; then
+    wget --no-check-certificate "$pubkey_url" -O $HOME_DIR/.ssh/authorized_keys;
+elif command -v curl >/dev/null 2>&1; then
+    curl --insecure --location "$pubkey_url" > $HOME_DIR/.ssh/authorized_keys;
 else
-    echo "Cannot download vagrant public key"
-    exit 1
+    echo "Cannot download vagrant public key";
+    exit 1;
 fi
-chown -R vagrant $home_dir/.ssh
-chmod -R go-rwsx $home_dir/.ssh
+chown -R vagrant $HOME_DIR/.ssh;
+chmod -R go-rwsx $HOME_DIR/.ssh;


### PR DESCRIPTION
The following improvements are made in this commit:

* Using the `template` user variable to replace repetition of
  `"macosx-10.*"` style strings throughout
* Bump the minimum version of Packer from 0.6.0 to 0.7.0
* Supply a `HOME_DIR` environment variable for provisioner scripts to
  use
* Remove the optional autologin logic, which wasn't being triggered by
  default leading to less behavior "tuning knobs" in the templates
* Remove now-unused user variables `arch` and `autologin`
* Add consistent `_README` user variable to explain how to obtain and
  prepare the base disk image
* Rename all template names from `"macosx-10.*"` to `"chef/macosx-10.*"`
* Extract the `iso_checksum_type` into a user variable and reference it
  in the templates
* Call all provider scripts with `sh -eux` which will: (e) exit
  immediately if a command exists with a non-zero exit status, (u)
  treats unset variables as a error, and (x) outputs the command and its
  expanded arguments or associated word list
* Ensure that all the provider shell scripts are more conservatively
  bourne shell friendly
* Add a call to VMware's `vmware-tools-cli disk shrink` command in
  `scripts/macosx/minimize.sh` if the provider is vmware-based