### PR TITLE
[debian-*] Improve DRYness, correctness, & speed of Debian templates.

### DIFF
--- a/debian-6.0.10-amd64.json
+++ b/debian-6.0.10-amd64.json
@@ -4,7 +4,7 @@
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
-        "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/debian-6.0/preseed.cfg <wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}} <wait>",
         "debian-installer=en_US <wait>",
         "auto <wait>",
         "locale=en_US <wait>",
@@ -25,11 +25,11 @@
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
-      "iso_checksum": "f3e70528664f174a121b26491c59cd66daaf8274",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/6.0.10/amd64/iso-cd/debian-6.0.10-amd64-CD-1.iso",
-      "output_directory": "packer-debian-6.0.10-amd64-virtualbox",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-virtualbox",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -56,7 +56,7 @@
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
-        "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/debian-6.0/preseed.cfg <wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}} <wait>",
         "debian-installer=en_US <wait>",
         "auto <wait>",
         "locale=en_US <wait>",
@@ -75,11 +75,11 @@
       "guest_os_type": "debian5-64",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
-      "iso_checksum": "f3e70528664f174a121b26491c59cd66daaf8274",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/6.0.10/amd64/iso-cd/debian-6.0.10-amd64-CD-1.iso",
-      "output_directory": "packer-debian-6.0.10-amd64-vmware",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-vmware",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -97,7 +97,7 @@
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
-        "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/debian-6.0/preseed.cfg <wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}} <wait>",
         "debian-installer=en_US <wait>",
         "auto <wait>",
         "locale=en_US <wait>",
@@ -116,10 +116,10 @@
       "guest_os_type": "debian",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
-      "iso_checksum": "f3e70528664f174a121b26491c59cd66daaf8274",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/6.0.10/amd64/iso-cd/debian-6.0.10-amd64-CD-1.iso",
-      "output_directory": "packer-debian-6.0.10-amd64-parallels",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "prlctl": [
         [
@@ -136,7 +136,7 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -158,8 +158,13 @@
       "type": "file"
     },
     {
-      "environment_vars": [],
-      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
+      "environment_vars": [
+        "HOME_DIR=/home/vagrant",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/common/metadata.sh",
         "scripts/debian/update.sh",
@@ -175,16 +180,23 @@
     }
   ],
   "variables": {
-    "arch": "64",
-    "box_basename": "debian-6.0.10",
+    "box_basename": "__unset_box_basename__",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "iso_checksum": "f3e70528664f174a121b26491c59cd66daaf8274",
+    "iso_checksum_type": "sha1",
+    "iso_name": "debian-6.0.10-amd64-CD-1.iso",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://cdimage.debian.org/cdimage/archive",
+    "mirror_directory": "6.0.10/amd64/iso-cd",
     "name": "debian-6.0.10",
+    "no_proxy": "{{env `no_proxy`}}",
+    "preseed_path": "debian-6.0/preseed.cfg",
     "template": "debian-6.0.10-amd64",
-    "version": "2.0.TIMESTAMP"
+    "version": "2.1.TIMESTAMP"
   }
 }
 

--- a/debian-6.0.10-i386.json
+++ b/debian-6.0.10-i386.json
@@ -4,7 +4,7 @@
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
-        "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/debian-6.0/preseed.cfg <wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}} <wait>",
         "debian-installer=en_US <wait>",
         "auto <wait>",
         "locale=en_US <wait>",
@@ -25,11 +25,11 @@
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
-      "iso_checksum": "e8f77720e30f669e731fe3166ad6c3d2da33d93a",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/6.0.10/i386/iso-cd/debian-6.0.10-i386-CD-1.iso",
-      "output_directory": "packer-debian-6.0.10-i386-virtualbox",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-virtualbox",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -56,7 +56,7 @@
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
-        "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/debian-6.0/preseed.cfg <wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}} <wait>",
         "debian-installer=en_US <wait>",
         "auto <wait>",
         "locale=en_US <wait>",
@@ -75,11 +75,11 @@
       "guest_os_type": "debian5",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
-      "iso_checksum": "e8f77720e30f669e731fe3166ad6c3d2da33d93a",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/6.0.10/i386/iso-cd/debian-6.0.10-i386-CD-1.iso",
-      "output_directory": "packer-debian-6.0.10-i386-vmware",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-vmware",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -97,7 +97,7 @@
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
-        "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/debian-6.0/preseed.cfg <wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}} <wait>",
         "debian-installer=en_US <wait>",
         "auto <wait>",
         "locale=en_US <wait>",
@@ -116,10 +116,10 @@
       "guest_os_type": "debian",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
-      "iso_checksum": "e8f77720e30f669e731fe3166ad6c3d2da33d93a",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/6.0.10/i386/iso-cd/debian-6.0.10-i386-CD-1.iso",
-      "output_directory": "packer-debian-6.0.10-i386-parallels",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "prlctl": [
         [
@@ -136,7 +136,7 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -158,8 +158,13 @@
       "type": "file"
     },
     {
-      "environment_vars": [],
-      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
+      "environment_vars": [
+        "HOME_DIR=/home/vagrant",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/common/metadata.sh",
         "scripts/debian/update.sh",
@@ -175,16 +180,23 @@
     }
   ],
   "variables": {
-    "arch": "32",
-    "box_basename": "debian-6.0.10-i386",
+    "box_basename": "__unset_box_basename__",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "iso_checksum": "e8f77720e30f669e731fe3166ad6c3d2da33d93a",
+    "iso_checksum_type": "sha1",
+    "iso_name": "debian-6.0.10-i386-CD-1.iso",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://cdimage.debian.org/cdimage/archive",
+    "mirror_directory": "6.0.10/i386/iso-cd",
     "name": "debian-6.0.10-i386",
+    "no_proxy": "{{env `no_proxy`}}",
+    "preseed_path": "debian-6.0/preseed.cfg",
     "template": "debian-6.0.10-i386",
-    "version": "2.0.TIMESTAMP"
+    "version": "2.1.TIMESTAMP"
   }
 }
 

--- a/debian-7.8-amd64.json
+++ b/debian-7.8-amd64.json
@@ -4,7 +4,7 @@
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
-        "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/debian-7/preseed.cfg <wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}} <wait>",
         "debian-installer=en_US <wait>",
         "auto <wait>",
         "locale=en_US <wait>",
@@ -25,11 +25,11 @@
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
-      "iso_checksum": "5f611b40b0803f8be1180da561cfbc159e381599",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/7.8.0/amd64/iso-cd/debian-7.8.0-amd64-CD-1.iso",
-      "output_directory": "packer-debian-7.8-amd64-virtualbox",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-virtualbox",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -56,7 +56,7 @@
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
-        "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/debian-7/preseed.cfg <wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}} <wait>",
         "debian-installer=en_US <wait>",
         "auto <wait>",
         "locale=en_US <wait>",
@@ -75,11 +75,11 @@
       "guest_os_type": "debian7-64",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
-      "iso_checksum": "5f611b40b0803f8be1180da561cfbc159e381599",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/7.8.0/amd64/iso-cd/debian-7.8.0-amd64-CD-1.iso",
-      "output_directory": "packer-debian-7.8-amd64-vmware",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-vmware",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -97,7 +97,7 @@
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
-        "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/debian-7/preseed.cfg <wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}} <wait>",
         "debian-installer=en_US <wait>",
         "auto <wait>",
         "locale=en_US <wait>",
@@ -116,10 +116,10 @@
       "guest_os_type": "debian",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
-      "iso_checksum": "5f611b40b0803f8be1180da561cfbc159e381599",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/7.8.0/amd64/iso-cd/debian-7.8.0-amd64-CD-1.iso",
-      "output_directory": "packer-debian-7.8-amd64-parallels",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "prlctl": [
         [
@@ -136,7 +136,7 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -158,8 +158,13 @@
       "type": "file"
     },
     {
-      "environment_vars": [],
-      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
+      "environment_vars": [
+        "HOME_DIR=/home/vagrant",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/common/metadata.sh",
         "scripts/debian/update.sh",
@@ -175,16 +180,23 @@
     }
   ],
   "variables": {
-    "arch": "64",
-    "box_basename": "debian-7.8",
+    "box_basename": "__unset_box_basename__",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "iso_checksum": "5f611b40b0803f8be1180da561cfbc159e381599",
+    "iso_checksum_type": "sha1",
+    "iso_name": "debian-7.8.0-amd64-CD-1.iso",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://cdimage.debian.org/cdimage/archive",
+    "mirror_directory": "7.8.0/amd64/iso-cd",
     "name": "debian-7.8",
+    "no_proxy": "{{env `no_proxy`}}",
+    "preseed_path": "debian-7/preseed.cfg",
     "template": "debian-7.8-amd64",
-    "version": "2.0.TIMESTAMP"
+    "version": "2.1.TIMESTAMP"
   }
 }
 

--- a/debian-7.8-i386.json
+++ b/debian-7.8-i386.json
@@ -4,7 +4,7 @@
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
-        "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/debian-7/preseed.cfg <wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}} <wait>",
         "debian-installer=en_US <wait>",
         "auto <wait>",
         "locale=en_US <wait>",
@@ -25,11 +25,11 @@
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
-      "iso_checksum": "d87664e590f39aba725ec9705dc58a8c75417fef",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/7.8.0/i386/iso-cd/debian-7.8.0-i386-CD-1.iso",
-      "output_directory": "packer-debian-7.8-i386-virtualbox",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-virtualbox",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -56,7 +56,7 @@
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
-        "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/debian-7/preseed.cfg <wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}} <wait>",
         "debian-installer=en_US <wait>",
         "auto <wait>",
         "locale=en_US <wait>",
@@ -75,11 +75,12 @@
       "guest_os_type": "debian7",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
-      "iso_checksum": "d87664e590f39aba725ec9705dc58a8c75417fef",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/7.8.0/i386/iso-cd/debian-7.8.0-i386-CD-1.iso",
-      "output_directory": "packer-debian-7.8-i386-vmware",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
+      "http_directory": "http",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-vmware",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -97,7 +98,7 @@
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
-        "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/debian-7/preseed.cfg <wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}} <wait>",
         "debian-installer=en_US <wait>",
         "auto <wait>",
         "locale=en_US <wait>",
@@ -116,10 +117,10 @@
       "guest_os_type": "debian",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
-      "iso_checksum": "d87664e590f39aba725ec9705dc58a8c75417fef",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/7.8.0/i386/iso-cd/debian-7.8.0-i386-CD-1.iso",
-      "output_directory": "packer-debian-7.8-i386-parallels",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "prlctl": [
         [
@@ -136,7 +137,7 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -158,8 +159,13 @@
       "type": "file"
     },
     {
-      "environment_vars": [],
-      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
+      "environment_vars": [
+        "HOME_DIR=/home/vagrant",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/common/metadata.sh",
         "scripts/debian/update.sh",
@@ -175,16 +181,23 @@
     }
   ],
   "variables": {
-    "arch": "32",
-    "box_basename": "debian-7.8-i386",
+    "box_basename": "__unset_box_basename__",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "iso_checksum": "d87664e590f39aba725ec9705dc58a8c75417fef",
+    "iso_checksum_type": "sha1",
+    "iso_name": "debian-7.8.0-i386-CD-1.iso",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://cdimage.debian.org/cdimage/archive",
+    "mirror_directory": "7.8.0/i386/iso-cd",
     "name": "debian-7.8-i386",
+    "no_proxy": "{{env `no_proxy`}}",
+    "preseed_path": "debian-7/preseed.cfg",
     "template": "debian-7.8-i386",
-    "version": "2.0.TIMESTAMP"
+    "version": "2.1.TIMESTAMP"
   }
 }
 

--- a/debian-8.1-amd64.json
+++ b/debian-8.1-amd64.json
@@ -4,7 +4,7 @@
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
-        "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/debian-8/preseed.cfg <wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}} <wait>",
         "debian-installer=en_US <wait>",
         "auto <wait>",
         "locale=en_US <wait>",
@@ -25,11 +25,11 @@
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
-      "iso_checksum": "22bae271a732333ebff150598292d9907d2c6001",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/8.1.0/amd64/iso-cd/debian-8.1.0-amd64-CD-1.iso",
-      "output_directory": "packer-debian-8.1-amd64-virtualbox",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-virtualbox",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -56,7 +56,7 @@
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
-        "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/debian-8/preseed.cfg <wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}} <wait>",
         "debian-installer=en_US <wait>",
         "auto <wait>",
         "locale=en_US <wait>",
@@ -75,11 +75,11 @@
       "guest_os_type": "debian8-64",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
-      "iso_checksum": "22bae271a732333ebff150598292d9907d2c6001",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/8.1.0/amd64/iso-cd/debian-8.1.0-amd64-CD-1.iso",
-      "output_directory": "packer-debian-8.1-amd64-vmware",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-vmware",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -97,7 +97,7 @@
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
-        "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/debian-8/preseed.cfg <wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}} <wait>",
         "debian-installer=en_US <wait>",
         "auto <wait>",
         "locale=en_US <wait>",
@@ -116,10 +116,10 @@
       "guest_os_type": "debian",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
-      "iso_checksum": "22bae271a732333ebff150598292d9907d2c6001",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/8.1.0/amd64/iso-cd/debian-8.1.0-amd64-CD-1.iso",
-      "output_directory": "packer-debian-8.1-amd64-parallels",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "prlctl": [
         [
@@ -136,7 +136,7 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -158,8 +158,13 @@
       "type": "file"
     },
     {
-      "environment_vars": [],
-      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
+      "environment_vars": [
+        "HOME_DIR=/home/vagrant",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/common/metadata.sh",
         "scripts/debian/update.sh",
@@ -175,16 +180,23 @@
     }
   ],
   "variables": {
-    "arch": "64",
-    "box_basename": "debian-8.1",
+    "box_basename": "__unset_box_basename__",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "iso_checksum": "22bae271a732333ebff150598292d9907d2c6001",
+    "iso_checksum_type": "sha1",
+    "iso_name": "debian-8.1.0-amd64-CD-1.iso",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://cdimage.debian.org/cdimage/release",
+    "mirror_directory": "8.1.0/amd64/iso-cd",
     "name": "debian-8.1",
+    "no_proxy": "{{env `no_proxy`}}",
+    "preseed_path": "debian-8/preseed.cfg",
     "template": "debian-8.1-amd64",
-    "version": "2.0.TIMESTAMP"
+    "version": "2.1.TIMESTAMP"
   }
 }
 

--- a/debian-8.1-i386.json
+++ b/debian-8.1-i386.json
@@ -4,7 +4,7 @@
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
-        "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/debian-8/preseed.cfg <wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}} <wait>",
         "debian-installer=en_US <wait>",
         "auto <wait>",
         "locale=en_US <wait>",
@@ -25,11 +25,11 @@
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
-      "iso_checksum": "e223823e0c159f057ec83bd51d4770a132e3e51b",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/8.1.0/i386/iso-cd/debian-8.1.0-i386-CD-1.iso",
-      "output_directory": "packer-debian-8.1-i386-virtualbox",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-virtualbox",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -56,7 +56,7 @@
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
-        "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/debian-8/preseed.cfg <wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}} <wait>",
         "debian-installer=en_US <wait>",
         "auto <wait>",
         "locale=en_US <wait>",
@@ -75,11 +75,11 @@
       "guest_os_type": "debian8",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
-      "iso_checksum": "e223823e0c159f057ec83bd51d4770a132e3e51b",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/8.1.0/i386/iso-cd/debian-8.1.0-i386-CD-1.iso",
-      "output_directory": "packer-debian-8.1-i386-vmware",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-vmware",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -97,7 +97,7 @@
       "boot_command": [
         "<esc><wait>",
         "install <wait>",
-        "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/debian-8/preseed.cfg <wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}} <wait>",
         "debian-installer=en_US <wait>",
         "auto <wait>",
         "locale=en_US <wait>",
@@ -116,10 +116,10 @@
       "guest_os_type": "debian",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
-      "iso_checksum": "e223823e0c159f057ec83bd51d4770a132e3e51b",
-      "iso_checksum_type": "sha1",
-      "iso_url": "{{user `mirror`}}/8.1.0/i386/iso-cd/debian-8.1.0-i386-CD-1.iso",
-      "output_directory": "packer-debian-8.1-i386-parallels",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "prlctl": [
         [
@@ -136,7 +136,7 @@
         ]
       ],
       "prlctl_version_file": ".prlctl_version",
-      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -hP now",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
@@ -158,8 +158,13 @@
       "type": "file"
     },
     {
-      "environment_vars": [],
-      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
+      "environment_vars": [
+        "HOME_DIR=/home/vagrant",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/common/metadata.sh",
         "scripts/debian/update.sh",
@@ -175,16 +180,23 @@
     }
   ],
   "variables": {
-    "arch": "32",
-    "box_basename": "debian-8.1-i386",
+    "box_basename": "__unset_box_basename__",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "iso_checksum": "e223823e0c159f057ec83bd51d4770a132e3e51b",
+    "iso_checksum_type": "sha1",
+    "iso_name": "debian-8.1.0-i386-CD-1.iso",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://cdimage.debian.org/cdimage/release",
+    "mirror_directory": "8.1.0/i386/iso-cd",
     "name": "debian-8.1-i386",
+    "no_proxy": "{{env `no_proxy`}}",
+    "preseed_path": "debian-8/preseed.cfg",
     "template": "debian-8.1-i386",
-    "version": "2.0.TIMESTAMP"
+    "version": "2.1.TIMESTAMP"
   }
 }
 

--- a/scripts/debian/cleanup.sh
+++ b/scripts/debian/cleanup.sh
@@ -1,6 +1,45 @@
-#!/bin/bash -eux
+#!/bin/sh -eux
 
-apt-get -y autoremove
-apt-get -y clean
-rm -rf VBoxGuestAdditions_*.iso VBoxGuestAdditions_*.iso.?
-rm -f /tmp/chef*deb
+# Delete all Linux headers
+dpkg --list \
+  | awk '{ print $2 }' \
+  | grep 'linux-headers' \
+  | xargs apt-get -y purge;
+
+# Remove specific Linux kernels, such as linux-image-3.11.0-15 but
+# keeps the current kernel and does not touch the virtual packages,
+# e.g. 'linux-image-amd64', etc.
+dpkg --list \
+    | awk '{ print $2 }' \
+    | grep 'linux-image-[234].*' \
+    | grep -v `uname -r` \
+    | xargs apt-get -y purge;
+
+# Delete Linux source
+dpkg --list \
+    | awk '{ print $2 }' \
+    | grep linux-source \
+    | xargs apt-get -y purge;
+
+# Delete development packages
+dpkg --list \
+    | awk '{ print $2 }' \
+    | grep -- '-dev$' \
+    | xargs apt-get -y purge;
+
+# Delete compilers and other development tools
+apt-get -y purge cpp gcc g++;
+
+# Delete X11 libraries
+apt-get -y purge libx11-data xauth libxmuu1 libxcb1 libx11-6 libxext6;
+
+# Delete obsolete networking
+apt-get -y purge ppp pppconfig pppoeconf;
+
+# Delete oddities
+apt-get -y purge popularity-contest;
+
+apt-get -y autoremove;
+apt-get -y clean;
+
+rm -f VBoxGuestAdditions_*.iso VBoxGuestAdditions_*.iso.?

--- a/scripts/debian/networking.sh
+++ b/scripts/debian/networking.sh
@@ -1,7 +1,11 @@
-#!/bin/bash -eux
+#!/bin/sh -eux
 
-rm /etc/udev/rules.d/70-persistent-net.rules
-mkdir /etc/udev/rules.d/70-persistent-net.rules
-rm /lib/udev/rules.d/75-persistent-net-generator.rules
-rm -rf /dev/.udev/ /var/lib/dhcp/*
+# Disable automatic udev rules for network interfaces in Ubuntu,
+# source: http://6.ptmc.org/164/
+rm -f /etc/udev/rules.d/70-persistent-net.rules;
+mkdir -p /etc/udev/rules.d/70-persistent-net.rules;
+rm -f /lib/udev/rules.d/75-persistent-net-generator.rules;
+rm -rf /dev/.udev/ /var/lib/dhcp/*;
+
+# Adding a 2 sec delay to the interface up, to make the dhclient happy
 echo "pre-up sleep 2" >> /etc/network/interfaces

--- a/scripts/debian/sudoers.sh
+++ b/scripts/debian/sudoers.sh
@@ -1,9 +1,10 @@
-#!/bin/bash -eux
+#!/bin/sh -eux
 
 # Only add the secure path line if it is not already present - Debian 7
 # includes it by default.
-grep -q 'secure_path' /etc/sudoers || sed -i -e '/Defaults\s\+env_reset/a Defaults\tsecure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"' /etc/sudoers
+grep -q 'secure_path' /etc/sudoers \
+  || sed -i -e '/Defaults\s\+env_reset/a Defaults\tsecure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"' /etc/sudoers;
 
 # Set up password-less sudo for the vagrant user
-echo 'vagrant ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/99_vagrant
-chmod 440 /etc/sudoers.d/99_vagrant
+echo 'vagrant ALL=(ALL) NOPASSWD:ALL' >/etc/sudoers.d/99_vagrant;
+chmod 440 /etc/sudoers.d/99_vagrant;

--- a/scripts/debian/update.sh
+++ b/scripts/debian/update.sh
@@ -1,4 +1,18 @@
-#!/bin/bash -eux
+#!/bin/sh -eux
 
-apt-get update
-apt-get -y upgrade
+arch="`uname -r | sed 's/^.*[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\(-[0-9]\{1,2\}\)-//'`"
+
+apt-get update;
+
+apt-get -y upgrade linux-image-$arch;
+apt-get -y install linux-headers-`uname -r`;
+
+if [ -d /etc/init ]; then
+    # update package index on boot
+    cat <<EOF >/etc/init/refresh-apt.conf;
+description "update package index"
+start on networking
+task
+exec /usr/bin/apt-get update
+EOF
+fi


### PR DESCRIPTION
The following improvements are made in this commit:

* Ensure that all related provisioner shell scripts are written using
  more conservative bourne code idioms
* Call all provisioner scripts with `sh -eux` which will (e) exit
  immediately if a command exits with a non-zero exit status, (u) treats
  unset variables as an error, and (x) outputs the command and its
  expanded arguments or associated word list
* Use the `template` user variable to replace repetition of `"debian-*"`
  style strings throughout
* Support a `HOME_DIR` environment variable for provisioner scripts to
  use
* Remove now-unused user variable `arch`
* Extract the `iso_checksum` and `iso_checksum_type` values into user
  variables and reference them in the templates
* Construct the `iso_url` value from the `mirror`, `mirror_directory`,
  and `iso_name` user variables
* Add an `install_path` user variable and use it throughout the
  templates
* Add an `iso_name` user variable and use it throughout the templates
* Use the `http_proxy`, `https_proxy`, and `no_proxy` environment
  variables if set on the workstation and make them available to the
  provisioner shell scripts to speed up package installations, etc.
* Improve the `scripts/debian/cleanup.sh` implementation to more closely
  match the Ubuntu version
* Attempt to upgrade the version of the kernel in
  `scripts/debian/update.sh`