### PR TITLE
Updating platforms to use sha256

### DIFF
--- a/centos-5.11-i386.json
+++ b/centos-5.11-i386.json
@@ -142,8 +142,8 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "iso_checksum": "ec3a89b4edc8e391d13c1ecce4e6ce3917719e39",
-    "iso_checksum_type": "sha1",
+    "iso_checksum": "66d7aa1be7f7aa327b823a706b04b37e219cea67c4eadd9185e8de5e3c4fb08d",
+    "iso_checksum_type": "sha256",
     "iso_name": "CentOS-5.11-i386-bin-DVD-1of2.iso",
     "ks_path": "centos-5.11/ks.cfg",
     "metadata": "floppy/dummy_metadata.json",
@@ -155,4 +155,3 @@
     "version": "2.1.TIMESTAMP"
   }
 }
-

--- a/centos-5.11-x86_64.json
+++ b/centos-5.11-x86_64.json
@@ -142,8 +142,8 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "iso_checksum": "ebd77f2fdfac8da04f31c508905cf52aa62937cc",
-    "iso_checksum_type": "sha1",
+    "iso_checksum": "b6eb0565b636513b90663ff01c6ec4da5058baff0d7d4007d187be997dd985f8",
+    "iso_checksum_type": "sha256",
     "iso_name": "CentOS-5.11-x86_64-bin-DVD-1of2.iso",
     "ks_path": "centos-5.11/ks.cfg",
     "metadata": "floppy/dummy_metadata.json",
@@ -155,4 +155,3 @@
     "version": "2.1.TIMESTAMP"
   }
 }
-

--- a/debian-6.0.10-amd64.json
+++ b/debian-6.0.10-amd64.json
@@ -186,8 +186,8 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "iso_checksum": "f3e70528664f174a121b26491c59cd66daaf8274",
-    "iso_checksum_type": "sha1",
+    "iso_checksum": "ee3bc7fd1a1bcbf49297fe305cec935cc8012ab6ec8d37e9428d0600b060c0d8",
+    "iso_checksum_type": "sha256",
     "iso_name": "debian-6.0.10-amd64-CD-1.iso",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://cdimage.debian.org/cdimage/archive",
@@ -199,4 +199,3 @@
     "version": "2.1.TIMESTAMP"
   }
 }
-

--- a/debian-6.0.10-i386.json
+++ b/debian-6.0.10-i386.json
@@ -186,8 +186,8 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "iso_checksum": "e8f77720e30f669e731fe3166ad6c3d2da33d93a",
-    "iso_checksum_type": "sha1",
+    "iso_checksum": "d2740420ba52d397c453fbfea6f5d3bcdbfe27dee666ee63b0fb1e7df1d18633",
+    "iso_checksum_type": "sha256",
     "iso_name": "debian-6.0.10-i386-CD-1.iso",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://cdimage.debian.org/cdimage/archive",
@@ -199,4 +199,3 @@
     "version": "2.1.TIMESTAMP"
   }
 }
-

--- a/ubuntu-10.04-amd64.json
+++ b/ubuntu-10.04-amd64.json
@@ -207,8 +207,8 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "iso_checksum": "796e80702d65f2ee96e88874a1ab437e24df9cd6",
-    "iso_checksum_type": "sha1",
+    "iso_checksum": "3de19967318906fd57252ef67ed3ad411b89e3ea6b81205e26517530d7a8cd0b",
+    "iso_checksum_type": "sha256",
     "iso_name": "ubuntu-10.04.4-server-amd64.iso",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
@@ -220,4 +220,3 @@
     "version": "2.1.TIMESTAMP"
   }
 }
-

--- a/ubuntu-10.04-i386.json
+++ b/ubuntu-10.04-i386.json
@@ -207,8 +207,8 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "iso_checksum": "5695d8b6b914269d1374ac8d4c3dd3786e92d3fe",
-    "iso_checksum_type": "sha1",
+    "iso_checksum": "564eb67534ab64dbddd4b5bed54ec96f447cbbeb27a8a1354eae85658559503f",
+    "iso_checksum_type": "sha256",
     "iso_name": "ubuntu-10.04.4-server-i386.iso",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
@@ -220,4 +220,3 @@
     "version": "2.1.TIMESTAMP"
   }
 }
-

--- a/ubuntu-12.04-amd64.json
+++ b/ubuntu-12.04-amd64.json
@@ -207,8 +207,8 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "iso_checksum": "7540ace2d6cdee264432f5ed987236d32edef798",
-    "iso_checksum_type": "sha1",
+    "iso_checksum": "af224223de99e2a730b67d7785b657f549be0d63221188e105445f75fb8305c9",
+    "iso_checksum_type": "sha256",
     "iso_name": "ubuntu-12.04.5-server-amd64.iso",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
@@ -220,4 +220,3 @@
     "version": "2.1.TIMESTAMP"
   }
 }
-

--- a/ubuntu-12.04-i386.json
+++ b/ubuntu-12.04-i386.json
@@ -207,8 +207,8 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "iso_checksum": "a34c224b7fe72a2f5c768be5afee5c53817743fd",
-    "iso_checksum_type": "sha1",
+    "iso_checksum": "bec39e79664aa189dea338993f636e54c5eda2f84c27def7b06bd6373ab87628",
+    "iso_checksum_type": "sha256",
     "iso_name": "ubuntu-12.04.5-server-i386.iso",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
@@ -220,4 +220,3 @@
     "version": "2.1.TIMESTAMP"
   }
 }
-

--- a/ubuntu-14.10-amd64.json
+++ b/ubuntu-14.10-amd64.json
@@ -207,8 +207,8 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "iso_checksum": "0c1ebea31c3523cfe9a4ffed8bcf6c7d23dfb97b",
-    "iso_checksum_type": "sha1",
+    "iso_checksum": "f79edea19575e2cabb5ff9aeca787ea821fcfdbf81ce89823c26b020d9940956",
+    "iso_checksum_type": "sha256",
     "iso_name": "ubuntu-14.10-server-amd64.iso",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
@@ -220,4 +220,3 @@
     "version": "2.1.TIMESTAMP"
   }
 }
-

--- a/ubuntu-14.10-i386.json
+++ b/ubuntu-14.10-i386.json
@@ -207,8 +207,8 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "iso_checksum": "26faf47df2162f4ff83e38e6831dd169da6db95f",
-    "iso_checksum_type": "sha1",
+    "iso_checksum": "e1c74e163b06e28bfd71ef322ce986fb6098d03704408f9dc2eaf3ef6f7f86b9",
+    "iso_checksum_type": "sha256",
     "iso_name": "ubuntu-14.10-server-i386.iso",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",
@@ -220,4 +220,3 @@
     "version": "2.1.TIMESTAMP"
   }
 }
-


### PR DESCRIPTION
Other platforms using sha1 will update this in their upcoming respective refactor PRs