### PR TITLE
Add "vm_name" parameter to Mac OS X templates for Parallels builder

### DIFF
--- a/macosx-10.10.json
+++ b/macosx-10.10.json
@@ -173,7 +173,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso"
+      "type": "parallels-iso",
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/macosx-10.7.json
+++ b/macosx-10.7.json
@@ -173,7 +173,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso"
+      "type": "parallels-iso",
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/macosx-10.8.json
+++ b/macosx-10.8.json
@@ -173,7 +173,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso"
+      "type": "parallels-iso",
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/macosx-10.9.json
+++ b/macosx-10.9.json
@@ -173,7 +173,8 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "type": "parallels-iso"
+      "type": "parallels-iso",
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [


### PR DESCRIPTION
This is an addition to my previous PR: GH-436
Without specifying the VM name, it will be named `packer-parallels-iso`, which is not unique.