### PR TITLE
Enterprise Linux 7.2 (RHEL/CentOS/OEL)

### DIFF
--- a/centos-7.2-x86_64.json
+++ b/centos-7.2-x86_64.json
@@ -7,7 +7,7 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
-      "guest_os_type": "Oracle_64",
+      "guest_os_type": "RedHat_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
@@ -44,7 +44,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "guest_os_type": "oraclelinux-64",
+      "guest_os_type": "centos-64",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
@@ -143,8 +143,8 @@
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/common/metadata.sh",
-        "scripts/centos/networking.sh",
         "scripts/common/sshd.sh",
+        "scripts/centos/networking.sh",
         "scripts/common/vagrant.sh",
         "scripts/common/vmtools.sh",
         "scripts/centos/cleanup.sh",
@@ -154,23 +154,23 @@
     }
   ],
   "variables": {
-    "arch": "64",
-    "box_basename": "oracle-7.1",
+    "box_basename": "centos-7.2",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "iso_checksum": "FA9666448E8A24AD6A4C7203575B66532FA833D7",
-    "iso_checksum_type": "sha1",
-    "iso_name": "OracleLinux-R7-U1-Server-x86_64-dvd.iso",
-    "ks_path": "centos-7.1/ks.cfg",
+    "iso_checksum": "907e5755f824c5848b9c8efbb484f3cd945e93faa024bad6ba875226f9683b16",
+    "iso_checksum_type": "sha256",
+    "iso_name": "CentOS-7-x86_64-DVD-1511.iso",
+    "ks_path": "centos-7.2/ks.cfg",
     "metadata": "floppy/dummy_metadata.json",
-    "mirror": "http://mirrors.dotsrc.org/oracle-linux",
-    "mirror_directory": "OL7/u1/x86_64",
-    "name": "oracle-7.1",
+    "mirror": "http://mirrors.kernel.org/centos",
+    "mirror_directory": "7.2.1511/isos/x86_64",
+    "name": "centos-7.2",
     "no_proxy": "{{env `no_proxy`}}",
-    "template": "oracle-7.1-x86_64",
-    "version": "2.2.TIMESTAMP"
+    "template": "centos-7.2-x86_64",
+    "version": "2.1.TIMESTAMP"
   }
 }
+

--- a/http/centos-7.2/ks.cfg
+++ b/http/centos-7.2/ks.cfg
@@ -28,6 +28,7 @@ kernel-devel
 gcc
 make
 perl
+selinux-policy-devel
 wget
 nfs-utils
 net-tools

--- a/oracle-7.2-x86_64.json
+++ b/oracle-7.2-x86_64.json
@@ -7,7 +7,7 @@
       "boot_wait": "10s",
       "disk_size": 40960,
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
-      "guest_os_type": "RedHat_64",
+      "guest_os_type": "Oracle_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
@@ -44,7 +44,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
-      "guest_os_type": "centos-64",
+      "guest_os_type": "oraclelinux-64",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
@@ -143,8 +143,8 @@
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/common/metadata.sh",
-        "scripts/common/sshd.sh",
         "scripts/centos/networking.sh",
+        "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",
         "scripts/common/vmtools.sh",
         "scripts/centos/cleanup.sh",
@@ -154,23 +154,23 @@
     }
   ],
   "variables": {
-    "box_basename": "centos-7.1",
+    "arch": "64",
+    "box_basename": "oracle-7.2",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "iso_checksum": "85bcf62462fb678adc0cec159bf8b39ab5515404bc3828c432f743a1b0b30157",
-    "iso_checksum_type": "sha256",
-    "iso_name": "CentOS-7-x86_64-DVD-1503-01.iso",
-    "ks_path": "centos-7.1/ks.cfg",
+    "iso_checksum": "03E048F23D798C8E8E7935FAB76245C2F1341378",
+    "iso_checksum_type": "sha1",
+    "iso_name": "OracleLinux-R7-U2-Server-x86_64-dvd.iso",
+    "ks_path": "centos-7.2/ks.cfg",
     "metadata": "floppy/dummy_metadata.json",
-    "mirror": "http://mirrors.kernel.org/centos",
-    "mirror_directory": "7.1.1503/isos/x86_64",
-    "name": "centos-7.1",
+    "mirror": "http://mirrors.dotsrc.org/oracle-linux",
+    "mirror_directory": "OL7/u2/x86_64",
+    "name": "oracle-7.2",
     "no_proxy": "{{env `no_proxy`}}",
-    "template": "centos-7.1-x86_64",
-    "version": "2.1.TIMESTAMP"
+    "template": "oracle-7.2-x86_64",
+    "version": "2.2.TIMESTAMP"
   }
 }
-

--- a/rhel-7.2-x86_64.json
+++ b/rhel-7.2-x86_64.json
@@ -155,22 +155,22 @@
   ],
   "variables": {
     "arch": "64",
-    "box_basename": "rhel-7.1",
+    "box_basename": "rhel-7.2",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "git_revision": "__unknown_git_revision__",
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "iso_checksum": "3685468ec6cdcb70dfc85ebbc164da427dc2d762644c3c2ee1520f4f661c15ce",
+    "iso_checksum": "03f3a0291634335f6995534d829bd21ffaa0d000004dfeb1b2fb81052d64a4d5",
     "iso_checksum_type": "sha256",
-    "iso_name": "rhel-server-7.1-x86_64-dvd.iso",
-    "ks_path": "centos-7.1/ks.cfg",
+    "iso_name": "rhel-server-7.2-x86_64-dvd.iso",
+    "ks_path": "centos-7.2/ks.cfg",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://YOU-MUST-PROVIDE-YOUR-OWN-ISO.sorry",
     "mirror_directory": "rhel",
-    "name": "rhel-7.1",
+    "name": "rhel-7.2",
     "no_proxy": "{{env `no_proxy`}}",
-    "template": "rhel-7.1-x86_64",
+    "template": "rhel-7.2-x86_64",
     "version": "2.2.TIMESTAMP"
   }
 }


### PR DESCRIPTION
Updated RHEL/CentOS/OEL to **7.2**

_Note:_ To install Parallels Tools package ```selinux-policy-devel``` is needed.

All builds passes on Parallels Desktop Pro 11.1.1, VMware Fusion Pro 7.1.3, and VirtualBox 5.0.10. Beside that I haven't done much testing of the boxes.