### PR TITLE
Disable automatic udev rules for network interfaces in CentOS

### DIFF
--- a/scripts/centos/cleanup.sh
+++ b/scripts/centos/cleanup.sh
@@ -19,6 +19,9 @@ fi
 
 # Clean up network interface persistence
 rm -f /etc/udev/rules.d/70-persistent-net.rules;
+mkdir -p /etc/udev/rules.d/70-persistent-net.rules;
+rm -f /lib/udev/rules.d/75-persistent-net-generator.rules;
+rm -rf /dev/.udev/;
 
 for ndev in `ls -1 /etc/sysconfig/network-scripts/ifcfg-*`; do
     if [ "`basename $ndev`" != "ifcfg-lo" ]; then


### PR DESCRIPTION
This PR makes thec lean-up of udev rules similar to ubuntu/debian approach:
https://github.com/chef/bento/blob/6d5771a/scripts/ubuntu/networking.sh#L3-L8
https://github.com/chef/bento/blob/250efaa/scripts/debian/networking.sh#L3-L8

It's not enough just to remove `/etc/udev/rules.d/70-persistent-net.rules`. We should also replace it with a directory and remove `/lib/udev/rules.d/75-persistent-net-generator.rules` to prevent the generating of new rules. 

P.s. It is already implemented in boxcutter project and it works fine:
https://github.com/boxcutter/centos/blob/a732c24/script/cleanup.sh#L3-L14