### PR TITLE
Fix dhcp settings cleanup in Ubuntu 12.04 and higher

### DIFF
--- a/scripts/ubuntu/networking.sh
+++ b/scripts/ubuntu/networking.sh
@@ -5,7 +5,7 @@
 rm -f /etc/udev/rules.d/70-persistent-net.rules;
 mkdir -p /etc/udev/rules.d/70-persistent-net.rules;
 rm -f /lib/udev/rules.d/75-persistent-net-generator.rules;
-rm -rf /dev/.udev/ /var/lib/dhcp3/*;
+rm -rf /dev/.udev/ /var/lib/dhcp3/* /var/lib/dhcp/*;
 
 # Adding a 2 sec delay to the interface up, to make the dhclient happy
 echo "pre-up sleep 2" >>/etc/network/interfaces;


### PR DESCRIPTION
There is a typo. It should be `/var/lib/dhcp/*`, like in the similar script for Debian: https://github.com/chef/bento/blob/250efaa/scripts/debian/networking.sh#L8