### PR TITLE
remove duplicate auth/authconfig and use sha512 algorithm for password hashing

### DIFF
--- a/http/centos-5.11/ks.cfg
+++ b/http/centos-5.11/ks.cfg
@@ -14,7 +14,6 @@ skipx
 zerombr
 clearpart --all --initlabel
 autopart
-auth  --useshadow  --enablemd5
 firstboot --disabled
 reboot
 user --name=vagrant --password vagrant

--- a/http/fedora-20/ks.cfg
+++ b/http/fedora-20/ks.cfg
@@ -19,7 +19,6 @@ volgroup vg_vagrant --pesize=32768 pv.2
 logvol / --fstype=ext4 --name=lv_root --vgname=vg_vagrant --size=1024 --grow
 logvol swap --fstype=swap --name=lv_swap --vgname=vg_vagrant --size=528 --grow --maxsize=1056
 bootloader --location=mbr --append="norhgb biosdevname=0"
-auth  --useshadow  --enablemd5
 firstboot --disabled
 reboot
 user --name=vagrant --plaintext --password vagrant

--- a/http/fedora-21/ks.cfg
+++ b/http/fedora-21/ks.cfg
@@ -19,7 +19,6 @@ volgroup vg_vagrant --pesize=32768 pv.2
 logvol / --fstype=ext4 --name=lv_root --vgname=vg_vagrant --size=1024 --grow
 logvol swap --fstype=swap --name=lv_swap --vgname=vg_vagrant --size=528 --grow --maxsize=1056
 bootloader --location=mbr --append="norhgb biosdevname=0"
-auth  --useshadow  --enablemd5
 firstboot --disabled
 reboot
 user --name=vagrant --plaintext --password vagrant

--- a/http/fedora-22/ks.cfg
+++ b/http/fedora-22/ks.cfg
@@ -19,7 +19,6 @@ volgroup vg_vagrant --pesize=32768 pv.2
 logvol / --fstype=ext4 --name=lv_root --vgname=vg_vagrant --size=1024 --grow
 logvol swap --fstype=swap --name=lv_swap --vgname=vg_vagrant --size=528 --grow --maxsize=1056
 bootloader --location=mbr --append="norhgb biosdevname=0"
-auth  --useshadow  --enablemd5
 firstboot --disabled
 reboot
 user --name=vagrant --plaintext --password vagrant


### PR DESCRIPTION
auth and authconfig are the same thing, they're used twice in the kickstart
files. the first one tells authconfig to use sha512, the second one tells it to
use md5. the end result the machine is configured to use md5 instead of sha512
for password hashing

https://github.com/rhinstaller/pykickstart/blob/master/docs/kickstart-docs.rst#auth-or-authconfig