### PR TITLE
Add provisioning script for Xcode CLI tools

### DIFF
--- a/macosx-10.10.json
+++ b/macosx-10.10.json
@@ -178,6 +178,7 @@
       "scripts": [
         "scripts/common/metadata.sh",
         "scripts/macosx/hostname.sh",
+        "scripts/macosx/xcode-cli-tools.sh",
         "scripts/macosx/update.sh",
         "scripts/macosx/networking.sh",
         "scripts/macosx/vagrant.sh",

--- a/scripts/macosx/xcode-cli-tools.sh
+++ b/scripts/macosx/xcode-cli-tools.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# Get and install Xcode CLI tools
+OSX_VERS=$(sw_vers -productVersion | awk -F "." '{print $2}')
+
+# on 10.9+, we can leverage SUS to get the latest CLI tools
+if [ "$OSX_VERS" -ge 9 ]; then
+    # create the placeholder file that's checked by CLI updates' .dist code
+    # in Apple's SUS catalog
+    touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
+    # find the CLI Tools update
+    PROD=$(softwareupdate -l | grep "\*.*Command Line" | head -n 1 | awk -F"*" '{print $2}' | sed -e 's/^ *//' | tr -d '\n')
+    # install it
+    softwareupdate -i "$PROD" -v
+    rm /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
+
+# on 10.7/10.8, we instead download from public download URLs, which can be found in
+# the dvtdownloadableindex:
+# https://devimages.apple.com.edgekey.net/downloads/xcode/simulators/index-3905972D-B609-49CE-8D06-51ADC78E07BC.dvtdownloadableindex
+else
+    [ "$OSX_VERS" -eq 7 ] && DMGURL=http://devimages.apple.com.edgekey.net/downloads/xcode/command_line_tools_for_xcode_os_x_lion_april_2013.dmg
+    [ "$OSX_VERS" -eq 8 ] && DMGURL=http://devimages.apple.com.edgekey.net/downloads/xcode/command_line_tools_for_osx_mountain_lion_april_2014.dmg
+
+    TOOLS=clitools.dmg
+    curl "$DMGURL" -o "$TOOLS"
+    TMPMOUNT=`/usr/bin/mktemp -d /tmp/clitools.XXXX`
+    hdiutil attach "$TOOLS" -mountpoint "$TMPMOUNT"
+    installer -pkg "$(find $TMPMOUNT -name '*.mpkg')" -target /
+    hdiutil detach "$TMPMOUNT"
+    rm -rf "$TMPMOUNT"
+    rm "$TOOLS"
+    exit
+fi


### PR DESCRIPTION
As I was building an OS X box to run Kitchen tests on a Chef cookbook,
I realized that even though Homebrew is the default package system for
Chef 12+, installing it actually requires the Xcode CLI tools to be already
there on the box.

Since the installation of those tools is somehow hackish (see how the
script `touch`es a file in `/tmp` in order to actually trigger an install through
the update system), it definitely makes sense to me that those tools are
provided on base boxes.

So I added Tim Sutton's script and it works pretty good.
Then I just wanted to share the result in case it might help others!