### PR TITLE
Revert "fix or suppress all shellcheck warnings"

### DIFF
--- a/scripts/centos/cleanup.sh
+++ b/scripts/centos/cleanup.sh
@@ -6,7 +6,7 @@ elif [ -s /etc/enterprise-release ]; then
   distro='oracle'
 elif [ -s /etc/redhat-release ]; then
   # should ouput 'centos' OR 'red hat'
-  distro=$(sed 's/^\(CentOS\|Red Hat\).*/\1/i' /etc/redhat-release | tr '[:upper:]' '[:lower:]')
+  distro=`cat /etc/redhat-release | sed 's/^\(CentOS\|Red Hat\).*/\1/i' | tr '[:upper:]' '[:lower:]'`
 fi
 
 
@@ -23,8 +23,8 @@ mkdir -p /etc/udev/rules.d/70-persistent-net.rules;
 rm -f /lib/udev/rules.d/75-persistent-net-generator.rules;
 rm -rf /dev/.udev/;
 
-for ndev in /etc/sysconfig/network-scripts/ifcfg-*; do
-    if [ "$(basename "$ndev")" != "ifcfg-lo" ]; then
+for ndev in `ls -1 /etc/sysconfig/network-scripts/ifcfg-*`; do
+    if [ "`basename $ndev`" != "ifcfg-lo" ]; then
         sed -i '/^HWADDR/d' "$ndev";
         sed -i '/^UUID/d' "$ndev";
     fi

--- a/scripts/centos/networking.sh
+++ b/scripts/centos/networking.sh
@@ -3,7 +3,7 @@
 case "$PACKER_BUILDER_TYPE" in
 
 virtualbox-iso|virtualbox-ovf)
-    major_version="$(sed 's/^.\+ release \([.0-9]\+\).*/\1/' /etc/redhat-release | awk -F. '{print $1}')";
+    major_version="`sed 's/^.\+ release \([.0-9]\+\).*/\1/' /etc/redhat-release | awk -F. '{print $1}'`";
 
     if [ "$major_version" -ge 6 ]; then
         # Fix slow DNS:

--- a/scripts/common/minimize.sh
+++ b/scripts/common/minimize.sh
@@ -5,7 +5,7 @@ case "$PACKER_BUILDER_TYPE" in
 esac
 
 set +e
-swapuuid="$(/sbin/blkid -o value -l -s UUID -t TYPE=swap)";
+swapuuid="`/sbin/blkid -o value -l -s UUID -t TYPE=swap`";
 case "$?" in
 	2|0) ;;
 	*) exit 1 ;;
@@ -15,7 +15,7 @@ set -e
 if [ "x${swapuuid}" != "x" ]; then
     # Whiteout the swap partition to reduce box size
     # Swap is disabled till reboot
-    swappart="$(readlink -f /dev/disk/by-uuid/"$swapuuid")";
+    swappart="`readlink -f /dev/disk/by-uuid/$swapuuid`";
     /sbin/swapoff "$swappart";
     dd if=/dev/zero of="$swappart" bs=1M || echo "dd exit code $? is suppressed";
     /sbin/mkswap -U "$swapuuid" "$swappart";

--- a/scripts/common/shutdown.sh
+++ b/scripts/common/shutdown.sh
@@ -1,3 +1,1 @@
-#!/bin/sh -eux
-
 shutdown -P now

--- a/scripts/common/sshd.sh
+++ b/scripts/common/sshd.sh
@@ -3,7 +3,6 @@
 SSHD_CONFIG="/etc/ssh/sshd_config"
 
 # ensure that there is a trailing newline before attempting to concatenate
-# shellcheck disable=SC1003
 sed -i -e '$a\' "$SSHD_CONFIG"
 
 USEDNS="UseDNS no"

--- a/scripts/common/vagrant.sh
+++ b/scripts/common/vagrant.sh
@@ -4,16 +4,16 @@
 HOME_DIR="${HOME_DIR:-/home/vagrant}";
 
 pubkey_url="https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub";
-mkdir -p "$HOME_DIR"/.ssh;
+mkdir -p $HOME_DIR/.ssh;
 if command -v wget >/dev/null 2>&1; then
-    wget --no-check-certificate "$pubkey_url" -O "$HOME_DIR"/.ssh/authorized_keys;
+    wget --no-check-certificate "$pubkey_url" -O $HOME_DIR/.ssh/authorized_keys;
 elif command -v curl >/dev/null 2>&1; then
-    curl --insecure --location "$pubkey_url" > "$HOME_DIR"/.ssh/authorized_keys;
+    curl --insecure --location "$pubkey_url" > $HOME_DIR/.ssh/authorized_keys;
 elif command -v fetch >/dev/null 2>&1; then
-    fetch -am -o "$HOME_DIR"/.ssh/authorized_keys "$pubkey_url";
+    fetch -am -o $HOME_DIR/.ssh/authorized_keys "$pubkey_url";
 else
     echo "Cannot download vagrant public key";
     exit 1;
 fi
-chown -R vagrant "$HOME_DIR"/.ssh;
-chmod -R go-rwsx "$HOME_DIR"/.ssh;
+chown -R vagrant $HOME_DIR/.ssh;
+chmod -R go-rwsx $HOME_DIR/.ssh;

--- a/scripts/common/vmtools.sh
+++ b/scripts/common/vmtools.sh
@@ -7,31 +7,31 @@ case "$PACKER_BUILDER_TYPE" in
 
 virtualbox-iso|virtualbox-ovf)
     mkdir -p /tmp/vbox;
-    ver="$(cat /home/vagrant/.vbox_version)";
-    mount -o loop "$HOME_DIR/VBoxGuestAdditions_${ver}.iso" /tmp/vbox;
+    ver="`cat /home/vagrant/.vbox_version`";
+    mount -o loop $HOME_DIR/VBoxGuestAdditions_${ver}.iso /tmp/vbox;
     sh /tmp/vbox/VBoxLinuxAdditions.run \
         || echo "VBoxLinuxAdditions.run exited $? and is suppressed." \
             "For more read https://www.virtualbox.org/ticket/12479";
     umount /tmp/vbox;
     rm -rf /tmp/vbox;
-    rm -f "$HOME_DIR"/*.iso;
+    rm -f $HOME_DIR/*.iso;
     ;;
 
 vmware-iso|vmware-vmx)
     mkdir -p /tmp/vmfusion;
     mkdir -p /tmp/vmfusion-archive;
-    mount -o loop "$HOME_DIR/linux.iso" /tmp/vmfusion;
+    mount -o loop $HOME_DIR/linux.iso /tmp/vmfusion;
     tar xzf /tmp/vmfusion/VMwareTools-*.tar.gz -C /tmp/vmfusion-archive;
     /tmp/vmfusion-archive/vmware-tools-distrib/vmware-install.pl --force-install;
     umount /tmp/vmfusion;
     rm -rf  /tmp/vmfusion;
     rm -rf  /tmp/vmfusion-archive;
-    rm -f "$HOME_DIR"/*.iso;
+    rm -f $HOME_DIR/*.iso;
     ;;
 
 parallels-iso|parallels-pvm)
     mkdir -p /tmp/parallels;
-    mount -o loop "$HOME_DIR/prl-tools-lin.iso" /tmp/parallels;
+    mount -o loop $HOME_DIR/prl-tools-lin.iso /tmp/parallels;
     /tmp/parallels/install --install-unattended-with-deps \
       || (code="$?"; \
           echo "Parallels tools installation exited $code, attempting" \
@@ -40,7 +40,7 @@ parallels-iso|parallels-pvm)
           exit $code);
     umount /tmp/parallels;
     rm -rf /tmp/parallels;
-    rm -f "$HOME_DIR"/*.iso;
+    rm -f $HOME_DIR/*.iso;
     ;;
 
 qemu)

--- a/scripts/debian/cleanup.sh
+++ b/scripts/debian/cleanup.sh
@@ -12,7 +12,7 @@ dpkg --list \
 dpkg --list \
     | awk '{ print $2 }' \
     | grep 'linux-image-[234].*' \
-    | grep -v "$(uname -r)" \
+    | grep -v `uname -r` \
     | xargs apt-get -y purge;
 
 # Delete Linux source

--- a/scripts/debian/update.sh
+++ b/scripts/debian/update.sh
@@ -1,11 +1,11 @@
 #!/bin/sh -eux
 
-arch="$(uname -r | sed 's/^.*[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\(-[0-9]\{1,2\}\)-//')"
+arch="`uname -r | sed 's/^.*[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\(-[0-9]\{1,2\}\)-//'`"
 
 apt-get update;
 
-apt-get -y "upgrade linux-image-$arch";
-apt-get -y "install linux-headers-$(uname -r)";
+apt-get -y upgrade linux-image-$arch;
+apt-get -y install linux-headers-`uname -r`;
 
 if [ -d /etc/init ]; then
     # update package index on boot

--- a/scripts/fedora/22-build-tools.sh
+++ b/scripts/fedora/22-build-tools.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -eux
 # Installing build tools here because Fedora 22 will not do so during kickstart
-dnf -y install "kernel-headers-$(uname -r)" "kernel-devel-$(uname -r)" gcc make perl
+dnf -y install kernel-headers-$(uname -r) kernel-devel-$(uname -r) gcc make perl

--- a/scripts/fedora/shutdown.sh
+++ b/scripts/fedora/shutdown.sh
@@ -1,3 +1,1 @@
-#!/bin/sh -eux
-
 /sbin/halt -h -p

--- a/scripts/freebsd/update.sh
+++ b/scripts/freebsd/update.sh
@@ -5,7 +5,7 @@
 [ -z "$http_proxy" ] && unset http_proxy
 [ -z "$https_proxy" ] && unset https_proxy
 
-major_version="$(uname -r | awk -F. '{print $1}')";
+major_version="`uname -r | awk -F. '{print $1}'`";
 
 if [ "$major_version" -lt 10 ]; then
   # Allow freebsd-update to run fetch without stdin attached to a terminal
@@ -19,8 +19,8 @@ fi
 
 # Update FreeBSD
 # NOTE: this will fail if there aren't any patches available for the release yet
-env PAGER=/bin/cat "$freebsd_update" fetch;
-env PAGER=/bin/cat "$freebsd_update" install;
+env PAGER=/bin/cat $freebsd_update fetch;
+env PAGER=/bin/cat $freebsd_update install;
 
 # Always use pkgng - pkg_add is EOL as of 1 September 2014
 env ASSUME_ALWAYS_YES=true pkg bootstrap;

--- a/scripts/freebsd/vmtools.sh
+++ b/scripts/freebsd/vmtools.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -eux
 
-freebsd_major="$(uname -r | awk -F. '{print $1}')";
+freebsd_major="`uname -r | awk -F. '{print $1}'`";
 
 case "$PACKER_BUILDER_TYPE" in
 
@@ -35,13 +35,13 @@ virtualbox-iso|virtualbox-ovf)
 vmware-iso|vmware-vmx)
     # Install Perl and other software needed by vmware-install.pl
     pkg install -y perl5;
-    pkg install -y "compat6x-$(uname -m)";
+    pkg install -y compat6x-`uname -m`;
     # the install script is very picky about location of perl command
     ln -s /usr/local/bin/perl /usr/bin/perl;
 
     mkdir -p /tmp/vmfusion;
     mkdir -p /tmp/vmfusion-archive;
-    mdconfig -a -t vnode -f "$HOME_DIR/freebsd.iso" -u 0;
+    mdconfig -a -t vnode -f $HOME_DIR/freebsd.iso -u 0;
     mount -t cd9660 /dev/md0 /tmp/vmfusion;
     tar xzf /tmp/vmfusion/vmware-freebsd-tools.tar.gz -C /tmp/vmfusion-archive;
     /tmp/vmfusion-archive/vmware-tools-distrib/vmware-install.pl --force-install;
@@ -49,7 +49,7 @@ vmware-iso|vmware-vmx)
     umount /tmp/vmfusion;
     rm -rf /tmp/vmfusion;
     rm -rf /tmp/vmfusion-archive;
-    rm -f "$HOME_DIR/*.iso";
+    rm -f $HOME_DIR/*.iso;
 
     rm -f /usr/bin/perl;
     ;;

--- a/scripts/macosx/hostname.sh
+++ b/scripts/macosx/hostname.sh
@@ -2,7 +2,7 @@
 # Major thanks to @timsutton's osx-vm-templates:
 # https://github.com/timsutton/osx-vm-templates
 
-osx_minor_version="$(sw_vers -productVersion | awk -F '.' '{print $2}')";
+osx_minor_version="`sw_vers -productVersion | awk -F '.' '{print $2}'`";
 
 # Set computer/hostname
 computer_name="macosx-10-${osx_minor_version}";

--- a/scripts/macosx/vagrant.sh
+++ b/scripts/macosx/vagrant.sh
@@ -1,14 +1,14 @@
 #!/bin/bash -eux
 
 pubkey_url="https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub";
-mkdir -p "$HOME_DIR/.ssh";
+mkdir -p $HOME_DIR/.ssh;
 if command -v wget >/dev/null 2>&1; then
-    wget --no-check-certificate "$pubkey_url" -O "$HOME_DIR/.ssh/authorized_keys";
+    wget --no-check-certificate "$pubkey_url" -O $HOME_DIR/.ssh/authorized_keys;
 elif command -v curl >/dev/null 2>&1; then
-    curl --insecure --location "$pubkey_url" > "$HOME_DIR/.ssh/authorized_keys";
+    curl --insecure --location "$pubkey_url" > $HOME_DIR/.ssh/authorized_keys;
 else
     echo "Cannot download vagrant public key";
     exit 1;
 fi
-chown -R vagrant "$HOME_DIR/.ssh";
-chmod -R go-rwsx "$HOME_DIR/.ssh";
+chown -R vagrant $HOME_DIR/.ssh;
+chmod -R go-rwsx $HOME_DIR/.ssh;

--- a/scripts/macosx/vmtools.sh
+++ b/scripts/macosx/vmtools.sh
@@ -8,7 +8,7 @@ virtualbox-iso|virtualbox-ovf)
 
 vmware-iso|vmware-vmx)
     iso_name="/tmp/vmtools.iso";
-    mount_point="$(mktemp -d /tmp/vmware-tools.XXXX)";
+    mount_point="`mktemp -d /tmp/vmware-tools.XXXX`";
     #Run install, unmount ISO and remove it
     hdiutil attach "$iso_name" -mountpoint "$mount_point";
     installer -pkg "$mount_point/Install VMware Tools.app/Contents/Resources/VMware Tools.pkg" -target /;
@@ -25,7 +25,7 @@ vmware-iso|vmware-vmx)
 
 parallels-iso|parallels-pvm)
     TOOLS_PATH="$HOME_DIR/prl-tools-mac.iso";
-    TMPMOUNT="$(/usr/bin/mktemp -d /tmp/parallels-tools.XXXX)";
+    TMPMOUNT="`/usr/bin/mktemp -d /tmp/parallels-tools.XXXX`";
 
     #Run install, unmount ISO and remove it
     hdiutil attach "$TOOLS_PATH" -mountpoint "$TMPMOUNT";

--- a/scripts/omnios/postinstall.sh
+++ b/scripts/omnios/postinstall.sh
@@ -45,7 +45,7 @@ svcadm restart ssh
 
 # update grub menu to lower timeout and remove unnecessary second entry
 echo "Updating Grub boot menu"
-sed -i -e 's/^timeout.*$/timeout 5/' -e "/^title omniosvar/,$(wc -l /rpool/boot/grub/menu.lst | awk '{ print $1 }') d" /rpool/boot/grub/menu.lst
+sed -i -e 's/^timeout.*$/timeout 5/' -e "/^title omniosvar/,`wc -l /rpool/boot/grub/menu.lst | awk '{ print $1 }'` d" /rpool/boot/grub/menu.lst
 
 # Reset resolv.conf
 echo "Resetting resolv.conf"

--- a/scripts/omnios/vmtools.sh
+++ b/scripts/omnios/vmtools.sh
@@ -1,31 +1,29 @@
-#!/bin/bash
+#!/bin/sh
 
-if [ "$PACKER_BUILDER_TYPE" == 'virtualbox' ]; then
+if [ $PACKER_BUILDER_TYPE == 'virtualbox' ]; then
   echo "Installing VirtualBox Guest Additions"
-  {
-    echo -e "mail=\ninstance=overwrite\npartial=quit"
-    echo -e "runlevel=nocheck\nidepend=quit\nrdepend=quit"
-    echo -e "space=quit\nsetuid=nocheck\nconflict=nocheck"
-    echo -e "action=nocheck\nbasedir=default"
-  } > /tmp/noask.admin
+  echo "mail=\ninstance=overwrite\npartial=quit" > /tmp/noask.admin
+  echo "runlevel=nocheck\nidepend=quit\nrdepend=quit" >> /tmp/noask.admin
+  echo "space=quit\nsetuid=nocheck\nconflict=nocheck" >> /tmp/noask.admin
+  echo "action=nocheck\nbasedir=default" >> /tmp/noask.admin
   mkdir /mnt/vbga
-  VBGADEV=$(lofiadm -a VBoxGuestAdditions.iso)
-  mount -o ro -F hsfs "$VBGADEV" /mnt/vbga
+  VBGADEV=`lofiadm -a VBoxGuestAdditions.iso`
+  mount -o ro -F hsfs $VBGADEV /mnt/vbga
   pkgadd -a /tmp/noask.admin -G -d /mnt/vbga/VBoxSolarisAdditions.pkg all
   umount /mnt/vbga
-  lofiadm -d "$VBGADEV"
+  lofiadm -d $VBGADEV
   rm -f VBoxGuestAdditions.iso
 fi
 
-if [ "$PACKER_BUILDER_TYPE" == 'vmware' ]; then
+if [ $PACKER_BUILDER_TYPE == 'vmware' ]; then
   mkdir /mnt/vmtools
-  VMTOOLSDEV=$(lofiadm -a solaris.iso)
-  mount -o ro -F hsfs "$VMTOOLSDEV" /mnt/vmtools
+  VMTOOLSDEV=`lofiadm -a solaris.iso`
+  mount -o ro -F hsfs $VMTOOLSDEV /mnt/vmtools
   mkdir /tmp/vmfusion-archive
   tar zxvf /mnt/vmtools/vmware-solaris-tools.tar.gz -C /tmp/vmfusion-archive
   /tmp/vmfusion-archive/vmware-tools-distrib/vmware-install.pl --force-install
   umount /mnt/vmtools
-  lofiadm -d "$VMTOOLSDEV"
+  lofiadm -d $VMTOOLSDEV
   rmdir /mnt/vmtools
   rm -rf /tmp/vmfusion-archive
   rm -f solaris.iso

--- a/scripts/opensuse/sudoers.sh
+++ b/scripts/opensuse/sudoers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eux
+#!/bin/sh -eux
 
 # update sudoers - can't do this in autoinst.xml
 echo -e "\nupdate sudoers ..."

--- a/scripts/sles/remove-dvd-source.sh
+++ b/scripts/sles/remove-dvd-source.sh
@@ -1,14 +1,20 @@
-#!/bin/bash -eux
+#!/bin/sh -eux
 
-oslevel=$(grep VERSION /etc/SuSE-release | awk '{ print $3 }')
-patchlevel=$(grep PATCHLEVEL /etc/SuSE-release | awk '{ print $3 }')
+if [ 'x86_64' == `uname -m` ]; then
+  arch_suffix=x64
+else
+  arch_suffix=x86
+fi
 
-if [ "$oslevel" == '11' ]; then
-  if [ "$patchlevel" == '2' ]; then
+oslevel=`grep VERSION /etc/SuSE-release | awk '{ print $3 }'`
+patchlevel=`grep PATCHLEVEL /etc/SuSE-release | awk '{ print $3 }'`
+
+if [ $oslevel == '11' ]; then
+  if [ $patchlevel == '2' ]; then
     repo_ver="11.2.2-1.234"
-  elif [ "$patchlevel" == '3' ]; then
+  elif [ $patchlevel == '3' ]; then
     repo_ver="11.3.3-1.138"
-  elif [ "$patchlevel" == '4' ]; then
+  elif [ $patchlevel == '4' ]; then
     repo_ver="11.4.4-1.109"
   else
     echo "Failed to remove DVD source; don't know how to deal with patchlevel $patchlevel"
@@ -16,7 +22,7 @@ if [ "$oslevel" == '11' ]; then
   fi
   zypper removerepo "SUSE-Linux-Enterprise-Server-11-SP$patchlevel $repo_ver"
 
-elif [ "$oslevel" == '12' ]; then
+elif [ $oslevel == '12' ]; then
   zypper removerepo "SLES12-12-$patchlevel";
 fi
 

--- a/scripts/sles/sudoers.sh
+++ b/scripts/sles/sudoers.sh
@@ -1,5 +1,3 @@
-#!/bin/bash -eux
-
 # update sudoers - can't do this in autoinst.xml
 echo -e "\nupdate sudoers ..."
 echo -e "vagrant ALL=(ALL) NOPASSWD: ALL\n" >> /etc/sudoers

--- a/scripts/sles/zypper-locks.sh
+++ b/scripts/sles/zypper-locks.sh
@@ -1,7 +1,7 @@
-#!/bin/bash -eux
+#!/bin/sh -eux
 
 # remove zypper locks on removed packages to avoid later dependency problems
-any_package_locks=$(zypper --non-interactive ll | grep package);
+any_package_locks=`zypper --non-interactive ll | grep package`;
 
 if [ 'There are no package locks defined.' == "$any_package_locks" ]; then
   echo 'There are no package locks defined. Doing nothing.';

--- a/scripts/solaris/vmtools.sh
+++ b/scripts/solaris/vmtools.sh
@@ -3,27 +3,24 @@
 # Add pkgadd auto-answer file
 sudo mkdir -p /tmp
 sudo chmod 777 /tmp
-{
-    echo "mail="
-    echo "instance=overwrite"
-    echo "partial=nocheck"
-    echo "runlevel=nocheck"
-    echo "idepend=nocheck"
-    echo "rdepend=nocheck"
-    echo "space=nocheck"
-    echo "setuid=nocheck"
-    echo "conflict=nocheck"
-    echo "action=nocheck"
-    echo "basedir=default"
-} >> /tmp/nocheck
+echo "mail=" > /tmp/nocheck
+echo "instance=overwrite" >> /tmp/nocheck
+echo "partial=nocheck" >> /tmp/nocheck
+echo "runlevel=nocheck" >> /tmp/nocheck
+echo "idepend=nocheck" >> /tmp/nocheck
+echo "rdepend=nocheck" >> /tmp/nocheck
+echo "space=nocheck" >> /tmp/nocheck
+echo "setuid=nocheck" >> /tmp/nocheck
+echo "conflict=nocheck" >> /tmp/nocheck
+echo "action=nocheck" >> /tmp/nocheck
+echo "basedir=default" >> /tmp/nocheck
 
 echo "all" > /tmp/allfiles
 
 if [ -f /home/vagrant/.vbox_version ]; then
     mkdir /tmp/vbox
+    VER=$(cat /home/vagrant/.vbox_version)
     ls
-    # XXX does this redirect actually work?
-    # shellcheck disable=SC2024
     sudo -i pkgadd -a /tmp/nocheck -d /media/VBOXADDITIONS_*/VBoxSolarisAdditions.pkg < /tmp/allfiles
 fi
 

--- a/scripts/solaris10/vmtools.sh
+++ b/scripts/solaris10/vmtools.sh
@@ -1,41 +1,39 @@
 #!/bin/bash -eux
 
 # Add pkgadd auto-answer file
-{
-    echo "mail="
-    echo "instance=overwrite"
-    echo "partial=nocheck"
-    echo "runlevel=nocheck"
-    echo "idepend=nocheck"
-    echo "rdepend=nocheck"
-    echo "space=nocheck"
-    echo "setuid=nocheck"
-    echo "conflict=nocheck"
-    echo "action=nocheck"
-    echo "basedir=default"
-} >> /tmp/nocheck
-
+echo "mail=" > /tmp/nocheck
+echo "instance=overwrite" >> /tmp/nocheck
+echo "partial=nocheck" >> /tmp/nocheck
+echo "runlevel=nocheck" >> /tmp/nocheck
+echo "idepend=nocheck" >> /tmp/nocheck
+echo "rdepend=nocheck" >> /tmp/nocheck
+echo "space=nocheck" >> /tmp/nocheck
+echo "setuid=nocheck" >> /tmp/nocheck
+echo "conflict=nocheck" >> /tmp/nocheck
+echo "action=nocheck" >> /tmp/nocheck
+echo "basedir=default" >> /tmp/nocheck
 
 echo "all" > /tmp/allfiles
 
 if [ -f /home/vagrant/.vbox_version ]; then
     mkdir /tmp/vbox
+    VER=$(cat /home/vagrant/.vbox_version)
     mkdir /cdrom
-    VBGADEV=$(lofiadm -a /home/vagrant/VBoxGuestAdditions.iso)
-    mount -o ro -F hsfs "$VBGADEV" /cdrom
+    VBGADEV=`lofiadm -a /home/vagrant/VBoxGuestAdditions.iso`
+    mount -o ro -F hsfs $VBGADEV /cdrom
     pkgadd -a /tmp/nocheck -d /cdrom/VBoxSolarisAdditions.pkg < /tmp/allfiles
     umount /cdrom
-    lofiadm -d "$VBGADEV"
+    lofiadm -d $VBGADEV
     rm -f /home/vagrant/VBoxGuestAdditions.iso
 else
-    VMTOOLSDEV=$(/usr/sbin/lofiadm -a /home/vagrant/solaris.iso)
+    VMTOOLSDEV=`/usr/sbin/lofiadm -a /home/vagrant/solaris.iso`
     mkdir /cdrom
-    mount -o ro -F hsfs "$VMTOOLSDEV" /cdrom
+    mount -o ro -F hsfs $VMTOOLSDEV /cdrom
     mkdir /tmp/vmfusion-archive
     gtar zxvf /cdrom/vmware-solaris-tools.tar.gz -C /tmp/vmfusion-archive
     /tmp/vmfusion-archive/vmware-tools-distrib/vmware-install.pl --force-install
     umount /cdrom
-    lofiadm -d "$VMTOOLSDEV"
+    lofiadm -d $VMTOOLSDEV
     rm -rf /mnt/vmtools
     rm -rf /tmp/vmfusion-archive
     rm -f /home/vagrant/solaris.iso

--- a/scripts/ubuntu/cleanup.sh
+++ b/scripts/ubuntu/cleanup.sh
@@ -12,7 +12,7 @@ dpkg --list \
 dpkg --list \
     | awk '{ print $2 }' \
     | grep 'linux-image-3.*-generic' \
-    | grep -v "$(uname -r)" \
+    | grep -v `uname -r` \
     | xargs apt-get -y purge;
 
 # Delete Linux source

--- a/scripts/ubuntu/sudoers.sh
+++ b/scripts/ubuntu/sudoers.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -eux
 
-major_version="$(lsb_release -r | awk '{print $2}' | awk -F. '{print $1}')";
+major_version="`lsb_release -r | awk '{print $2}' | awk -F. '{print $1}'`";
 
 if [ ! -z "$major_version" -a "$major_version" -lt 12 ]; then
     sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=admin' /etc/sudoers;

--- a/scripts/ubuntu/update.sh
+++ b/scripts/ubuntu/update.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -eux
 
-ubuntu_version="$(lsb_release -r | awk '{print $2}')";
-ubuntu_major_version="$(echo "$ubuntu_version" | awk -F. '{print $1}')";
+ubuntu_version="`lsb_release -r | awk '{print $2}'`";
+ubuntu_major_version="`echo $ubuntu_version | awk -F. '{print $1}'`";
 
 # Work around bad cached lists on Ubuntu 12.04
 if [ "$ubuntu_version" = "12.04" ]; then
@@ -20,7 +20,7 @@ else
 fi
 
 # ensure the correct kernel headers are installed
-apt-get -y install "linux-headers-$(uname -r)";
+apt-get -y install linux-headers-`uname -r`;
 
 # update package index on boot
 cat <<EOF >/etc/init/refresh-apt.conf;

--- a/scripts/ubuntu/vagrant.sh
+++ b/scripts/ubuntu/vagrant.sh
@@ -1,14 +1,14 @@
 #!/bin/bash -eux
 
 pubkey_url="https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub";
-mkdir -p "$HOME_DIR/.ssh";
+mkdir -p $HOME_DIR/.ssh;
 if command -v wget >/dev/null 2>&1; then
-    wget --no-check-certificate "$pubkey_url" -O "$HOME_DIR/.ssh/authorized_keys";
+    wget --no-check-certificate "$pubkey_url" -O $HOME_DIR/.ssh/authorized_keys;
 elif command -v curl >/dev/null 2>&1; then
-    curl --insecure --location "$pubkey_url" > "$HOME_DIR/.ssh/authorized_keys";
+    curl --insecure --location "$pubkey_url" > $HOME_DIR/.ssh/authorized_keys;
 else
     echo "Cannot download vagrant public key";
     exit 1;
 fi
-chown -R vagrant "$HOME_DIR/.ssh";
-chmod -R go-rwsx "$HOME_DIR/.ssh";
+chown -R vagrant $HOME_DIR/.ssh;
+chmod -R go-rwsx $HOME_DIR/.ssh;


### PR DESCRIPTION
Reverts chef/bento#494 - looks like some of the shellcheck stuff breaks builds. Notably changes to `scripts/debian/update.sh`