### PR TITLE
Stops DKMS package from being removed.

### DIFF
--- a/scripts/debian/cleanup.sh
+++ b/scripts/debian/cleanup.sh
@@ -27,9 +27,6 @@ dpkg --list \
     | grep -- '-dev$' \
     | xargs apt-get -y purge;
 
-# Delete compilers and other development tools
-apt-get -y purge cpp gcc g++;
-
 # Delete X11 libraries
 apt-get -y purge libx11-data xauth libxmuu1 libxcb1 libx11-6 libxext6;
 

--- a/scripts/ubuntu/cleanup.sh
+++ b/scripts/ubuntu/cleanup.sh
@@ -27,9 +27,6 @@ dpkg --list \
     | grep -- '-dev$' \
     | xargs apt-get -y purge;
 
-# Delete compilers and other development tools
-apt-get -y purge cpp gcc g++;
-
 # Delete X11 libraries
 apt-get -y purge libx11-data xauth libxmuu1 libxcb1 libx11-6 libxext6;
 


### PR DESCRIPTION
DKMS is needed to recompile the guest additions if a new kernel
is installed.  Removing the C/C++ packages also removes the `dkms`
package.  This fixes #509 for Dedian based distros.