### PR TITLE
Fix grep character class syntax in sshd.sh script

### DIFF
--- a/scripts/common/sshd.sh
+++ b/scripts/common/sshd.sh
@@ -6,14 +6,14 @@ SSHD_CONFIG="/etc/ssh/sshd_config"
 sed -i -e '$a\' "$SSHD_CONFIG"
 
 USEDNS="UseDNS no"
-if grep -q -E "^[:space:]*UseDNS" "$SSHD_CONFIG"; then
+if grep -q -E "^[[:space:]]*UseDNS" "$SSHD_CONFIG"; then
     sed -i "s/^\s*UseDNS.*/${USEDNS}/" "$SSHD_CONFIG"
 else
     echo "$USEDNS" >>"$SSHD_CONFIG"
 fi
 
 GSSAPI="GSSAPIAuthentication no"
-if grep -q -E "^[:space:]*GSSAPIAuthentication" "$SSHD_CONFIG"; then
+if grep -q -E "^[[:space:]]*GSSAPIAuthentication" "$SSHD_CONFIG"; then
     sed -i "s/^\s*GSSAPIAuthentication.*/${GSSAPI}/" "$SSHD_CONFIG"
 else
     echo "$GSSAPI" >>"$SSHD_CONFIG"


### PR DESCRIPTION
This PR fixes the following error:
```
==> parallels-iso: Provisioning with shell script: scripts/common/sshd.sh
    parallels-iso: grep: character class syntax is [[:space:]], not [:space:]
    parallels-iso: grep: character class syntax is [[:space:]], not [:space:]
```

cc: @jhoblitt