### PR TITLE
attempt to manage sshd_config in an [more] idempotent manner

### DIFF
--- a/scripts/common/sshd.sh
+++ b/scripts/common/sshd.sh
@@ -1,4 +1,20 @@
 #!/bin/sh -eux
 
-echo "UseDNS no" >>/etc/ssh/sshd_config;
-echo "GSSAPIAuthentication no" >>/etc/ssh/sshd_config;
+SSHD_CONFIG="/etc/ssh/sshd_config"
+
+# ensure that there is a trailing newline before attempting to concatenate
+sed -i -e '$a\' "$SSHD_CONFIG"
+
+USEDNS="UseDNS no"
+if grep -q -E "^[:space:]*UseDNS" "$SSHD_CONFIG"; then
+    sed -i "s/^\s*UseDNS.*/${USEDNS}/" "$SSHD_CONFIG"
+else
+    echo "$USEDNS" >>"$SSHD_CONFIG"
+fi
+
+GSSAPI="GSSAPIAuthentication no"
+if grep -q -E "^[:space:]*GSSAPIAuthentication" "$SSHD_CONFIG"; then
+    sed -i "s/^\s*GSSAPIAuthentication.*/${GSSAPI}/" "$SSHD_CONFIG"
+else
+    echo "$GSSAPI" >>"$SSHD_CONFIG"
+fi


### PR DESCRIPTION
Blindly appending entries to `sshd_config` is problematic if the
configuration keys are already defined and/or the configuration file is
missing a trailing newline.