### PR TITLE
Fixing Fedora 22 build tools to fix vm tools

### DIFF
--- a/fedora-22-i386.json
+++ b/fedora-22-i386.json
@@ -141,6 +141,7 @@
         "scripts/common/metadata.sh",
         "scripts/fedora/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
+        "scripts/fedora/22-build-tools.sh",
         "scripts/common/vmtools.sh",
         "scripts/common/vagrant.sh",
         "scripts/fedora/cleanup.sh",

--- a/fedora-22-x86_64.json
+++ b/fedora-22-x86_64.json
@@ -145,6 +145,7 @@
         "scripts/common/metadata.sh",
         "scripts/fedora/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
+        "scripts/fedora/22-build-tools.sh",
         "scripts/common/vmtools.sh",
         "scripts/common/vagrant.sh",
         "scripts/fedora/cleanup.sh",

--- a/http/fedora-22/ks.cfg
+++ b/http/fedora-22/ks.cfg
@@ -23,9 +23,10 @@ firstboot --disabled
 reboot
 user --name=vagrant --plaintext --password vagrant
 
-%packages --nobase --ignoremissing --excludedocs
+%packages --ignoremissing --excludedocs
 bzip2
-gcc
+# GCC won't install during kickstart
+# gcc
 kernel-devel
 kernel-headers
 tar

--- a/scripts/fedora/22-build-tools.sh
+++ b/scripts/fedora/22-build-tools.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -eux
+# Installing build tools here because Fedora 22 will not do so during kickstart
+dnf -y install kernel-headers-$(uname -r) kernel-devel-$(uname -r) gcc make perl


### PR DESCRIPTION
Fedora 22 builds are broken because apparently one cannot install GCC from kickstart (reasons unknown)

- add build tool script just for Fedora 22
- update kickstart and remove deprecated `--nobase` option
- doesn't fix i386 build but that is it's own yak