### PR TITLE
[macosx-*] Increase disk_size to ~40G from ~20G.

### DIFF
--- a/macosx-10.10.json
+++ b/macosx-10.10.json
@@ -2,7 +2,7 @@
   "builders": [
     {
       "boot_wait": "2s",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "guest_os_type": "darwin12-64",
       "headless": "{{ user `headless` }}",
       "iso_checksum": "{{user `iso_checksum`}}",
@@ -34,7 +34,7 @@
     },
     {
       "boot_wait": "2s",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "guest_additions_mode": "disable",
       "guest_os_type": "MacOS109_64",
       "hard_drive_interface": "sata",

--- a/macosx-10.7.json
+++ b/macosx-10.7.json
@@ -2,7 +2,7 @@
   "builders": [
     {
       "boot_wait": "2s",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "guest_os_type": "darwin12-64",
       "headless": "{{ user `headless` }}",
       "iso_checksum": "{{user `iso_checksum`}}",
@@ -34,7 +34,7 @@
     },
     {
       "boot_wait": "2s",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "guest_additions_mode": "disable",
       "guest_os_type": "MacOS107_64",
       "hard_drive_interface": "sata",

--- a/macosx-10.8.json
+++ b/macosx-10.8.json
@@ -2,7 +2,7 @@
   "builders": [
     {
       "boot_wait": "2s",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "guest_os_type": "darwin12-64",
       "headless": "{{ user `headless` }}",
       "iso_checksum": "{{user `iso_checksum`}}",
@@ -34,7 +34,7 @@
     },
     {
       "boot_wait": "2s",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "guest_additions_mode": "disable",
       "guest_os_type": "MacOS108_64",
       "hard_drive_interface": "sata",

--- a/macosx-10.9.json
+++ b/macosx-10.9.json
@@ -2,7 +2,7 @@
   "builders": [
     {
       "boot_wait": "2s",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "guest_os_type": "darwin12-64",
       "headless": "{{ user `headless` }}",
       "iso_checksum": "{{user `iso_checksum`}}",
@@ -34,7 +34,7 @@
     },
     {
       "boot_wait": "2s",
-      "disk_size": 20480,
+      "disk_size": 40960,
       "guest_additions_mode": "disable",
       "guest_os_type": "MacOS109_64",
       "hard_drive_interface": "sata",


### PR DESCRIPTION
When running some tests of the Xcode and Vagrant cookbooks, I found that the virtual machines were running out of drive space before the Chef runs completed. This should buy the VMs a bit more headroom.