### PR TITLE
Remove the headless option for Parallels builder.

### DIFF
--- a/centos-5.11-i386.json
+++ b/centos-5.11-i386.json
@@ -72,7 +72,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "centos",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/centos-5.11-x86_64.json
+++ b/centos-5.11-x86_64.json
@@ -72,7 +72,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "centos",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/centos-6.7-i386.json
+++ b/centos-6.7-i386.json
@@ -72,7 +72,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "centos",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/centos-6.7-x86_64.json
+++ b/centos-6.7-x86_64.json
@@ -72,7 +72,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "centos",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/centos-7.1-x86_64.json
+++ b/centos-7.1-x86_64.json
@@ -72,7 +72,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "centos",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-6.0.10-amd64.json
+++ b/debian-6.0.10-amd64.json
@@ -114,7 +114,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "debian",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-6.0.10-i386.json
+++ b/debian-6.0.10-i386.json
@@ -114,7 +114,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "debian",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-7.8-amd64.json
+++ b/debian-7.8-amd64.json
@@ -114,7 +114,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "debian",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-7.8-i386.json
+++ b/debian-7.8-i386.json
@@ -114,7 +114,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "debian",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-7.9-amd64.json
+++ b/debian-7.9-amd64.json
@@ -114,7 +114,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "debian",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-7.9-i386.json
+++ b/debian-7.9-i386.json
@@ -114,7 +114,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "debian",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-8.1-amd64.json
+++ b/debian-8.1-amd64.json
@@ -114,7 +114,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "debian",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-8.1-i386.json
+++ b/debian-8.1-i386.json
@@ -114,7 +114,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "debian",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-8.2-amd64.json
+++ b/debian-8.2-amd64.json
@@ -114,7 +114,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "debian",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-8.2-i386.json
+++ b/debian-8.2-i386.json
@@ -114,7 +114,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "debian",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/fedora-20-i386.json
+++ b/fedora-20-i386.json
@@ -72,7 +72,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "fedora-core",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/fedora-20-x86_64.json
+++ b/fedora-20-x86_64.json
@@ -72,7 +72,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "fedora-core",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/fedora-21-i386.json
+++ b/fedora-21-i386.json
@@ -72,7 +72,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "fedora-core",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/fedora-21-x86_64.json
+++ b/fedora-21-x86_64.json
@@ -72,7 +72,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "fedora-core",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/fedora-22-i386.json
+++ b/fedora-22-i386.json
@@ -73,7 +73,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "fedora-core",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/fedora-22-x86_64.json
+++ b/fedora-22-x86_64.json
@@ -72,7 +72,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "fedora-core",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/freebsd-10.2-amd64.json
+++ b/freebsd-10.2-amd64.json
@@ -96,7 +96,6 @@
       "boot_wait": "8s",
       "disk_size": 10140,
       "guest_os_type": "freebsd",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/freebsd-10.2-i386.json
+++ b/freebsd-10.2-i386.json
@@ -96,7 +96,6 @@
       "boot_wait": "8s",
       "disk_size": 10140,
       "guest_os_type": "freebsd",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/freebsd-9.3-amd64.json
+++ b/freebsd-9.3-amd64.json
@@ -108,7 +108,6 @@
       "boot_wait": "8s",
       "disk_size": 10140,
       "guest_os_type": "freebsd",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/freebsd-9.3-i386.json
+++ b/freebsd-9.3-i386.json
@@ -108,7 +108,6 @@
       "boot_wait": "8s",
       "disk_size": 10140,
       "guest_os_type": "freebsd",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/macosx-10.10.json
+++ b/macosx-10.10.json
@@ -157,7 +157,6 @@
       "boot_wait": "2s",
       "disk_size": 40960,
       "guest_os_type": "macosx",
-      "headless": "{{ user `headless` }}",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",

--- a/macosx-10.7.json
+++ b/macosx-10.7.json
@@ -157,7 +157,6 @@
       "boot_wait": "2s",
       "disk_size": 40960,
       "guest_os_type": "macosx",
-      "headless": "{{ user `headless` }}",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",

--- a/macosx-10.8.json
+++ b/macosx-10.8.json
@@ -157,7 +157,6 @@
       "boot_wait": "2s",
       "disk_size": 40960,
       "guest_os_type": "macosx",
-      "headless": "{{ user `headless` }}",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",

--- a/macosx-10.9.json
+++ b/macosx-10.9.json
@@ -157,7 +157,6 @@
       "boot_wait": "2s",
       "disk_size": 40960,
       "guest_os_type": "macosx",
-      "headless": "{{ user `headless` }}",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",

--- a/omnios-r151010j.json
+++ b/omnios-r151010j.json
@@ -152,7 +152,6 @@
       "disk_size": 40960,
       "guest_os_type": "opensolaris",
       "hard_drive_interface": "ide",
-      "headless": "{{ user `headless` }}",
       "iso_checksum": "bc3f4c0d29a5da75174de62da00294e5ef826b5e",
       "iso_checksum_type": "sha1",
       "iso_url": "{{user `mirror`}}/OmniOS_Text_r151010j.iso",

--- a/opensuse-13.2-i386.json
+++ b/opensuse-13.2-i386.json
@@ -84,7 +84,6 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "opensuse",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/opensuse-13.2-x86_64.json
+++ b/opensuse-13.2-x86_64.json
@@ -84,7 +84,6 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "opensuse",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/oracle-5.11-i386.json
+++ b/oracle-5.11-i386.json
@@ -72,7 +72,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "centos",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "f4ef2b868a0cccb736664136eca798ec",
       "iso_checksum_type": "md5",

--- a/oracle-5.11-x86_64.json
+++ b/oracle-5.11-x86_64.json
@@ -72,7 +72,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "centos",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "8af2121088c7e6f5ebdb6d5900403240",
       "iso_checksum_type": "md5",

--- a/oracle-6.6-i386.json
+++ b/oracle-6.6-i386.json
@@ -72,7 +72,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "centos",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "81f0c85217f40763dea5053ec5594e4958498bbc",
       "iso_checksum_type": "sha1",

--- a/oracle-6.6-x86_64.json
+++ b/oracle-6.6-x86_64.json
@@ -72,7 +72,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "centos",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "5738f10a506d3630edfd297ef179b553091c6a48",
       "iso_checksum_type": "sha1",

--- a/rhel-5.11-i386.json
+++ b/rhel-5.11-i386.json
@@ -72,7 +72,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "rhel",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "4e38e4ed06d83efb10446e7db19d96761715cdbdbf0bbfacb978b44ce368bbe2",
       "iso_checksum_type": "sha256",

--- a/rhel-5.11-x86_64.json
+++ b/rhel-5.11-x86_64.json
@@ -72,7 +72,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "rhel",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "36565fe0c8a97207d63234d10123daeedb29d509576dbd7b34e71958ac2f9050",
       "iso_checksum_type": "sha256",

--- a/rhel-6.6-i386.json
+++ b/rhel-6.6-i386.json
@@ -72,7 +72,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "rhel",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "0a14ed1f7d7ea7b831739ed8e71719d9cb7c294bf801e8db39358651768547ad",
       "iso_checksum_type": "sha256",

--- a/rhel-6.6-x86_64.json
+++ b/rhel-6.6-x86_64.json
@@ -72,7 +72,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "rhel",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "16044cb7264f4bc0150f5b6f3f66936ccf2d36e0a4152c00d9236fb7dcae5f32",
       "iso_checksum_type": "sha256",

--- a/rhel-7.1-x86_64.json
+++ b/rhel-7.1-x86_64.json
@@ -72,7 +72,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "rhel",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "3685468ec6cdcb70dfc85ebbc164da427dc2d762644c3c2ee1520f4f661c15ce",
       "iso_checksum_type": "sha256",

--- a/sles-11-sp2-i386.json
+++ b/sles-11-sp2-i386.json
@@ -84,7 +84,6 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "suse",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "a0b34f6237b2b2a6b2174c82b40ed326",
       "iso_checksum_type": "md5",

--- a/sles-11-sp2-x86_64.json
+++ b/sles-11-sp2-x86_64.json
@@ -84,7 +84,6 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "suse",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "461d82ae6e15062b0807c1338f040497",
       "iso_checksum_type": "md5",

--- a/sles-11-sp3-i386.json
+++ b/sles-11-sp3-i386.json
@@ -84,7 +84,6 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "suse",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "5c30a409fc8fb3343b4dc90d93ff2c89",
       "iso_checksum_type": "md5",

--- a/sles-11-sp3-x86_64.json
+++ b/sles-11-sp3-x86_64.json
@@ -84,7 +84,6 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "suse",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "480b70d50cbb538382dc2b9325221e1b",
       "iso_checksum_type": "md5",

--- a/sles-12-x86_64.json
+++ b/sles-12-x86_64.json
@@ -84,7 +84,6 @@
       "boot_wait": "10s",
       "disk_size": 20480,
       "guest_os_type": "suse",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "58086fca0441b1d44c7a51c5ee64e1bd4365466fcee48ec92c4f39d07739aeed",
       "iso_checksum_type": "sha256",

--- a/ubuntu-10.04-amd64.json
+++ b/ubuntu-10.04-amd64.json
@@ -135,7 +135,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/ubuntu-10.04-i386.json
+++ b/ubuntu-10.04-i386.json
@@ -135,7 +135,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/ubuntu-12.04-amd64.json
+++ b/ubuntu-12.04-amd64.json
@@ -135,7 +135,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/ubuntu-12.04-i386.json
+++ b/ubuntu-12.04-i386.json
@@ -135,7 +135,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/ubuntu-14.04-amd64.json
+++ b/ubuntu-14.04-amd64.json
@@ -135,7 +135,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/ubuntu-14.04-i386.json
+++ b/ubuntu-14.04-i386.json
@@ -135,7 +135,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/ubuntu-14.10-amd64.json
+++ b/ubuntu-14.10-amd64.json
@@ -135,7 +135,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/ubuntu-14.10-i386.json
+++ b/ubuntu-14.10-i386.json
@@ -135,7 +135,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/ubuntu-15.04-amd64.json
+++ b/ubuntu-15.04-amd64.json
@@ -135,7 +135,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/ubuntu-15.04-i386.json
+++ b/ubuntu-15.04-i386.json
@@ -135,7 +135,6 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_os_type": "ubuntu",
-      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",


### PR DESCRIPTION
This option will not be allowed anymore by packer,
it has never been documented and never hade any effect.

See https://github.com/mitchellh/packer/pull/2662