### PR TITLE
Update Readme and small fixes/cleanup to Rake tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,82 +18,30 @@ this project. Note that our baseboxes do not include Chef Client.
 Vagrant can be instructed to install Chef at runtime using the
 [vagrant-omnibus](https://github.com/schisamo/vagrant-omnibus) plugin.
 
-### VirtualBox
+These baseboxes are currently hosted via the Atlas [bento organization](https://atlas.hashicorp.com/bento/)
 
-These baseboxes were all built using a Mac OS X host running VirtualBox 4.3.16, and have that format of Guest Extensions.
+|               | VirtualBox (5.0.2)       | VMware (7.1.2)            | Parallels (11.0.0)        |
+|  ------------ | -------------            | -------------             | -------------             |
+| centos-5.11   | [i386][1],  [x86_64][2]  |  [i386][3],  [x86_64][4]  |   [i386][5], [x86_64][6]  |
+| centos-6.7    | [i386][7],  [x86_64][8]  |  [i386][9],  [x86_64][10] |  [i386][11], [x86_64][12] |
+| centos-7.1    |             [x86_64][13] |              [x86_64][14] |              [x86_64][15] |
+| debian-6.0.10 | [i386][16], [amd64][17]  |  [i386][18], [amd64][19]  |  [i386][20], [amd64][21]  |
+| debian-7.8    | [i386][22], [amd64][23]  |  [i386][24], [amd64][25]  |  [i386][26], [amd64][27]  |
+| debian-8.1    | [i386][28], [amd64][29]  |  [i386][30], [amd64][31]  |  [i386][32], [amd64][33]  |
+| freebsd-9.3   |             [amd64][35]  |              [amd64][37]  |              [amd64][39]  |
+| freebsd-10.2  |             [amd64][41]  |              [amd64][43]  |              [amd64][45]  |
+| opensuse-13.2 | [i386][46], [x86_64][47] |  [i386][48], [x86_64][49] |  [i386][50], [x86_64][51] |
+| ubuntu-10.04  | [i386][52], [amd64][53]  |  [i386][54], [amd64][55]  |  [i386][56], [amd64][57]  |
+| ubuntu-12.04  | [i386][58], [amd64][59]  |  [i386][60], [amd64][61]  |  [i386][62], [amd64][63]  |
+| ubuntu-14.04  | [i386][64], [amd64][65]  |  [i386][66], [amd64][67]  |  [i386][68], [amd64][69]  |
+| ubuntu-15.04  | [i386][70], [amd64][71]  |  [i386][72], [amd64][73]  |  [i386][74], [amd64][75]  |
 
-* [opscode-centos-5.11-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-5.11-i386_chef-provisionerless.box)
-* [opscode-centos-5.11](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-5.11_chef-provisionerless.box)
-* [opscode-centos-6.6-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.6-i386_chef-provisionerless.box)
-* [opscode-centos-6.6](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.6_chef-provisionerless.box)
-* [opscode-centos-7.1](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-7.1_chef-provisionerless.box)
-* [opscode-debian-6.0.10-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-6.0.10-i386_chef-provisionerless.box)
-* [opscode-debian-6.0.10](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-6.0.10_chef-provisionerless.box)
-* [opscode-debian-7.8-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-7.8-i386_chef-provisionerless.box)
-* [opscode-debian-7.8](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-7.8_chef-provisionerless.box)
-* [opscode-debian-8.1-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-8.1-i386_chef-provisionerless.box)
-* [opscode-debian-8.1](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-8.1_chef-provisionerless.box)
-* [opscode-fedora-20-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_fedora-20-i386_chef-provisionerless.box)
-* [opscode-fedora-20](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_fedora-20_chef-provisionerless.box)
-* [opscode-fedora-21-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_fedora-21-i386_chef-provisionerless.box)
-* [opscode-fedora-21](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_fedora-21_chef-provisionerless.box)
-* [opscode-freebsd-9.3-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_freebsd-9.3-i386_chef-provisionerless.box)
-* [opscode-freebsd-9.3](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_freebsd-9.3_chef-provisionerless.box)
-* [opscode-freebsd-10.1](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_freebsd-10.1_chef-provisionerless.box)
-* [opscode-freebsd-10.1-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_freebsd-10.1-i386_chef-provisionerless.box)
-* [opscode-opensuse-13.1-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_opensuse-13.1-i386_chef-provisionerless.box)
-* [opscode-opensuse-13.1](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_opensuse-13.1-x86_64_chef-provisionerless.box)
-* [opscode-ubuntu-10.04-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-10.04-i386_chef-provisionerless.box)
-* [opscode-ubuntu-10.04](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-10.04_chef-provisionerless.box)
-* [opscode-ubuntu-12.04-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04-i386_chef-provisionerless.box)
-* [opscode-ubuntu-12.04](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04_chef-provisionerless.box)
-* [opscode-ubuntu-14.04-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04-i386_chef-provisionerless.box)
-* [opscode-ubuntu-14.04](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box)
-* [opscode-ubuntu-14.10-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.10-i386_chef-provisionerless.box)
-* [opscode-ubuntu-14.10](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.10_chef-provisionerless.box)
-* [opscode-ubuntu-15.04-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-15.04-i386_chef-provisionerless.box)
-* [opscode-ubuntu-15.04](http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-15.04_chef-provisionerless.box)
+### Build Notes
 
-### VMWare
-
-These baseboxes were all built using a Mac OS X host running VMWare Fusion 6.0.2, and have that version of VMWare Tools.
-The boxes should work unchanged in VMWare Workstation for Windows or Linux.
-
-If you're using the [Vagrant VMWare Fusion](https://www.vagrantup.com/vmware)
+* Boxes built on OSX 10.10.5 hosts
+* If you're using the [Vagrant VMWare Fusion](https://www.vagrantup.com/vmware)
 provider, using `vagrant box add --provider vmware_desktop ...` will work for
 these boxes. Using `--provider vmware_fusion`, will not.
-
-* [opscode-centos-5.11-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_centos-5.11-i386_chef-provisionerless.box)
-* [opscode-centos-5.11](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_centos-5.11_chef-provisionerless.box)
-* [opscode-centos-6.6-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_centos-6.6-i386_chef-provisionerless.box)
-* [opscode-centos-6.6](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_centos-6.6_chef-provisionerless.box)
-* [opscode-centos-7.1](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_centos-7.1_chef-provisionerless.box)
-* [opscode-debian-6.0.10-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_debian-6.0.10-i386_chef-provisionerless.box)
-* [opscode-debian-6.0.10](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_debian-6.0.10_chef-provisionerless.box)
-* [opscode-debian-7.8-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_debian-7.8-i386_chef-provisionerless.box)
-* [opscode-debian-7.8](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_debian-7.8_chef-provisionerless.box)
-* [opscode-debian-8.1-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_debian-8.1-i386_chef-provisionerless.box)
-* [opscode-debian-8.1](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_debian-8.1_chef-provisionerless.box)
-* [opscode-fedora-20-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_fedora-20-i386_chef-provisionerless.box)
-* [opscode-fedora-20](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_fedora-20_chef-provisionerless.box)
-* [opscode-fedora-21-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_fedora-21-i386_chef-provisionerless.box)
-* [opscode-fedora-21](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_fedora-21_chef-provisionerless.box)
-* [opscode-freebsd-9.3-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_freebsd-9.3-i386_chef-provisionerless.box)
-* [opscode-freebsd-9.3](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_freebsd-9.3_chef-provisionerless.box)
-* [opscode-freebsd-10.1](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_freebsd-10.1_chef-provisionerless.box)
-* [opscode-freebsd-10.1-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_freebsd-10.1-i386_chef-provisionerless.box)
-* [opscode-opensuse-13.1-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_opensuse-13.1-i386_chef-provisionerless.box)
-* [opscode-opensuse-13.1](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_opensuse-13.1-x86_64_chef-provisionerless.box)
-* [opscode-ubuntu-10.04-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_ubuntu-10.04-i386_chef-provisionerless.box)
-* [opscode-ubuntu-10.04](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_ubuntu-10.04_chef-provisionerless.box)
-* [opscode-ubuntu-12.04-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_ubuntu-12.04-i386_chef-provisionerless.box)
-* [opscode-ubuntu-12.04](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_ubuntu-12.04_chef-provisionerless.box)
-* [opscode-ubuntu-14.04-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_ubuntu-14.04-i386_chef-provisionerless.box)
-* [opscode-ubuntu-14.04](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_ubuntu-14.04_chef-provisionerless.box)
-* [opscode-ubuntu-14.10-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_ubuntu-14.10-i386_chef-provisionerless.box)
-* [opscode-ubuntu-14.10](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_ubuntu-14.10_chef-provisionerless.box)
-* [opscode-ubuntu-15.04-i386](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_ubuntu-15.04-i386_chef-provisionerless.box)
-* [opscode-ubuntu-15.04](http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_ubuntu-15.04_chef-provisionerless.box)
 
 ## Older Baseboxes
 
@@ -107,15 +55,15 @@ First, install [Packer](http://packer.io) and then clone this project.
 Inside the `packer` directory, a JSON file describes each box that can be built. You can use `packer build` to build the
 boxes.
 
-    $ packer build debian-7.2.0-i386.json
+    $ packer build debian-7.8.0-i386.json
 
 If you want to use a another mirror site, use mirror variable.
 
-    $ packer build -var 'mirror=http://ftp.jaist.ac.jp/pub/Linux/debian-cdimage/release' debian-7.2.0-i386.json
+    $ packer build -var 'mirror=http://ftp.jaist.ac.jp/pub/Linux/debian-cdimage/release' debian-7.8.0-i386.json
 
 If you only have VMware or VirtualBox available, you may also tell Packer to build only that box.
 
-    $ packer build -only=virtualbox-iso debian-7.2.0-i386.json
+    $ packer build -only=virtualbox-iso debian-7.8.0-i386.json
 
 Congratulations! You now have box(es) in the ../builds directory that you can then add to Vagrant and start testing cookbooks.
 
@@ -209,3 +157,92 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
+
+[1]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-5.11-i386_chef-provisionerless.box
+[2]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-5.11_chef-provisionerless.box
+[3]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_centos-5.11-i386_chef-provisionerless.box
+[4]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_centos-5.11_chef-provisionerless.box
+[5]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/parallels/opscode_centos-5.11-i386_chef-provisionerless.box
+[6]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/parallels/opscode_centos-5.11_chef-provisionerless.box
+
+[7]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.7-i386_chef-provisionerless.box
+[8]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.7_chef-provisionerless.box
+[9]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_centos-6.7-i386_chef-provisionerless.box
+[10]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_centos-6.7_chef-provisionerless.box
+[11]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/parallels/opscode_centos-6.7-i386_chef-provisionerless.box
+[12]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/parallels/opscode_centos-6.7_chef-provisionerless.box
+
+[13]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-7.1_chef-provisionerless.box
+[14]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_centos-7.1_chef-provisionerless.box
+[15]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/parallels/opscode_centos-7.1_chef-provisionerless.box
+
+[16]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-6.0.10-i386_chef-provisionerless.box
+[17]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-6.0.10_chef-provisionerless.box
+[18]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_debian-6.0.10-i386_chef-provisionerless.box
+[19]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_debian-6.0.10_chef-provisionerless.box
+[20]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/parallels/opscode_debian-6.0.10-i386_chef-provisionerless.box
+[21]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/parallels/opscode_debian-6.0.10_chef-provisionerless.box
+
+[22]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-7.8-i386_chef-provisionerless.box
+[23]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-7.8_chef-provisionerless.box
+[24]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_debian-7.8-i386_chef-provisionerless.box
+[25]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_debian-7.8_chef-provisionerless.box
+[26]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/parallels/opscode_debian-7.8-i386_chef-provisionerless.box
+[27]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/parallels/opscode_debian-7.8_chef-provisionerless.box
+
+[28]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-8.1-i386_chef-provisionerless.box
+[29]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-8.1_chef-provisionerless.box
+[30]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_debian-8.1-i386_chef-provisionerless.box
+[31]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_debian-8.1_chef-provisionerless.box
+[32]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/parallels/opscode_debian-8.1-i386_chef-provisionerless.box
+[33]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/parallels/opscode_debian-8.1_chef-provisionerless.box
+
+[34]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_freebsd-9.3-i386_chef-provisionerless.box
+[35]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_freebsd-9.3_chef-provisionerless.box
+[36]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_freebsd-9.3-i386_chef-provisionerless.box
+[37]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_freebsd-9.3_chef-provisionerless.box
+[38]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/parallels/opscode_freebsd-9.3-i386_chef-provisionerless.box
+[39]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/parallels/opscode_freebsd-9.3_chef-provisionerless.box
+
+[40]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_freebsd-10.2-i386_chef-provisionerless.box
+[41]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_freebsd-10.2_chef-provisionerless.box
+[42]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_freebsd-10.2-i386_chef-provisionerless.box
+[43]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_freebsd-10.2_chef-provisionerless.box
+[44]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/parallels/opscode_freebsd-10.2-i386_chef-provisionerless.box
+[45]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/parallels/opscode_freebsd-10.2_chef-provisionerless.box
+
+[46]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_opensuse-13.2-i386_chef-provisionerless.box
+[47]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_opensuse-13.2-x86_64_chef-provisionerless.box
+[48]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_opensuse-13.2-i386_chef-provisionerless.box
+[49]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_opensuse-13.2-x86_64_chef-provisionerless.box
+[50]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/parallels/opscode_opensuse-13.2-i386_chef-provisionerless.box
+[51]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/parallels/opscode_opensuse-13.2-x86_64_chef-provisionerless.box
+
+[52]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-10.04-i386_chef-provisionerless.box
+[53]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-10.04_chef-provisionerless.box
+[54]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_ubuntu-10.04-i386_chef-provisionerless.box
+[55]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_ubuntu-10.04_chef-provisionerless.box
+[56]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/parallels/opscode_ubuntu-10.04-i386_chef-provisionerless.box
+[57]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/parallels/opscode_ubuntu-10.04_chef-provisionerless.box
+
+[58]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04-i386_chef-provisionerless.box
+[59]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04_chef-provisionerless.box
+[60]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_ubuntu-12.04-i386_chef-provisionerless.box
+[61]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_ubuntu-12.04_chef-provisionerless.box
+[62]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/parallels/opscode_ubuntu-12.04-i386_chef-provisionerless.box
+[63]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/parallels/opscode_ubuntu-12.04_chef-provisionerless.box
+
+[64]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04-i386_chef-provisionerless.box
+[65]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box
+[66]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_ubuntu-14.04-i386_chef-provisionerless.box
+[67]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_ubuntu-14.04_chef-provisionerless.box
+[68]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/parallels/opscode_ubuntu-14.04-i386_chef-provisionerless.box
+[69]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/parallels/opscode_ubuntu-14.04_chef-provisionerless.box
+
+
+[70]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-15.04-i386_chef-provisionerless.box
+[71]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-15.04_chef-provisionerless.box
+[72]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_ubuntu-15.04-i386_chef-provisionerless.box
+[73]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/vmware/opscode_ubuntu-15.04_chef-provisionerless.box
+[74]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/parallels/opscode_ubuntu-15.04-i386_chef-provisionerless.box
+[75]: http://opscode-vm-bento.s3.amazonaws.com/vagrant/parallels/opscode_ubuntu-15.04_chef-provisionerless.box


### PR DESCRIPTION
- This update heralds the new age of the bento build pipeline
- Boxes will *soon* be built for each PR / commit
- Boxes now exist on Atlas https://atlas.hashicorp.com/bento
- Boxes will also continue to be served from S3 until upcoming changes to kitchen-vagrant
- Readme is now way prettier