### PR TITLE
[macosx-*, ubuntu-*] Remove name prefixes from templates.

### DIFF
--- a/macosx-10.10.json
+++ b/macosx-10.10.json
@@ -198,7 +198,7 @@
     "iso_checksum_type": "md5",
     "iso_url": "http://YOU-MUST-PROVIDE-YOUR-OWN-DMG.sorry",
     "metadata": "floppy/dummy_metadata.json",
-    "name": "chef/macosx-10.10",
+    "name": "macosx-10.10",
     "no_proxy": "{{env `no_proxy`}}",
     "template": "macosx-10.10",
     "version": "2.1.TIMESTAMP"

--- a/macosx-10.7.json
+++ b/macosx-10.7.json
@@ -198,7 +198,7 @@
     "iso_checksum_type": "md5",
     "iso_url": "http://YOU-MUST-PROVIDE-YOUR-OWN-DMG.sorry",
     "metadata": "floppy/dummy_metadata.json",
-    "name": "chef/macosx-10.7",
+    "name": "macosx-10.7",
     "no_proxy": "{{env `no_proxy`}}",
     "template": "macosx-10.7",
     "version": "2.1.TIMESTAMP"

--- a/macosx-10.8.json
+++ b/macosx-10.8.json
@@ -198,7 +198,7 @@
     "iso_checksum_type": "md5",
     "iso_url": "http://YOU-MUST-PROVIDE-YOUR-OWN-DMG.sorry",
     "metadata": "floppy/dummy_metadata.json",
-    "name": "chef/macosx-10.8",
+    "name": "macosx-10.8",
     "no_proxy": "{{env `no_proxy`}}",
     "template": "macosx-10.8",
     "version": "2.1.TIMESTAMP"

--- a/macosx-10.9.json
+++ b/macosx-10.9.json
@@ -198,7 +198,7 @@
     "iso_checksum_type": "md5",
     "iso_url": "http://YOU-MUST-PROVIDE-YOUR-OWN-DMG.sorry",
     "metadata": "floppy/dummy_metadata.json",
-    "name": "chef/macosx-10.9",
+    "name": "macosx-10.9",
     "no_proxy": "{{env `no_proxy`}}",
     "template": "macosx-10.9",
     "version": "2.1.TIMESTAMP"

--- a/ubuntu-10.04-amd64.json
+++ b/ubuntu-10.04-amd64.json
@@ -209,7 +209,7 @@
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
     "mirror_directory": "10.04.4",
-    "name": "chef/ubuntu-10.04",
+    "name": "ubuntu-10.04",
     "no_proxy": "{{env `no_proxy`}}",
     "preseed_path": "ubuntu-10.04/preseed.cfg",
     "template": "ubuntu-10.04-amd64",

--- a/ubuntu-10.04-i386.json
+++ b/ubuntu-10.04-i386.json
@@ -209,7 +209,7 @@
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
     "mirror_directory": "10.04.4",
-    "name": "chef/ubuntu-10.04-i386",
+    "name": "ubuntu-10.04-i386",
     "no_proxy": "{{env `no_proxy`}}",
     "preseed_path": "ubuntu-10.04/preseed.cfg",
     "template": "ubuntu-10.04-i386",

--- a/ubuntu-12.04-amd64.json
+++ b/ubuntu-12.04-amd64.json
@@ -209,7 +209,7 @@
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
     "mirror_directory": "12.04.5",
-    "name": "chef/ubuntu-12.04",
+    "name": "ubuntu-12.04",
     "no_proxy": "{{env `no_proxy`}}",
     "preseed_path": "ubuntu-12.04/preseed.cfg",
     "template": "ubuntu-12.04-amd64",

--- a/ubuntu-12.04-i386.json
+++ b/ubuntu-12.04-i386.json
@@ -209,7 +209,7 @@
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
     "mirror_directory": "12.04.5",
-    "name": "chef/ubuntu-12.04-i386",
+    "name": "ubuntu-12.04-i386",
     "no_proxy": "{{env `no_proxy`}}",
     "preseed_path": "ubuntu-12.04/preseed.cfg",
     "template": "ubuntu-12.04-i386",

--- a/ubuntu-14.04-amd64.json
+++ b/ubuntu-14.04-amd64.json
@@ -209,7 +209,7 @@
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
     "mirror_directory": "14.04.2",
-    "name": "chef/ubuntu-14.04",
+    "name": "ubuntu-14.04",
     "no_proxy": "{{env `no_proxy`}}",
     "preseed_path": "ubuntu-14.04/preseed.cfg",
     "template": "ubuntu-14.04-amd64",

--- a/ubuntu-14.04-i386.json
+++ b/ubuntu-14.04-i386.json
@@ -209,7 +209,7 @@
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
     "mirror_directory": "14.04.2",
-    "name": "chef/ubuntu-14.04-i386",
+    "name": "ubuntu-14.04-i386",
     "no_proxy": "{{env `no_proxy`}}",
     "preseed_path": "ubuntu-14.04/preseed.cfg",
     "template": "ubuntu-14.04-i386",

--- a/ubuntu-14.10-amd64.json
+++ b/ubuntu-14.10-amd64.json
@@ -209,7 +209,7 @@
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
     "mirror_directory": "14.10",
-    "name": "chef/ubuntu-14.10",
+    "name": "ubuntu-14.10",
     "no_proxy": "{{env `no_proxy`}}",
     "preseed_path": "ubuntu-14.10/preseed.cfg",
     "template": "ubuntu-14.10-amd64",

--- a/ubuntu-14.10-i386.json
+++ b/ubuntu-14.10-i386.json
@@ -209,7 +209,7 @@
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
     "mirror_directory": "14.10",
-    "name": "chef/ubuntu-14.10-i386",
+    "name": "ubuntu-14.10-i386",
     "no_proxy": "{{env `no_proxy`}}",
     "preseed_path": "ubuntu-14.10/preseed.cfg",
     "template": "ubuntu-14.10-i386",

--- a/ubuntu-15.04-amd64.json
+++ b/ubuntu-15.04-amd64.json
@@ -209,7 +209,7 @@
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
     "mirror_directory": "15.04",
-    "name": "chef/ubuntu-15.04",
+    "name": "ubuntu-15.04",
     "no_proxy": "{{env `no_proxy`}}",
     "preseed_path": "ubuntu-15.04/preseed.cfg",
     "template": "ubuntu-15.04-amd64",

--- a/ubuntu-15.04-i386.json
+++ b/ubuntu-15.04-i386.json
@@ -209,7 +209,7 @@
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
     "mirror_directory": "15.04",
-    "name": "chef/ubuntu-15.04-i386",
+    "name": "ubuntu-15.04-i386",
     "no_proxy": "{{env `no_proxy`}}",
     "preseed_path": "ubuntu-15.04/preseed.cfg",
     "template": "ubuntu-15.04-i386",


### PR DESCRIPTION
This allows the publishing namespace to be separated from the box name.