### PR TITLE
Shortening vm_name to avoid Parallels box corruption

### DIFF
--- a/centos-5.11-i386.json
+++ b/centos-5.11-i386.json
@@ -36,7 +36,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-{{user `template`}}-virtualbox"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -58,7 +58,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-{{user `template`}}-vmware",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "480",
@@ -100,7 +100,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-{{user `template`}}-parallels"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/centos-5.11-x86_64.json
+++ b/centos-5.11-x86_64.json
@@ -36,7 +36,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-{{user `template`}}-virtualbox"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -58,7 +58,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-{{user `template`}}-vmware",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "480",
@@ -100,7 +100,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-{{user `template`}}-parallels"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/centos-6.6-i386.json
+++ b/centos-6.6-i386.json
@@ -36,7 +36,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-{{user `template`}}-virtualbox"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -58,7 +58,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-{{user `template`}}-vmware",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "480",
@@ -100,7 +100,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-{{user `template`}}-parallels"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/centos-6.6-x86_64.json
+++ b/centos-6.6-x86_64.json
@@ -36,7 +36,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-{{user `template`}}-virtualbox"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -58,7 +58,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-{{user `template`}}-vmware",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "480",
@@ -100,7 +100,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-{{user `template`}}-parallels"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/centos-7.1-x86_64.json
+++ b/centos-7.1-x86_64.json
@@ -36,7 +36,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-{{user `template`}}-virtualbox"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -58,7 +58,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-{{user `template`}}-vmware",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "480",
@@ -100,7 +100,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-{{user `template`}}-parallels"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/debian-6.0.10-amd64.json
+++ b/debian-6.0.10-amd64.json
@@ -50,7 +50,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-debian-6.0.10-amd64"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -86,7 +86,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-debian-6.0.10-amd64",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -142,7 +142,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-debian-6.0.10-amd64"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/debian-6.0.10-i386.json
+++ b/debian-6.0.10-i386.json
@@ -50,7 +50,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-debian-6.0.10-i386"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -86,7 +86,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-debian-6.0.10-i386",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -142,7 +142,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-debian-6.0.10-i386"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/debian-7.8-amd64.json
+++ b/debian-7.8-amd64.json
@@ -50,7 +50,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-debian-7.8-amd64"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -86,7 +86,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-debian-7.8-amd64",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -142,7 +142,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-debian-7.8-amd64"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/debian-7.8-i386.json
+++ b/debian-7.8-i386.json
@@ -50,7 +50,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-debian-7.8-i386"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -86,7 +86,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-debian-7.8-i386",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -142,7 +142,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-debian-7.8-i386"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/debian-8.1-amd64.json
+++ b/debian-8.1-amd64.json
@@ -50,7 +50,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-debian-8.1-amd64"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -86,7 +86,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-debian-8.1-amd64",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -142,7 +142,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-debian-8.1-amd64"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/debian-8.1-i386.json
+++ b/debian-8.1-i386.json
@@ -50,7 +50,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-debian-8.1-i386"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -86,7 +86,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-debian-8.1-i386",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -142,7 +142,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-debian-8.1-i386"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/fedora-20-i386.json
+++ b/fedora-20-i386.json
@@ -36,7 +36,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-fedora-20-i386"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -58,7 +58,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-fedora-20-i386",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "512",
@@ -100,7 +100,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-fedora-20-i386"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/fedora-20-x86_64.json
+++ b/fedora-20-x86_64.json
@@ -36,7 +36,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-fedora-20-x86_64"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -58,7 +58,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-fedora-20-x86_64",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "512",
@@ -100,7 +100,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-fedora-20-x86_64"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/fedora-21-i386.json
+++ b/fedora-21-i386.json
@@ -36,7 +36,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-fedora-21-i386"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -58,7 +58,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-fedora-21-i386",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "512",
@@ -100,7 +100,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-fedora-21-i386"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/fedora-21-x86_64.json
+++ b/fedora-21-x86_64.json
@@ -36,7 +36,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-fedora-21-x86_64"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -58,7 +58,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-fedora-21-x86_64",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "512",
@@ -100,7 +100,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-fedora-21-x86_64"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/freebsd-10.1-amd64.json
+++ b/freebsd-10.1-amd64.json
@@ -43,7 +43,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-freebsd-10.1-amd64"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -74,7 +74,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "freebsd",
       "type": "vmware-iso",
-      "vm_name": "packer-freebsd-10.1-amd64",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "512",
@@ -144,7 +144,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-freebsd-10.1-amd64"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/freebsd-10.1-i386.json
+++ b/freebsd-10.1-i386.json
@@ -43,7 +43,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-freebsd-10.1-i386"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -74,7 +74,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "freebsd",
       "type": "vmware-iso",
-      "vm_name": "packer-freebsd-10.1-i386",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "512",
@@ -144,7 +144,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-freebsd-10.1-amd64"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/freebsd-9.3-amd64.json
+++ b/freebsd-9.3-amd64.json
@@ -47,7 +47,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-freebsd-9.3-amd64"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -82,7 +82,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "freebsd",
       "type": "vmware-iso",
-      "vm_name": "packer-freebsd-9.3-amd64",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "512",
@@ -156,7 +156,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-freebsd-9.3-amd64"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/freebsd-9.3-i386.json
+++ b/freebsd-9.3-i386.json
@@ -47,7 +47,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-freebsd-9.3-i386"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -82,7 +82,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "freebsd",
       "type": "vmware-iso",
-      "vm_name": "packer-freebsd-9.3-i386",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "512",
@@ -154,7 +154,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-freebsd-9.3-i386"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/macosx-10.10.json
+++ b/macosx-10.10.json
@@ -18,7 +18,7 @@
       "tools_upload_flavor": "darwin",
       "tools_upload_path": "/tmp/vmtools.iso",
       "type": "vmware-iso",
-      "vm_name": "packer-{{user `template`}}-vmware",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "ehci.present": "TRUE",
@@ -151,7 +151,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-{{user `template`}}-virtualbox"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "min_packer_version": "0.7.0",

--- a/macosx-10.7.json
+++ b/macosx-10.7.json
@@ -18,7 +18,7 @@
       "tools_upload_flavor": "darwin",
       "tools_upload_path": "/tmp/vmtools.iso",
       "type": "vmware-iso",
-      "vm_name": "packer-{{user `template`}}-vmware",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "ehci.present": "TRUE",
@@ -151,7 +151,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-{{user `template`}}-virtualbox"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "min_packer_version": "0.7.0",

--- a/macosx-10.8.json
+++ b/macosx-10.8.json
@@ -18,7 +18,7 @@
       "tools_upload_flavor": "darwin",
       "tools_upload_path": "/tmp/vmtools.iso",
       "type": "vmware-iso",
-      "vm_name": "packer-{{user `template`}}-vmware",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "ehci.present": "TRUE",
@@ -151,7 +151,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-{{user `template`}}-virtualbox"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "min_packer_version": "0.7.0",

--- a/macosx-10.9.json
+++ b/macosx-10.9.json
@@ -18,7 +18,7 @@
       "tools_upload_flavor": "darwin",
       "tools_upload_path": "/tmp/vmtools.iso",
       "type": "vmware-iso",
-      "vm_name": "packer-{{user `template`}}-vmware",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "ehci.present": "TRUE",
@@ -151,7 +151,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-{{user `template`}}-virtualbox"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "min_packer_version": "0.7.0",

--- a/omnios-r151010j.json
+++ b/omnios-r151010j.json
@@ -58,7 +58,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-omnios-r151010j"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -109,7 +109,7 @@
       "ssh_username": "root",
       "tools_upload_flavor": "solaris",
       "type": "vmware-iso",
-      "vm_name": "packer-omnios-r151010j",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "1024",
@@ -177,7 +177,7 @@
       "ssh_port": 22,
       "ssh_username": "root",
       "type": "parallels-iso",
-      "vm_name": "packer-omnios-r151010j"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/opensuse-13.2-i386.json
+++ b/opensuse-13.2-i386.json
@@ -39,7 +39,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-opensuse-13.2-i386"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -65,7 +65,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-opensuse-13.2-i386",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "480",
@@ -111,7 +111,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-opensuse-13.2-i386"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/opensuse-13.2-x86_64.json
+++ b/opensuse-13.2-x86_64.json
@@ -39,7 +39,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-opensuse-13.2-x86_64"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -65,7 +65,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-opensuse-13.2-x86_64",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "480",
@@ -111,7 +111,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-opensuse-13.2-x86_64"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/oracle-5.11-i386.json
+++ b/oracle-5.11-i386.json
@@ -36,7 +36,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-oracle-5.11-i386"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -58,7 +58,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-oracle-5.11-i386",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -100,7 +100,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-oracle-5.11-i386"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/oracle-5.11-x86_64.json
+++ b/oracle-5.11-x86_64.json
@@ -36,7 +36,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-oracle-5.11-x86_64"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -58,7 +58,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-oracle-5.11-x86_64",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -100,7 +100,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-oracle-5.11-x86_64"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/oracle-6.6-i386.json
+++ b/oracle-6.6-i386.json
@@ -36,7 +36,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-oracle-6.6-i386"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -58,7 +58,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-oracle-6.6-i386",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "480",
@@ -100,7 +100,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-oracle-6.6-i386"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/oracle-6.6-x86_64.json
+++ b/oracle-6.6-x86_64.json
@@ -36,7 +36,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-oracle-6.6-x86_64"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -58,7 +58,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-oracle-6.6-x86_64",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "480",
@@ -100,7 +100,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-oracle-6.6-x86_64"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/rhel-5.11-i386.json
+++ b/rhel-5.11-i386.json
@@ -36,7 +36,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-rhel-5.11-i386"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -58,7 +58,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-rhel-5.11-i386",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -100,7 +100,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-rhel-5.11-i386"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/rhel-5.11-x86_64.json
+++ b/rhel-5.11-x86_64.json
@@ -36,7 +36,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-rhel-5.11-x86_64"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -58,7 +58,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-rhel-5.11-x86_64",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -100,7 +100,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-rhel-5.11-x86_64"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/rhel-6.6-i386.json
+++ b/rhel-6.6-i386.json
@@ -36,7 +36,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-rhel-6.6-i386"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -58,7 +58,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-rhel-6.6-i386",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "480",
@@ -100,7 +100,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-rhel-6.6-i386"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/rhel-6.6-x86_64.json
+++ b/rhel-6.6-x86_64.json
@@ -36,7 +36,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-rhel-6.6-x86_64"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -58,7 +58,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-rhel-6.6-x86_64",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "480",
@@ -100,7 +100,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-rhel-6.6-x86_64"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/rhel-7.1-x86_64.json
+++ b/rhel-7.1-x86_64.json
@@ -36,7 +36,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-rhel-7.1-x86_64"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -58,7 +58,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-rhel-7.1-x86_64",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "480",
@@ -100,7 +100,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-rhel-7.1-x86_64"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/sles-11-sp2-i386.json
+++ b/sles-11-sp2-i386.json
@@ -40,7 +40,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-sles-11-sp2-i386"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -66,7 +66,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-sles-11-sp2-i386",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "480",
@@ -112,7 +112,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-sles-11-sp2-i386"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/sles-11-sp2-x86_64.json
+++ b/sles-11-sp2-x86_64.json
@@ -40,7 +40,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-sles-11-sp2-x86_64"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -66,7 +66,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-sles-11-sp2-x86_64",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "480",
@@ -112,7 +112,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-sles-11-sp2-x86_64"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/sles-11-sp3-i386.json
+++ b/sles-11-sp3-i386.json
@@ -40,7 +40,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-sles-11-sp3-i386"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -66,7 +66,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-sles-11-sp3-i386",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "480",
@@ -112,7 +112,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-sles-11-sp3-i386"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/sles-11-sp3-x86_64.json
+++ b/sles-11-sp3-x86_64.json
@@ -40,7 +40,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-sles-11-sp3-x86_64"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -66,7 +66,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-sles-11-sp3-x86_64",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "480",
@@ -112,7 +112,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-sles-11-sp3-x86_64"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/sles-12-x86_64.json
+++ b/sles-12-x86_64.json
@@ -40,7 +40,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-sles-12-x86_64"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -66,7 +66,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-sles-12-sp3-x86_64",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "480",
@@ -112,7 +112,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-sles-12-x86_64"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/solaris-10.11-x86.json
+++ b/solaris-10.11-x86.json
@@ -49,7 +49,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-solaris-10u11-x86_64"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -86,7 +86,7 @@
       "tools_upload_flavor": "solaris",
       "tools_upload_path": "/home/vagrant/solaris.iso",
       "type": "vmware-iso",
-      "vm_name": "packer-solaris-10u11-x86_64",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "1536",

--- a/solaris-11-x86.json
+++ b/solaris-11-x86.json
@@ -60,7 +60,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-solaris-11.2-x86_64"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -106,7 +106,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "vmware-iso",
-      "vm_name": "packer-solaris-11.2-x86_64",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "2048",

--- a/ubuntu-10.04-amd64.json
+++ b/ubuntu-10.04-amd64.json
@@ -57,7 +57,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-{{user `template`}}-virtualbox"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -100,7 +100,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-{{user `template`}}-vmware",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -163,7 +163,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-{{user `template`}}-parallels"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/ubuntu-10.04-i386.json
+++ b/ubuntu-10.04-i386.json
@@ -57,7 +57,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-{{user `template`}}-virtualbox"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -100,7 +100,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-{{user `template`}}-vmware",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -163,7 +163,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-{{user `template`}}-parallels"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/ubuntu-12.04-amd64.json
+++ b/ubuntu-12.04-amd64.json
@@ -57,7 +57,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-{{user `template`}}-virtualbox"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -100,7 +100,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-{{user `template`}}-vmware",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -163,7 +163,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-{{user `template`}}-parallels"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/ubuntu-12.04-i386.json
+++ b/ubuntu-12.04-i386.json
@@ -57,7 +57,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-{{user `template`}}-virtualbox"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -100,7 +100,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-{{user `template`}}-vmware",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -163,7 +163,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-{{user `template`}}-parallels"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/ubuntu-14.04-amd64.json
+++ b/ubuntu-14.04-amd64.json
@@ -57,7 +57,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-{{user `template`}}-virtualbox"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -100,7 +100,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-{{user `template`}}-vmware",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -163,7 +163,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-{{user `template`}}-parallels"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/ubuntu-14.04-i386.json
+++ b/ubuntu-14.04-i386.json
@@ -57,7 +57,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-{{user `template`}}-virtualbox"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -100,7 +100,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-{{user `template`}}-vmware",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -163,7 +163,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-{{user `template`}}-parallels"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/ubuntu-14.10-amd64.json
+++ b/ubuntu-14.10-amd64.json
@@ -57,7 +57,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-{{user `template`}}-virtualbox"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -100,7 +100,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-{{user `template`}}-vmware",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -163,7 +163,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-{{user `template`}}-parallels"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/ubuntu-14.10-i386.json
+++ b/ubuntu-14.10-i386.json
@@ -57,7 +57,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-{{user `template`}}-virtualbox"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -100,7 +100,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-{{user `template`}}-vmware",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -163,7 +163,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-{{user `template`}}-parallels"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/ubuntu-15.04-amd64.json
+++ b/ubuntu-15.04-amd64.json
@@ -57,7 +57,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-{{user `template`}}-virtualbox"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -100,7 +100,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-{{user `template`}}-vmware",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -163,7 +163,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-{{user `template`}}-parallels"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/ubuntu-15.04-i386.json
+++ b/ubuntu-15.04-i386.json
@@ -57,7 +57,7 @@
         ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "packer-{{user `template`}}-virtualbox"
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": [
@@ -100,7 +100,7 @@
       "ssh_wait_timeout": "10000s",
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
-      "vm_name": "packer-{{user `template`}}-vmware",
+      "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
         "memsize": "384",
@@ -163,7 +163,7 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "parallels-iso",
-      "vm_name": "packer-{{user `template`}}-parallels"
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [


### PR DESCRIPTION
Due to this issue in the Go tar library https://github.com/mitchellh/packer/issues/1590 we are shortening VM names to just sneak under the bug limit. This only seems to affect Parallels but we're changing it across the board for the sake of consistency and de-duplication.