### PR TITLE
Add Parallels builder to Mac OS X templates

### DIFF
--- a/macosx-10.10.json
+++ b/macosx-10.10.json
@@ -152,6 +152,28 @@
       ],
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
+    },
+    {
+      "boot_wait": "2s",
+      "disk_size": 40960,
+      "guest_os_type": "macosx",
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "output_directory": "packer-{{user `template`}}-parallels",
+      "parallels_tools_flavor": "mac",
+      "prlctl": [
+        ["set", "{{.Name}}", "--memsize", "2048"],
+        ["set", "{{.Name}}", "--cpus", "1"],
+        ["set", "{{.Name}}", "--on-window-close", "keep-running"]
+      ],
+      "shutdown_command": "echo 'vagrant'| sudo -S shutdown -h now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso"
     }
   ],
   "post-processors": [

--- a/macosx-10.7.json
+++ b/macosx-10.7.json
@@ -152,6 +152,28 @@
       ],
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
+    },
+    {
+      "boot_wait": "2s",
+      "disk_size": 40960,
+      "guest_os_type": "macosx",
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "output_directory": "packer-{{user `template`}}-parallels",
+      "parallels_tools_flavor": "mac",
+      "prlctl": [
+        ["set", "{{.Name}}", "--memsize", "2048"],
+        ["set", "{{.Name}}", "--cpus", "1"],
+        ["set", "{{.Name}}", "--on-window-close", "keep-running"]
+      ],
+      "shutdown_command": "echo 'vagrant'| sudo -S shutdown -h now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso"
     }
   ],
   "post-processors": [

--- a/macosx-10.8.json
+++ b/macosx-10.8.json
@@ -152,6 +152,28 @@
       ],
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
+    },
+    {
+      "boot_wait": "2s",
+      "disk_size": 40960,
+      "guest_os_type": "macosx",
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "output_directory": "packer-{{user `template`}}-parallels",
+      "parallels_tools_flavor": "mac",
+      "prlctl": [
+        ["set", "{{.Name}}", "--memsize", "2048"],
+        ["set", "{{.Name}}", "--cpus", "1"],
+        ["set", "{{.Name}}", "--on-window-close", "keep-running"]
+      ],
+      "shutdown_command": "echo 'vagrant'| sudo -S shutdown -h now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso"
     }
   ],
   "post-processors": [

--- a/macosx-10.9.json
+++ b/macosx-10.9.json
@@ -152,6 +152,28 @@
       ],
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
+    },
+    {
+      "boot_wait": "2s",
+      "disk_size": 40960,
+      "guest_os_type": "macosx",
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "output_directory": "packer-{{user `template`}}-parallels",
+      "parallels_tools_flavor": "mac",
+      "prlctl": [
+        ["set", "{{.Name}}", "--memsize", "2048"],
+        ["set", "{{.Name}}", "--cpus", "1"],
+        ["set", "{{.Name}}", "--on-window-close", "keep-running"]
+      ],
+      "shutdown_command": "echo 'vagrant'| sudo -S shutdown -h now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso"
     }
   ],
   "post-processors": [

--- a/scripts/macosx/vmtools.sh
+++ b/scripts/macosx/vmtools.sh
@@ -24,9 +24,19 @@ vmware-iso|vmware-vmx)
     ;;
 
 parallels-iso|parallels-pvm)
-    echo "Parallels not currently supported, sadface";
-    ;;
+    TOOLS_PATH="$HOME_DIR/prl-tools-mac.iso";
+    TMPMOUNT="`/usr/bin/mktemp -d /tmp/parallels-tools.XXXX`";
 
+    #Run install, unmount ISO and remove it
+    hdiutil attach "$TOOLS_PATH" -mountpoint "$TMPMOUNT";
+    echo "Installing Parallels Tools..."
+    installer -pkg "$TMPMOUNT/Install.app/Contents/Resources/Install.mpkg" -target /;
+
+    # This usually fails
+    hdiutil detach "$TMPMOUNT" || true;
+    rmdir "$TMPMOUNT";
+    rm -f "$TOOLS_PATH";
+    ;;
 *)
     echo "Unknown Packer Builder Type >>${PACKER_BUILDER_TYPE}<< selected.";
     echo "Known are virtualbox-iso|virtualbox-ovf|vmware-iso|vmware-vmx|parallels-iso|parallels-pvm.";


### PR DESCRIPTION
I've added Parallels builder support for `macosx-*` templates.
Verified on Packer v0.8.6 + Parallels Desktop Pro 11.0.0

I'm ready to maintain the compatibility with Parallels Desktop, so feel free to highlight me if something is going wrong with that.