### PR TITLE
[ubuntu-*] Improve DRYness, correctness, and speed of Ubuntu templates.

### DIFF
--- a/scripts/common/metadata.sh
+++ b/scripts/common/metadata.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -eux
 
-mkdir -p /etc
-cp /tmp/bento-metadata.json /etc/bento-metadata.json
-chmod 0444 /etc/bento-metadata.json
-rm -f /tmp/bento-metadata.json
+mkdir -p /etc;
+cp /tmp/bento-metadata.json /etc/bento-metadata.json;
+chmod 0444 /etc/bento-metadata.json;
+rm -f /tmp/bento-metadata.json;

--- a/scripts/common/minimize.sh
+++ b/scripts/common/minimize.sh
@@ -1,15 +1,15 @@
 #!/bin/sh -eux
 
-# Whiteout the swap partition to reduce box size 
-# Swap is disabled till reboot 
-readonly swapuuid=$(/sbin/blkid -o value -l -s UUID -t TYPE=swap)
-readonly swappart=$(readlink -f /dev/disk/by-uuid/"$swapuuid")
-/sbin/swapoff "$swappart"
-dd if=/dev/zero of="$swappart" bs=1M || echo "dd exit code $? is suppressed" 
-/sbin/mkswap -U "$swapuuid" "$swappart"
+# Whiteout the swap partition to reduce box size
+# Swap is disabled till reboot
+swapuuid="`/sbin/blkid -o value -l -s UUID -t TYPE=swap`";
+swappart="`readlink -f /dev/disk/by-uuid/$swapuuid`";
+/sbin/swapoff "$swappart";
+dd if=/dev/zero of="$swappart" bs=1M || echo "dd exit code $? is suppressed";
+/sbin/mkswap -U "$swapuuid" "$swappart";
 
-dd if=/dev/zero of=/EMPTY bs=1M
-rm -f /EMPTY
+dd if=/dev/zero of=/EMPTY bs=1M || echo "dd exit code $? is suppressed";
+rm -f /EMPTY;
 # Block until the empty file has been removed, otherwise, Packer
 # will try to kill the box while the disk is still full and that's bad
-sync
+sync;

--- a/scripts/common/sshd.sh
+++ b/scripts/common/sshd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eux
+#!/bin/sh -eux
 
-echo "UseDNS no" >> /etc/ssh/sshd_config
-echo "GSSAPIAuthentication no" >> /etc/ssh/sshd_config
+echo "UseDNS no" >>/etc/ssh/sshd_config;
+echo "GSSAPIAuthentication no" >>/etc/ssh/sshd_config;

--- a/scripts/common/vmtools.sh
+++ b/scripts/common/vmtools.sh
@@ -4,9 +4,11 @@ case "$PACKER_BUILDER_TYPE" in
 
 virtualbox-iso|virtualbox-ovf)
     mkdir /tmp/vbox
-    VER=$(cat /home/vagrant/.vbox_version)
+    VER="`cat /home/vagrant/.vbox_version`"
     mount -o loop /home/vagrant/VBoxGuestAdditions_$VER.iso /tmp/vbox
-    sh /tmp/vbox/VBoxLinuxAdditions.run
+    sh /tmp/vbox/VBoxLinuxAdditions.run \
+        || echo "VBoxLinuxAdditions.run exited $? and is suppressed." \
+            "For more read https://www.virtualbox.org/ticket/12479"
     umount /tmp/vbox
     rmdir /tmp/vbox
     rm /home/vagrant/*.iso

--- a/scripts/ubuntu/cleanup.sh
+++ b/scripts/ubuntu/cleanup.sh
@@ -1,34 +1,45 @@
-#!/bin/bash -eux
+#!/bin/sh -eux
 
-# delete all linux headers
-dpkg --list | awk '{ print $2 }' | grep linux-headers | xargs apt-get -y purge
+# Delete all Linux headers
+dpkg --list \
+  | awk '{ print $2 }' \
+  | grep 'linux-headers' \
+  | xargs apt-get -y purge;
 
-# this removes specific linux kernels, such as
-# linux-image-3.11.0-15-generic but 
-# * keeps the current kernel
-# * does not touch the virtual packages, e.g.'linux-image-generic', etc.
-#
-dpkg --list | awk '{ print $2 }' | grep 'linux-image-3.*-generic' | grep -v `uname -r` | xargs apt-get -y purge
+# Remove specific Linux kernels, such as linux-image-3.11.0-15-generic but
+# keeps the current kernel and does not touch the virtual packages,
+# e.g. 'linux-image-generic', etc.
+dpkg --list \
+    | awk '{ print $2 }' \
+    | grep 'linux-image-3.*-generic' \
+    | grep -v `uname -r` \
+    | xargs apt-get -y purge;
 
-# delete linux source
-dpkg --list | awk '{ print $2 }' | grep linux-source | xargs apt-get -y purge
+# Delete Linux source
+dpkg --list \
+    | awk '{ print $2 }' \
+    | grep linux-source \
+    | xargs apt-get -y purge;
 
-# delete development packages
-dpkg --list | awk '{ print $2 }' | grep -- '-dev$' | xargs apt-get -y purge
+# Delete development packages
+dpkg --list \
+    | awk '{ print $2 }' \
+    | grep -- '-dev$' \
+    | xargs apt-get -y purge;
 
-# delete compilers and other development tools
-apt-get -y purge cpp gcc g++
+# Delete compilers and other development tools
+apt-get -y purge cpp gcc g++;
 
-# delete X11 libraries
-apt-get -y purge libx11-data xauth libxmuu1 libxcb1 libx11-6 libxext6
+# Delete X11 libraries
+apt-get -y purge libx11-data xauth libxmuu1 libxcb1 libx11-6 libxext6;
 
-# delete obsolete networking
-apt-get -y purge ppp pppconfig pppoeconf
+# Delete obsolete networking
+apt-get -y purge ppp pppconfig pppoeconf;
 
-# delete oddities
-apt-get -y purge popularity-contest
+# Delete oddities
+apt-get -y purge popularity-contest;
 
-apt-get -y autoremove
-apt-get -y clean
-rm -rf VBoxGuestAdditions_*.iso VBoxGuestAdditions_*.iso.?
-rm -f /tmp/chef*deb
+apt-get -y autoremove;
+apt-get -y clean;
+
+rm -f VBoxGuestAdditions_*.iso VBoxGuestAdditions_*.iso.?;

--- a/scripts/ubuntu/networking.sh
+++ b/scripts/ubuntu/networking.sh
@@ -1,7 +1,11 @@
-#!/bin/bash -eux
+#!/bin/sh -eux
 
-rm /etc/udev/rules.d/70-persistent-net.rules
-mkdir /etc/udev/rules.d/70-persistent-net.rules
-rm /lib/udev/rules.d/75-persistent-net-generator.rules
-rm -rf /dev/.udev/ /var/lib/dhcp3/*
-echo "pre-up sleep 2" >> /etc/network/interfaces
+# Disable automatic udev rules for network interfaces in Ubuntu,
+# source: http://6.ptmc.org/164/
+rm -f /etc/udev/rules.d/70-persistent-net.rules;
+mkdir -p /etc/udev/rules.d/70-persistent-net.rules;
+rm -f /lib/udev/rules.d/75-persistent-net-generator.rules;
+rm -rf /dev/.udev/ /var/lib/dhcp3/*;
+
+# Adding a 2 sec delay to the interface up, to make the dhclient happy
+echo "pre-up sleep 2" >>/etc/network/interfaces;

--- a/scripts/ubuntu/sudoers.sh
+++ b/scripts/ubuntu/sudoers.sh
@@ -1,17 +1,11 @@
-#!/bin/bash -eux
+#!/bin/sh -eux
 
-# https://help.ubuntu.com/community/CheckingYourUbuntuVersion
-if [ lsb_release > /dev/null 2>&1 ]
-then
-  # Get the major version (like "12" from the version string (like "12.04")
-  major_version=$(lsb_release -r | cut -f 2 | cut -d . -f 1)
-fi
+major_version="`lsb_release -r | awk '{print $2}' | awk -F. '{print $1}'`";
 
-if [ ! -z "$major_version" -a "$major_version" -lt 12 ]
-then
-  sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=admin' /etc/sudoers
-  sed -i -e 's/%admin\s*ALL=(ALL) ALL/%admin\tALL=(ALL) NOPASSWD:ALL/g' /etc/sudoers
+if [ ! -z "$major_version" -a "$major_version" -lt 12 ]; then
+    sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=admin' /etc/sudoers;
+    sed -i -e 's/%admin\s*ALL=(ALL) ALL/%admin\tALL=(ALL) NOPASSWD:ALL/g' /etc/sudoers;
 else
-  sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=sudo' /etc/sudoers
-  sed -i -e 's/%sudo\s*ALL=(ALL:ALL) ALL/%sudo\tALL=(ALL) NOPASSWD:ALL/g' /etc/sudoers
+    sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=sudo' /etc/sudoers;
+    sed -i -e 's/%sudo\s*ALL=(ALL:ALL) ALL/%sudo\tALL=(ALL) NOPASSWD:ALL/g' /etc/sudoers;
 fi

--- a/scripts/ubuntu/vagrant.sh
+++ b/scripts/ubuntu/vagrant.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -eux
+
+pubkey_url="https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub";
+mkdir -p $HOME_DIR/.ssh;
+if command -v wget >/dev/null 2>&1; then
+    wget --no-check-certificate "$pubkey_url" -O $HOME_DIR/.ssh/authorized_keys;
+elif command -v curl >/dev/null 2>&1; then
+    curl --insecure --location "$pubkey_url" > $HOME_DIR/.ssh/authorized_keys;
+else
+    echo "Cannot download vagrant public key";
+    exit 1;
+fi
+chown -R vagrant $HOME_DIR/.ssh;
+chmod -R go-rwsx $HOME_DIR/.ssh;

--- a/ubuntu-10.04-amd64.json
+++ b/ubuntu-10.04-amd64.json
@@ -21,7 +21,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-10.04/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -31,11 +31,11 @@
       "guest_os_type": "Ubuntu_64",
       "hard_drive_interface": "sata",
       "http_directory": "http",
-      "iso_checksum": "796e80702d65f2ee96e88874a1ab437e24df9cd6",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/10.04.4/ubuntu-10.04.4-server-amd64.iso",
-      "output_directory": "packer-ubuntu-10.04-amd64-virtualbox",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-virtualbox",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -56,7 +56,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-10.04-amd64"
+      "vm_name": "packer-{{user `template`}}-virtualbox"
     },
     {
       "boot_command": [
@@ -79,7 +79,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-10.04/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -87,18 +87,18 @@
       "disk_size": 40960,
       "guest_os_type": "ubuntu-64",
       "http_directory": "http",
-      "iso_checksum": "796e80702d65f2ee96e88874a1ab437e24df9cd6",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/10.04.4/ubuntu-10.04.4-server-amd64.iso",
-      "output_directory": "packer-ubuntu-10.04-amd64-vmware",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-vmware",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-ubuntu-10.04-amd64",
+      "vm_name": "packer-{{user `template`}}-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -126,7 +126,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-10.04/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -134,10 +134,10 @@
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
       "http_directory": "http",
-      "iso_checksum": "796e80702d65f2ee96e88874a1ab437e24df9cd6",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/10.04.4/ubuntu-10.04.4-server-amd64.iso",
-      "output_directory": "packer-ubuntu-10.04-amd64-parallels",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "prlctl": [
         [
@@ -154,13 +154,13 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-ubuntu-10.04-amd64"
+      "vm_name": "packer-{{user `template`}}-parallels"
     }
   ],
   "post-processors": [
@@ -176,15 +176,20 @@
       "type": "file"
     },
     {
-      "environment_vars": [],
-      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
+      "environment_vars": [
+        "HOME_DIR=/home/vagrant",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/common/metadata.sh",
         "scripts/ubuntu/update.sh",
         "scripts/common/sshd.sh",
         "scripts/ubuntu/networking.sh",
         "scripts/ubuntu/sudoers.sh",
-        "scripts/common/vagrant.sh",
+        "scripts/ubuntu/vagrant.sh",
         "scripts/common/vmtools.sh",
         "scripts/ubuntu/cleanup.sh",
         "scripts/common/minimize.sh"
@@ -193,15 +198,22 @@
     }
   ],
   "variables": {
-    "arch": "64",
-    "box_basename": "ubuntu-10.04",
+    "box_basename": "__unset_box_basename__",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "iso_checksum": "796e80702d65f2ee96e88874a1ab437e24df9cd6",
+    "iso_checksum_type": "sha1",
+    "iso_name": "ubuntu-10.04.4-server-amd64.iso",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
-    "name": "ubuntu-10.04",
+    "mirror_directory": "10.04.4",
+    "name": "chef/ubuntu-10.04",
+    "no_proxy": "{{env `no_proxy`}}",
+    "preseed_path": "ubuntu-10.04/preseed.cfg",
     "template": "ubuntu-10.04-amd64",
-    "version": "2.0.TIMESTAMP"
+    "version": "2.1.TIMESTAMP"
   }
 }
 

--- a/ubuntu-10.04-i386.json
+++ b/ubuntu-10.04-i386.json
@@ -21,7 +21,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-10.04/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -31,11 +31,11 @@
       "guest_os_type": "Ubuntu",
       "hard_drive_interface": "sata",
       "http_directory": "http",
-      "iso_checksum": "5695d8b6b914269d1374ac8d4c3dd3786e92d3fe",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/10.04.4/ubuntu-10.04.4-server-i386.iso",
-      "output_directory": "packer-ubuntu-10.04-i386-virtualbox",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-virtualbox",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -56,7 +56,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-10.04-i386"
+      "vm_name": "packer-{{user `template`}}-virtualbox"
     },
     {
       "boot_command": [
@@ -79,7 +79,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-10.04/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -87,18 +87,18 @@
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
       "http_directory": "http",
-      "iso_checksum": "5695d8b6b914269d1374ac8d4c3dd3786e92d3fe",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/10.04.4/ubuntu-10.04.4-server-i386.iso",
-      "output_directory": "packer-ubuntu-10.04-i386-vmware",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-vmware",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-ubuntu-10.04-i386",
+      "vm_name": "packer-{{user `template`}}-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -126,7 +126,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-10.04/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -134,10 +134,10 @@
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
       "http_directory": "http",
-      "iso_checksum": "5695d8b6b914269d1374ac8d4c3dd3786e92d3fe",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/10.04.4/ubuntu-10.04.4-server-i386.iso",
-      "output_directory": "packer-ubuntu-10.04-i386-parallels",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "prlctl": [
         [
@@ -154,13 +154,13 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-ubuntu-10.04-i386"
+      "vm_name": "packer-{{user `template`}}-parallels"
     }
   ],
   "post-processors": [
@@ -176,15 +176,20 @@
       "type": "file"
     },
     {
-      "environment_vars": [],
-      "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'",
+      "environment_vars": [
+        "HOME_DIR=/home/vagrant",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/common/metadata.sh",
         "scripts/ubuntu/update.sh",
         "scripts/common/sshd.sh",
         "scripts/ubuntu/networking.sh",
         "scripts/ubuntu/sudoers.sh",
-        "scripts/common/vagrant.sh",
+        "scripts/ubuntu/vagrant.sh",
         "scripts/common/vmtools.sh",
         "scripts/ubuntu/cleanup.sh",
         "scripts/common/minimize.sh"
@@ -193,15 +198,22 @@
     }
   ],
   "variables": {
-    "arch": "32",
-    "box_basename": "ubuntu-10.04-i386",
+    "box_basename": "__unset_box_basename__",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "iso_checksum": "5695d8b6b914269d1374ac8d4c3dd3786e92d3fe",
+    "iso_checksum_type": "sha1",
+    "iso_name": "ubuntu-10.04.4-server-i386.iso",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
-    "name": "ubuntu-10.04-i386",
+    "mirror_directory": "10.04.4",
+    "name": "chef/ubuntu-10.04-i386",
+    "no_proxy": "{{env `no_proxy`}}",
+    "preseed_path": "ubuntu-10.04/preseed.cfg",
     "template": "ubuntu-10.04-i386",
-    "version": "2.0.TIMESTAMP"
+    "version": "2.1.TIMESTAMP"
   }
 }
 

--- a/ubuntu-12.04-amd64.json
+++ b/ubuntu-12.04-amd64.json
@@ -21,21 +21,21 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-12.04/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "guest_additions_path": "VBoxGuestAdditions_{{ .Version }}.iso",
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "guest_os_type": "Ubuntu_64",
       "hard_drive_interface": "sata",
       "http_directory": "http",
-      "iso_checksum": "7540ace2d6cdee264432f5ed987236d32edef798",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/12.04.5/ubuntu-12.04.5-server-amd64.iso",
-      "output_directory": "packer-ubuntu-12.04-amd64-virtualbox",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-virtualbox",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -56,7 +56,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-12.04-amd64"
+      "vm_name": "packer-{{user `template`}}-virtualbox"
     },
     {
       "boot_command": [
@@ -79,7 +79,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-12.04/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -87,18 +87,18 @@
       "disk_size": 40960,
       "guest_os_type": "ubuntu-64",
       "http_directory": "http",
-      "iso_checksum": "7540ace2d6cdee264432f5ed987236d32edef798",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/12.04.5/ubuntu-12.04.5-server-amd64.iso",
-      "output_directory": "packer-ubuntu-12.04-amd64-vmware",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-vmware",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-ubuntu-12.04-amd64",
+      "vm_name": "packer-{{user `template`}}-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -126,7 +126,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-12.04/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -134,10 +134,10 @@
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
       "http_directory": "http",
-      "iso_checksum": "7540ace2d6cdee264432f5ed987236d32edef798",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/12.04.5/ubuntu-12.04.5-server-amd64.iso",
-      "output_directory": "packer-ubuntu-12.04-amd64-parallels",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "prlctl": [
         [
@@ -154,13 +154,13 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-ubuntu-12.04-amd64"
+      "vm_name": "packer-{{user `template`}}-parallels"
     }
   ],
   "post-processors": [
@@ -176,15 +176,20 @@
       "type": "file"
     },
     {
-      "environment_vars": [],
-      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
+      "environment_vars": [
+        "HOME_DIR=/home/vagrant",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/common/metadata.sh",
         "scripts/ubuntu/update.sh",
         "scripts/common/sshd.sh",
         "scripts/ubuntu/networking.sh",
         "scripts/ubuntu/sudoers.sh",
-        "scripts/common/vagrant.sh",
+        "scripts/ubuntu/vagrant.sh",
         "scripts/common/vmtools.sh",
         "scripts/ubuntu/cleanup.sh",
         "scripts/common/minimize.sh"
@@ -193,15 +198,22 @@
     }
   ],
   "variables": {
-    "arch": "64",
-    "box_basename": "ubuntu-12.04",
+    "box_basename": "__unset_box_basename__",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "iso_checksum": "7540ace2d6cdee264432f5ed987236d32edef798",
+    "iso_checksum_type": "sha1",
+    "iso_name": "ubuntu-12.04.5-server-amd64.iso",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
-    "name": "ubuntu-12.04",
+    "mirror_directory": "12.04.5",
+    "name": "chef/ubuntu-12.04",
+    "no_proxy": "{{env `no_proxy`}}",
+    "preseed_path": "ubuntu-12.04/preseed.cfg",
     "template": "ubuntu-12.04-amd64",
-    "version": "2.0.TIMESTAMP"
+    "version": "2.1.TIMESTAMP"
   }
 }
 

--- a/ubuntu-12.04-i386.json
+++ b/ubuntu-12.04-i386.json
@@ -21,7 +21,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-12.04/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -31,11 +31,11 @@
       "guest_os_type": "Ubuntu",
       "hard_drive_interface": "sata",
       "http_directory": "http",
-      "iso_checksum": "a34c224b7fe72a2f5c768be5afee5c53817743fd",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/12.04.5/ubuntu-12.04.5-server-i386.iso",
-      "output_directory": "packer-ubuntu-12.04-i386-virtualbox",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-virtualbox",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -56,7 +56,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-12.04-i386"
+      "vm_name": "packer-{{user `template`}}-virtualbox"
     },
     {
       "boot_command": [
@@ -79,7 +79,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-12.04/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -87,18 +87,18 @@
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
       "http_directory": "http",
-      "iso_checksum": "a34c224b7fe72a2f5c768be5afee5c53817743fd",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/12.04.5/ubuntu-12.04.5-server-i386.iso",
-      "output_directory": "packer-ubuntu-12.04-i386-vmware",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-vmware",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-ubuntu-12.04-i386",
+      "vm_name": "packer-{{user `template`}}-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -126,7 +126,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-12.04/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -134,10 +134,10 @@
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
       "http_directory": "http",
-      "iso_checksum": "a34c224b7fe72a2f5c768be5afee5c53817743fd",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/12.04.5/ubuntu-12.04.5-server-i386.iso",
-      "output_directory": "packer-ubuntu-12.04-i386-parallels",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "prlctl": [
         [
@@ -154,13 +154,13 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-ubuntu-12.04-i386"
+      "vm_name": "packer-{{user `template`}}-parallels"
     }
   ],
   "post-processors": [
@@ -176,15 +176,20 @@
       "type": "file"
     },
     {
-      "environment_vars": [],
-      "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'",
+      "environment_vars": [
+        "HOME_DIR=/home/vagrant",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/common/metadata.sh",
         "scripts/ubuntu/update.sh",
         "scripts/common/sshd.sh",
         "scripts/ubuntu/networking.sh",
         "scripts/ubuntu/sudoers.sh",
-        "scripts/common/vagrant.sh",
+        "scripts/ubuntu/vagrant.sh",
         "scripts/common/vmtools.sh",
         "scripts/ubuntu/cleanup.sh",
         "scripts/common/minimize.sh"
@@ -193,15 +198,22 @@
     }
   ],
   "variables": {
-    "arch": "32",
-    "box_basename": "ubuntu-12.04-i386",
+    "box_basename": "__unset_box_basename__",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "iso_checksum": "a34c224b7fe72a2f5c768be5afee5c53817743fd",
+    "iso_checksum_type": "sha1",
+    "iso_name": "ubuntu-12.04.5-server-i386.iso",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
-    "name": "ubuntu-12.04-i386",
+    "mirror_directory": "12.04.5",
+    "name": "chef/ubuntu-12.04-i386",
+    "no_proxy": "{{env `no_proxy`}}",
+    "preseed_path": "ubuntu-12.04/preseed.cfg",
     "template": "ubuntu-12.04-i386",
-    "version": "2.0.TIMESTAMP"
+    "version": "2.1.TIMESTAMP"
   }
 }
 

--- a/ubuntu-14.04-amd64.json
+++ b/ubuntu-14.04-amd64.json
@@ -21,7 +21,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-14.04/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -31,11 +31,11 @@
       "guest_os_type": "Ubuntu_64",
       "hard_drive_interface": "sata",
       "http_directory": "http",
-      "iso_checksum": "8acd2f56bfcba2f7ac74a7e4a5e565ce68c024c38525c0285573e41c86ae90c0",
-      "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/14.04.2/ubuntu-14.04.2-server-amd64.iso",
-      "output_directory": "packer-ubuntu-14.04-amd64-virtualbox",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-virtualbox",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -56,7 +56,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-14.04-amd64"
+      "vm_name": "packer-{{user `template`}}-virtualbox"
     },
     {
       "boot_command": [
@@ -79,7 +79,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-14.04/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -87,18 +87,18 @@
       "disk_size": 40960,
       "guest_os_type": "ubuntu-64",
       "http_directory": "http",
-      "iso_checksum": "8acd2f56bfcba2f7ac74a7e4a5e565ce68c024c38525c0285573e41c86ae90c0",
-      "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/14.04.2/ubuntu-14.04.2-server-amd64.iso",
-      "output_directory": "packer-ubuntu-14.04-amd64-vmware",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-vmware",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-ubuntu-14.04-amd64",
+      "vm_name": "packer-{{user `template`}}-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -126,7 +126,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-14.04/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -134,10 +134,10 @@
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
       "http_directory": "http",
-      "iso_checksum": "8acd2f56bfcba2f7ac74a7e4a5e565ce68c024c38525c0285573e41c86ae90c0",
-      "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/14.04.2/ubuntu-14.04.2-server-amd64.iso",
-      "output_directory": "packer-ubuntu-14.04-amd64-parallels",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "prlctl": [
         [
@@ -154,13 +154,13 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-ubuntu-14.04-amd64"
+      "vm_name": "packer-{{user `template`}}-parallels"
     }
   ],
   "post-processors": [
@@ -176,15 +176,20 @@
       "type": "file"
     },
     {
-      "environment_vars": [],
-      "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'",
+      "environment_vars": [
+        "HOME_DIR=/home/vagrant",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/common/metadata.sh",
         "scripts/ubuntu/update.sh",
         "scripts/common/sshd.sh",
         "scripts/ubuntu/networking.sh",
         "scripts/ubuntu/sudoers.sh",
-        "scripts/common/vagrant.sh",
+        "scripts/ubuntu/vagrant.sh",
         "scripts/common/vmtools.sh",
         "scripts/ubuntu/cleanup.sh",
         "scripts/common/minimize.sh"
@@ -193,15 +198,22 @@
     }
   ],
   "variables": {
-    "arch": "64",
-    "box_basename": "ubuntu-14.04",
+    "box_basename": "__unset_box_basename__",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "iso_checksum": "8acd2f56bfcba2f7ac74a7e4a5e565ce68c024c38525c0285573e41c86ae90c0",
+    "iso_checksum_type": "sha256",
+    "iso_name": "ubuntu-14.04.2-server-amd64.iso",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
-    "name": "ubuntu-14.04",
+    "mirror_directory": "14.04.2",
+    "name": "chef/ubuntu-14.04",
+    "no_proxy": "{{env `no_proxy`}}",
+    "preseed_path": "ubuntu-14.04/preseed.cfg",
     "template": "ubuntu-14.04-amd64",
-    "version": "2.0.TIMESTAMP"
+    "version": "2.1.TIMESTAMP"
   }
 }
 

--- a/ubuntu-14.04-i386.json
+++ b/ubuntu-14.04-i386.json
@@ -21,7 +21,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-14.04/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -31,11 +31,11 @@
       "guest_os_type": "Ubuntu",
       "hard_drive_interface": "sata",
       "http_directory": "http",
-      "iso_checksum": "76524ab9502a34b983ed56af2d5a72835ce41aec1e2b4c0cb7788ef596958ed6",
-      "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/14.04.2/ubuntu-14.04.2-server-i386.iso",
-      "output_directory": "packer-ubuntu-14.04-i386-virtualbox",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-virtualbox",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -56,7 +56,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-14.04-i386"
+      "vm_name": "packer-{{user `template`}}-virtualbox"
     },
     {
       "boot_command": [
@@ -79,7 +79,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-14.04/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -87,18 +87,18 @@
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
       "http_directory": "http",
-      "iso_checksum": "76524ab9502a34b983ed56af2d5a72835ce41aec1e2b4c0cb7788ef596958ed6",
-      "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/14.04.2/ubuntu-14.04.2-server-i386.iso",
-      "output_directory": "packer-ubuntu-14.04-i386-vmware",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-vmware",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-ubuntu-14.04-i386",
+      "vm_name": "packer-{{user `template`}}-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -126,7 +126,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-14.04/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -134,10 +134,10 @@
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
       "http_directory": "http",
-      "iso_checksum": "76524ab9502a34b983ed56af2d5a72835ce41aec1e2b4c0cb7788ef596958ed6",
-      "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/14.04.2/ubuntu-14.04.2-server-i386.iso",
-      "output_directory": "packer-ubuntu-14.04-i386-parallels",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "prlctl": [
         [
@@ -154,13 +154,13 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-ubuntu-14.04-i386"
+      "vm_name": "packer-{{user `template`}}-parallels"
     }
   ],
   "post-processors": [
@@ -176,15 +176,20 @@
       "type": "file"
     },
     {
-      "environment_vars": [],
-      "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'",
+      "environment_vars": [
+        "HOME_DIR=/home/vagrant",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/common/metadata.sh",
         "scripts/ubuntu/update.sh",
         "scripts/common/sshd.sh",
         "scripts/ubuntu/networking.sh",
         "scripts/ubuntu/sudoers.sh",
-        "scripts/common/vagrant.sh",
+        "scripts/ubuntu/vagrant.sh",
         "scripts/common/vmtools.sh",
         "scripts/ubuntu/cleanup.sh",
         "scripts/common/minimize.sh"
@@ -193,16 +198,22 @@
     }
   ],
   "variables": {
-    "arch": "32",
-    "box_basename": "ubuntu-14.04-i386",
+    "box_basename": "__unset_box_basename__",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
-    "chef_version": "provisionerless",
     "git_revision": "__unknown_git_revision__",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "iso_checksum": "76524ab9502a34b983ed56af2d5a72835ce41aec1e2b4c0cb7788ef596958ed6",
+    "iso_checksum_type": "sha256",
+    "iso_name": "ubuntu-14.04.2-server-i386.iso",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
-    "name": "ubuntu-14.04-i386",
+    "mirror_directory": "14.04.2",
+    "name": "chef/ubuntu-14.04-i386",
+    "no_proxy": "{{env `no_proxy`}}",
+    "preseed_path": "ubuntu-14.04/preseed.cfg",
     "template": "ubuntu-14.04-i386",
-    "version": "2.0.TIMESTAMP"
+    "version": "2.1.TIMESTAMP"
   }
 }
 

--- a/ubuntu-14.10-amd64.json
+++ b/ubuntu-14.10-amd64.json
@@ -21,7 +21,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-14.10/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -31,11 +31,11 @@
       "guest_os_type": "Ubuntu_64",
       "hard_drive_interface": "sata",
       "http_directory": "http",
-      "iso_checksum": "0c1ebea31c3523cfe9a4ffed8bcf6c7d23dfb97b",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/14.10/ubuntu-14.10-server-amd64.iso",
-      "output_directory": "packer-ubuntu-14.10-amd64-virtualbox",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-virtualbox",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -56,7 +56,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-14.10-amd64"
+      "vm_name": "packer-{{user `template`}}-virtualbox"
     },
     {
       "boot_command": [
@@ -79,7 +79,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-14.10/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -87,18 +87,18 @@
       "disk_size": 40960,
       "guest_os_type": "ubuntu-64",
       "http_directory": "http",
-      "iso_checksum": "0c1ebea31c3523cfe9a4ffed8bcf6c7d23dfb97b",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/14.10/ubuntu-14.10-server-amd64.iso",
-      "output_directory": "packer-ubuntu-14.10-amd64-vmware",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-vmware",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-ubuntu-14.10-amd64",
+      "vm_name": "packer-{{user `template`}}-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -126,7 +126,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-14.10/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -134,10 +134,10 @@
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
       "http_directory": "http",
-      "iso_checksum": "0c1ebea31c3523cfe9a4ffed8bcf6c7d23dfb97b",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/14.10/ubuntu-14.10-server-amd64.iso",
-      "output_directory": "packer-ubuntu-14.10-amd64-parallels",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "prlctl": [
         [
@@ -154,13 +154,13 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-ubuntu-14.10-amd64"
+      "vm_name": "packer-{{user `template`}}-parallels"
     }
   ],
   "post-processors": [
@@ -176,15 +176,20 @@
       "type": "file"
     },
     {
-      "environment_vars": [],
-      "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'",
+      "environment_vars": [
+        "HOME_DIR=/home/vagrant",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/common/metadata.sh",
         "scripts/ubuntu/update.sh",
         "scripts/common/sshd.sh",
         "scripts/ubuntu/networking.sh",
         "scripts/ubuntu/sudoers.sh",
-        "scripts/common/vagrant.sh",
+        "scripts/ubuntu/vagrant.sh",
         "scripts/common/vmtools.sh",
         "scripts/ubuntu/cleanup.sh",
         "scripts/common/minimize.sh"
@@ -193,15 +198,22 @@
     }
   ],
   "variables": {
-    "arch": "64",
-    "box_basename": "ubuntu-14.10",
+    "box_basename": "__unset_box_basename__",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "iso_checksum": "0c1ebea31c3523cfe9a4ffed8bcf6c7d23dfb97b",
+    "iso_checksum_type": "sha1",
+    "iso_name": "ubuntu-14.10-server-amd64.iso",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
-    "name": "ubuntu-14.10",
+    "mirror_directory": "14.10",
+    "name": "chef/ubuntu-14.10",
+    "no_proxy": "{{env `no_proxy`}}",
+    "preseed_path": "ubuntu-14.10/preseed.cfg",
     "template": "ubuntu-14.10-amd64",
-    "version": "2.0.TIMESTAMP"
+    "version": "2.1.TIMESTAMP"
   }
 }
 

--- a/ubuntu-14.10-i386.json
+++ b/ubuntu-14.10-i386.json
@@ -21,7 +21,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-14.10/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -31,11 +31,11 @@
       "guest_os_type": "Ubuntu",
       "hard_drive_interface": "sata",
       "http_directory": "http",
-      "iso_checksum": "26faf47df2162f4ff83e38e6831dd169da6db95f",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/14.10/ubuntu-14.10-server-i386.iso",
-      "output_directory": "packer-ubuntu-14.10-i386-virtualbox",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-virtualbox",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -56,7 +56,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-14.10-i386"
+      "vm_name": "packer-{{user `template`}}-virtualbox"
     },
     {
       "boot_command": [
@@ -79,7 +79,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-14.10/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -87,18 +87,18 @@
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
       "http_directory": "http",
-      "iso_checksum": "26faf47df2162f4ff83e38e6831dd169da6db95f",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/14.10/ubuntu-14.10-server-i386.iso",
-      "output_directory": "packer-ubuntu-14.10-i386-vmware",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-vmware",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-ubuntu-14.10-i386",
+      "vm_name": "packer-{{user `template`}}-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -126,7 +126,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-14.10/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -134,10 +134,10 @@
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
       "http_directory": "http",
-      "iso_checksum": "26faf47df2162f4ff83e38e6831dd169da6db95f",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/14.10/ubuntu-14.10-server-i386.iso",
-      "output_directory": "packer-ubuntu-14.10-i386-parallels",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "prlctl": [
         [
@@ -154,13 +154,13 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-ubuntu-14.10-i386"
+      "vm_name": "packer-{{user `template`}}-parallels"
     }
   ],
   "post-processors": [
@@ -176,15 +176,20 @@
       "type": "file"
     },
     {
-      "environment_vars": [],
-      "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'",
+      "environment_vars": [
+        "HOME_DIR=/home/vagrant",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/common/metadata.sh",
         "scripts/ubuntu/update.sh",
         "scripts/common/sshd.sh",
         "scripts/ubuntu/networking.sh",
         "scripts/ubuntu/sudoers.sh",
-        "scripts/common/vagrant.sh",
+        "scripts/ubuntu/vagrant.sh",
         "scripts/common/vmtools.sh",
         "scripts/ubuntu/cleanup.sh",
         "scripts/common/minimize.sh"
@@ -193,15 +198,22 @@
     }
   ],
   "variables": {
-    "arch": "32",
-    "box_basename": "ubuntu-14.10-i386",
+    "box_basename": "__unset_box_basename__",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "iso_checksum": "26faf47df2162f4ff83e38e6831dd169da6db95f",
+    "iso_checksum_type": "sha1",
+    "iso_name": "ubuntu-14.10-server-i386.iso",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
-    "name": "ubuntu-14.10-i386",
+    "mirror_directory": "14.10",
+    "name": "chef/ubuntu-14.10-i386",
+    "no_proxy": "{{env `no_proxy`}}",
+    "preseed_path": "ubuntu-14.10/preseed.cfg",
     "template": "ubuntu-14.10-i386",
-    "version": "2.0.TIMESTAMP"
+    "version": "2.1.TIMESTAMP"
   }
 }
 

--- a/ubuntu-15.04-amd64.json
+++ b/ubuntu-15.04-amd64.json
@@ -21,7 +21,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-15.04/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -31,11 +31,11 @@
       "guest_os_type": "Ubuntu_64",
       "hard_drive_interface": "sata",
       "http_directory": "http",
-      "iso_checksum": "6501c8545374665823384bbb6235f865108f56d8a30bbf69dd18df73c14ccb84",
-      "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/15.04/ubuntu-15.04-server-amd64.iso",
-      "output_directory": "packer-ubuntu-15.04-amd64-virtualbox",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-virtualbox",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -56,7 +56,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-15.04-amd64"
+      "vm_name": "packer-{{user `template`}}-virtualbox"
     },
     {
       "boot_command": [
@@ -79,7 +79,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-15.04/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -87,18 +87,18 @@
       "disk_size": 40960,
       "guest_os_type": "ubuntu-64",
       "http_directory": "http",
-      "iso_checksum": "6501c8545374665823384bbb6235f865108f56d8a30bbf69dd18df73c14ccb84",
-      "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/15.04/ubuntu-15.04-server-amd64.iso",
-      "output_directory": "packer-ubuntu-15.04-amd64-vmware",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-vmware",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-ubuntu-15.04-amd64",
+      "vm_name": "packer-{{user `template`}}-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -126,7 +126,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-15.04/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -134,10 +134,10 @@
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
       "http_directory": "http",
-      "iso_checksum": "6501c8545374665823384bbb6235f865108f56d8a30bbf69dd18df73c14ccb84",
-      "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/15.04/ubuntu-15.04-server-amd64.iso",
-      "output_directory": "packer-ubuntu-15.04-amd64-parallels",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "prlctl": [
         [
@@ -154,13 +154,13 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-ubuntu-15.04-amd64"
+      "vm_name": "packer-{{user `template`}}-parallels"
     }
   ],
   "post-processors": [
@@ -176,15 +176,20 @@
       "type": "file"
     },
     {
-      "environment_vars": [],
-      "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'",
+      "environment_vars": [
+        "HOME_DIR=/home/vagrant",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/common/metadata.sh",
         "scripts/ubuntu/update.sh",
         "scripts/common/sshd.sh",
         "scripts/ubuntu/networking.sh",
         "scripts/ubuntu/sudoers.sh",
-        "scripts/common/vagrant.sh",
+        "scripts/ubuntu/vagrant.sh",
         "scripts/common/vmtools.sh",
         "scripts/ubuntu/cleanup.sh",
         "scripts/common/minimize.sh"
@@ -193,15 +198,22 @@
     }
   ],
   "variables": {
-    "arch": "64",
-    "box_basename": "ubuntu-15.04",
+    "box_basename": "__unset_box_basename__",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "iso_checksum": "6501c8545374665823384bbb6235f865108f56d8a30bbf69dd18df73c14ccb84",
+    "iso_checksum_type": "sha256",
+    "iso_name": "ubuntu-15.04-server-amd64.iso",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
-    "name": "ubuntu-15.04",
+    "mirror_directory": "15.04",
+    "name": "chef/ubuntu-15.04",
+    "no_proxy": "{{env `no_proxy`}}",
+    "preseed_path": "ubuntu-15.04/preseed.cfg",
     "template": "ubuntu-15.04-amd64",
-    "version": "2.0.TIMESTAMP"
+    "version": "2.1.TIMESTAMP"
   }
 }
 

--- a/ubuntu-15.04-i386.json
+++ b/ubuntu-15.04-i386.json
@@ -21,7 +21,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-15.04/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -31,11 +31,11 @@
       "guest_os_type": "Ubuntu",
       "hard_drive_interface": "sata",
       "http_directory": "http",
-      "iso_checksum": "f510169ddc03121d11a627ae3a231e1272d8e4d75f9ef76f73daa5b809c5b6d8",
-      "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/15.04/ubuntu-15.04-server-i386.iso",
-      "output_directory": "packer-ubuntu-15.04-i386-virtualbox",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-virtualbox",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -56,7 +56,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-ubuntu-15.04-i386"
+      "vm_name": "packer-{{user `template`}}-virtualbox"
     },
     {
       "boot_command": [
@@ -79,7 +79,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-15.04/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -87,18 +87,18 @@
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
       "http_directory": "http",
-      "iso_checksum": "f510169ddc03121d11a627ae3a231e1272d8e4d75f9ef76f73daa5b809c5b6d8",
-      "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/15.04/ubuntu-15.04-server-i386.iso",
-      "output_directory": "packer-ubuntu-15.04-i386-vmware",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-vmware",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-ubuntu-15.04-i386",
+      "vm_name": "packer-{{user `template`}}-vmware",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -126,7 +126,7 @@
         " netcfg/get_domain=vm<wait>",
         " netcfg/get_hostname=vagrant<wait>",
         " noapic<wait>",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-15.04/preseed.cfg<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}}<wait>",
         " -- <wait>",
         "<enter><wait>"
       ],
@@ -134,10 +134,10 @@
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
       "http_directory": "http",
-      "iso_checksum": "f510169ddc03121d11a627ae3a231e1272d8e4d75f9ef76f73daa5b809c5b6d8",
-      "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/15.04/ubuntu-15.04-server-i386.iso",
-      "output_directory": "packer-ubuntu-15.04-i386-parallels",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "prlctl": [
         [
@@ -154,13 +154,13 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
-      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-ubuntu-15.04-i386"
+      "vm_name": "packer-{{user `template`}}-parallels"
     }
   ],
   "post-processors": [
@@ -176,15 +176,20 @@
       "type": "file"
     },
     {
-      "environment_vars": [],
-      "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'",
+      "environment_vars": [
+        "HOME_DIR=/home/vagrant",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/common/metadata.sh",
         "scripts/ubuntu/update.sh",
         "scripts/common/sshd.sh",
         "scripts/ubuntu/networking.sh",
         "scripts/ubuntu/sudoers.sh",
-        "scripts/common/vagrant.sh",
+        "scripts/ubuntu/vagrant.sh",
         "scripts/common/vmtools.sh",
         "scripts/ubuntu/cleanup.sh",
         "scripts/common/minimize.sh"
@@ -193,15 +198,22 @@
     }
   ],
   "variables": {
-    "arch": "32",
-    "box_basename": "ubuntu-15.04-i386",
+    "box_basename": "__unset_box_basename__",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "iso_checksum": "f510169ddc03121d11a627ae3a231e1272d8e4d75f9ef76f73daa5b809c5b6d8",
+    "iso_checksum_type": "sha256",
+    "iso_name": "ubuntu-15.04-server-i386.iso",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
-    "name": "ubuntu-15.04-i386",
+    "mirror_directory": "15.04",
+    "name": "chef/ubuntu-15.04-i386",
+    "no_proxy": "{{env `no_proxy`}}",
+    "preseed_path": "ubuntu-15.04/preseed.cfg",
     "template": "ubuntu-15.04-i386",
-    "version": "2.0.TIMESTAMP"
+    "version": "2.1.TIMESTAMP"
   }
 }
 


### PR DESCRIPTION
The following improvements are made in this commit:

* Ensure that all related provisioner shell scripts are written using
  more conservative bourne coding idioms
* Call all provisioner scripts with `sh -eux` which will: (e) exit
  immeditately if a command exits with a non-zero exit status, (u)
  treats unset variables as an error, and (x) outputs the command and
  its expanded arguments or associated word list
* Use the `template` user variable to replace repetition of
  `"ubuntu-*"`style strings throughout
* Support a `HOME_DIR` environment variable for provisioner scripts to
  use
* Remove now-unused user variable `arch`
* Rename all template names from `"ubuntu-*"` to `"chef/ubuntu-*"`
* Extract the `iso_checksum` and `iso_checksum_type` into user
  variables and reference them in the templates
* Construct the `iso_url` value from the `mirror`, `mirror_directory`,
  and `iso_name` user variables
* Add a `preseed_path` user variable and use it throughout the templates
* Add an `iso_name` user variable and use it throughout the templates
* Use the `http_proxy`, `https_proxy`, and `no_proxy` environment
  variables if set on the workstation and make them available to the
  provisioner shell scripts to speed up package installations, etc.