### PR TITLE
Adds host only network for nano and enables file and printer sharing

### DIFF
--- a/scripts/windows/SetupComplete.cmd
+++ b/scripts/windows/SetupComplete.cmd
@@ -2,4 +2,6 @@ REG ADD HKLM\Software\Microsoft\Windows\CurrentVersion\WSMAN\Service /v allow_un
 REG ADD HKLM\Software\Microsoft\Windows\CurrentVersion\WSMAN\Service /v auth_basic /t REG_DWORD /d 1 /f
 REG ADD HKLM\Software\Microsoft\Windows\CurrentVersion\WSMAN\Client /v auth_basic /t REG_DWORD /d 1 /f
 
+netsh advfirewall firewall set rule group="File and Printer Sharing" new enable=yes
+
 cmd.exe /c C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -command . c:\windows\setup\scripts\nano_cleanup.ps1 > c:\windows\setup\scripts\cleanup.txt

--- a/vagrantfile_templates/windows-nano.rb
+++ b/vagrantfile_templates/windows-nano.rb
@@ -4,7 +4,7 @@
 Vagrant.configure(2) do |config|
   config.vm.guest = :windows
   config.vm.communicator = "winrm"
-  config.vm.network "private_network", type: "dhcp", virtualbox__intnet: true
+  config.vm.network "private_network", type: "dhcp"
 
   config.vm.provider "virtualbox" do |vb|
     vb.customize ["modifyvm", :id, "--hardwareuuid", "02f110e7-369a-4bbc-bbe6-6f0b6864ccb6"]

--- a/vagrantfile_templates/windows-nano.rb
+++ b/vagrantfile_templates/windows-nano.rb
@@ -4,6 +4,7 @@
 Vagrant.configure(2) do |config|
   config.vm.guest = :windows
   config.vm.communicator = "winrm"
+  config.vm.network "private_network", type: "dhcp", virtualbox__intnet: true
 
   config.vm.provider "virtualbox" do |vb|
     vb.customize ["modifyvm", :id, "--hardwareuuid", "02f110e7-369a-4bbc-bbe6-6f0b6864ccb6"]

--- a/windows-nano-tp3.json
+++ b/windows-nano-tp3.json
@@ -74,6 +74,6 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/7/3/C/73C250BE-67C4-440B-A69B-D0E8EE77F01C/10514.0.150808-1529.TH2_RELEASE_SERVER_OEMRET_X64FRE_EN-US.ISO",
     "metadata": "floppy/dummy_metadata.json",
     "template": "windows-nano-tp3",
-    "version": "1.2.TIMESTAMP"
+    "version": "1.3.TIMESTAMP"
   }
 }

--- a/windows-nano-tp3.json
+++ b/windows-nano-tp3.json
@@ -74,6 +74,6 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/7/3/C/73C250BE-67C4-440B-A69B-D0E8EE77F01C/10514.0.150808-1529.TH2_RELEASE_SERVER_OEMRET_X64FRE_EN-US.ISO",
     "metadata": "floppy/dummy_metadata.json",
     "template": "windows-nano-tp3",
-    "version": "1.1.TIMESTAMP"
+    "version": "1.2.TIMESTAMP"
   }
 }

--- a/windows-nano-tp3.json
+++ b/windows-nano-tp3.json
@@ -74,6 +74,6 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/7/3/C/73C250BE-67C4-440B-A69B-D0E8EE77F01C/10514.0.150808-1529.TH2_RELEASE_SERVER_OEMRET_X64FRE_EN-US.ISO",
     "metadata": "floppy/dummy_metadata.json",
     "template": "windows-nano-tp3",
-    "version": "1.3.TIMESTAMP"
+    "version": "1.1.TIMESTAMP"
   }
 }

--- a/windows-nano-tp3.json
+++ b/windows-nano-tp3.json
@@ -74,6 +74,6 @@
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/7/3/C/73C250BE-67C4-440B-A69B-D0E8EE77F01C/10514.0.150808-1529.TH2_RELEASE_SERVER_OEMRET_X64FRE_EN-US.ISO",
     "metadata": "floppy/dummy_metadata.json",
     "template": "windows-nano-tp3",
-    "version": "1.0.TIMESTAMP"
+    "version": "1.1.TIMESTAMP"
   }
 }


### PR DESCRIPTION
T be able to easily establish a powershell remoting connection to a nano box from another windows vm, I am adding a host only network to expose a reachable ip.

To be able to easily create a SMB share, I am enabling File and Printer sharing firewall rules.