### PR TITLE
Enable key insertion on OS X

### DIFF
--- a/vagrantfile_templates/macosx.rb
+++ b/vagrantfile_templates/macosx.rb
@@ -1,8 +1,6 @@
-Vagrant.configure(2) do |config|
-  # disabled until https://github.com/mitchellh/vagrant/pull/5326 makes it
-  # into a release following 1.7.2
-  config.ssh.insert_key = false
+Vagrant.require_version '>= 1.7.3'
 
+Vagrant.configure(2) do |config|
   config.vm.provider 'virtualbox' do |_, override|
     override.vm.synced_folder '.', '/vagrant', type: 'rsync'
   end


### PR DESCRIPTION
The fix was released in Vagrant 1.7.3.