### PR TITLE
Use bento prefix for box names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ new plugins. The full list of old boxes are available in the [old boxes file](ht
 
 Adding a bento box to vagrant:
 
-    $ vagrant box add chef/debian-8.1
+    $ vagrant box add bento/debian-8.1
 
 Using a bento box in a Vagrantfile:
 
 ```
 Vagrant.configure("2") do |config|
-  config.vm.box = "chef/debian-8.1"
+  config.vm.box = "bento/debian-8.1"
 end
 ```
 


### PR DESCRIPTION
First up, thanks for bento! I've used these boxes for a while now and really appreciate the effort that goes into this project :sparkles:.

I ran into a small issue, but I think I have a solution. `vagrant up` failed when I used the `chef/` prefix in my `Vagrantfile`.

Here is the error I experienced:

```
$> vagrant --version
Vagrant 1.7.4
$> cat Vagrantfile
Vagrant.configure(2) do |config|
  config.vm.box = "chef/ubuntu-12.04"
end
$> vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Box 'chef/ubuntu-12.04' could not be found. Attempting to find and install...
    default: Box Provider: virtualbox
    default: Box Version: >= 0
==> default: Loading metadata for box 'chef/ubuntu-12.04'
    default: URL: https://atlas.hashicorp.com/chef/ubuntu-12.04
The box you're adding has a name different from the name you
requested. For boxes with metadata, you cannot override the name.
If you're adding a box using `vagrant box add`, don't specify
the `--name` parameter. If the box is being added via a Vagrantfile,
change the `config.vm.box` value to match the name below.

Requested name: chef/ubuntu-12.04
Actual name: bento/ubuntu-12.04
```

I updated the README based on the recommendation in the error message. The `bento/` prefix works in my testing for both `vagrant up` and `vagrant box add`. 

`vagrant box add` works with the `chef/` prefix because it appears to redirect from the `chef/` prefix to the `bento/` one. I updated the `vagrant box add` example to use the `bento/` prefix since it seems to be the new location and for consistency between the two examples.