### PR TITLE
Removed spaces in variable assignment

### DIFF
--- a/scripts/centos/cleanup.sh
+++ b/scripts/centos/cleanup.sh
@@ -1,9 +1,9 @@
 #!/bin/sh -eux
 
 if [ -s /etc/oracle-release ]; then
-  distro = 'oracle'
+  distro='oracle'
 elif [ -s /etc/enterprise-release ]; then
-  distro = 'oracle'
+  distro='oracle'
 elif [ -s /etc/redhat-release ]; then
   # should ouput 'centos' OR 'red hat'
   distro=`cat /etc/redhat-release | sed 's/^\(CentOS\|Red Hat\).*/\1/i' | tr '[:upper:]' '[:lower:]'`


### PR DESCRIPTION
As this is a shell script, we can't have spaces between the variable and it's value