### PR TITLE
Changing box_basename back to a sensible default

### DIFF
--- a/centos-5.11-i386.json
+++ b/centos-5.11-i386.json
@@ -136,7 +136,7 @@
     }
   ],
   "variables": {
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "centos-5.11-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/centos-5.11-x86_64.json
+++ b/centos-5.11-x86_64.json
@@ -136,7 +136,7 @@
     }
   ],
   "variables": {
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "centos-5.11",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/centos-6.7-i386.json
+++ b/centos-6.7-i386.json
@@ -136,7 +136,7 @@
     }
   ],
   "variables": {
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "centos-6.7-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/centos-6.7-x86_64.json
+++ b/centos-6.7-x86_64.json
@@ -136,7 +136,7 @@
     }
   ],
   "variables": {
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "centos-6.7",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/centos-7.1-x86_64.json
+++ b/centos-7.1-x86_64.json
@@ -136,7 +136,7 @@
     }
   ],
   "variables": {
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "centos-7.1",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/debian-6.0.10-amd64.json
+++ b/debian-6.0.10-amd64.json
@@ -180,7 +180,7 @@
     }
   ],
   "variables": {
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "debian-6.0.10",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/debian-6.0.10-i386.json
+++ b/debian-6.0.10-i386.json
@@ -180,7 +180,7 @@
     }
   ],
   "variables": {
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "debian-6.0.10-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/debian-7.8-amd64.json
+++ b/debian-7.8-amd64.json
@@ -180,7 +180,7 @@
     }
   ],
   "variables": {
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "debian-7.8",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/debian-7.8-i386.json
+++ b/debian-7.8-i386.json
@@ -180,7 +180,7 @@
     }
   ],
   "variables": {
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "debian-7.8-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/debian-8.1-amd64.json
+++ b/debian-8.1-amd64.json
@@ -180,7 +180,7 @@
     }
   ],
   "variables": {
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "debian-8.1",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/debian-8.1-i386.json
+++ b/debian-8.1-i386.json
@@ -180,7 +180,7 @@
     }
   ],
   "variables": {
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "debian-8.1-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/freebsd-10.2-amd64.json
+++ b/freebsd-10.2-amd64.json
@@ -182,7 +182,7 @@
     }
   ],
   "variables": {
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "freebsd-10.2",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/freebsd-10.2-i386.json
+++ b/freebsd-10.2-i386.json
@@ -182,7 +182,7 @@
     }
   ],
   "variables": {
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "freebsd-10.2-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/freebsd-9.3-amd64.json
+++ b/freebsd-9.3-amd64.json
@@ -194,7 +194,7 @@
     }
   ],
   "variables": {
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "freebsd-9.3",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/freebsd-9.3-i386.json
+++ b/freebsd-9.3-i386.json
@@ -194,7 +194,7 @@
     }
   ],
   "variables": {
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "freebsd-9.3-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/macosx-10.10.json
+++ b/macosx-10.10.json
@@ -213,7 +213,7 @@
   ],
   "variables": {
     "_README": "You must provide a prepared Mac disk image (from https://github.com/timsutton/osx-vm-templates) and checksum value for this template to work. For more details, consult this project's README.md",
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "macosx-10.10",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/macosx-10.7.json
+++ b/macosx-10.7.json
@@ -213,7 +213,7 @@
   ],
   "variables": {
     "_README": "You must provide a prepared Mac disk image (from https://github.com/timsutton/osx-vm-templates) and checksum value for this template to work. For more details, consult this project's README.md",
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "macosx-10.7",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/macosx-10.8.json
+++ b/macosx-10.8.json
@@ -213,7 +213,7 @@
   ],
   "variables": {
     "_README": "You must provide a prepared Mac disk image (from https://github.com/timsutton/osx-vm-templates) and checksum value for this template to work. For more details, consult this project's README.md",
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "macosx-10.8",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/macosx-10.9.json
+++ b/macosx-10.9.json
@@ -213,7 +213,7 @@
   ],
   "variables": {
     "_README": "You must provide a prepared Mac disk image (from https://github.com/timsutton/osx-vm-templates) and checksum value for this template to work. For more details, consult this project's README.md",
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "macosx-10.9",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/ubuntu-10.04-amd64.json
+++ b/ubuntu-10.04-amd64.json
@@ -201,7 +201,7 @@
     }
   ],
   "variables": {
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "ubuntu-10.04",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/ubuntu-10.04-i386.json
+++ b/ubuntu-10.04-i386.json
@@ -201,7 +201,7 @@
     }
   ],
   "variables": {
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "ubuntu-10.04-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/ubuntu-12.04-amd64.json
+++ b/ubuntu-12.04-amd64.json
@@ -201,7 +201,7 @@
     }
   ],
   "variables": {
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "ubuntu-12.04",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/ubuntu-12.04-i386.json
+++ b/ubuntu-12.04-i386.json
@@ -201,7 +201,7 @@
     }
   ],
   "variables": {
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "ubuntu-12.04-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/ubuntu-14.04-amd64.json
+++ b/ubuntu-14.04-amd64.json
@@ -201,7 +201,7 @@
     }
   ],
   "variables": {
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "ubuntu-14.04",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/ubuntu-14.04-i386.json
+++ b/ubuntu-14.04-i386.json
@@ -201,7 +201,7 @@
     }
   ],
   "variables": {
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "ubuntu-14.04-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/ubuntu-14.10-amd64.json
+++ b/ubuntu-14.10-amd64.json
@@ -201,7 +201,7 @@
     }
   ],
   "variables": {
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "ubuntu-14.10",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/ubuntu-14.10-i386.json
+++ b/ubuntu-14.10-i386.json
@@ -201,7 +201,7 @@
     }
   ],
   "variables": {
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "ubuntu-14.10-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/ubuntu-15.04-amd64.json
+++ b/ubuntu-15.04-amd64.json
@@ -201,7 +201,7 @@
     }
   ],
   "variables": {
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "ubuntu-15.04",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",

--- a/ubuntu-15.04-i386.json
+++ b/ubuntu-15.04-i386.json
@@ -201,7 +201,7 @@
     }
   ],
   "variables": {
-    "box_basename": "__unset_box_basename__",
+    "box_basename": "ubuntu-15.04-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",


### PR DESCRIPTION
Setting this back to a sensible default to avoid confusion and making building directly with packer more delightful.