### PR TITLE
simplify distro detection for RHEL-derivatives

### DIFF
--- a/scripts/centos/cleanup.sh
+++ b/scripts/centos/cleanup.sh
@@ -1,19 +1,12 @@
 #!/bin/sh -eux
 
-if [ -s /etc/oracle-release ]; then
-  distro='oracle'
-elif [ -s /etc/enterprise-release ]; then
-  distro='oracle'
-elif [ -s /etc/redhat-release ]; then
-  # should ouput 'centos' OR 'red hat'
-  distro=`cat /etc/redhat-release | sed 's/^\(CentOS\|Red Hat\).*/\1/i' | tr '[:upper:]' '[:lower:]'`
-fi
-
+# should output one of 'redhat' 'centos' 'oraclelinux'
+distro="`rpm -qf --queryformat '%{NAME}' /etc/redhat-release | cut -f 1 -d '-'`" 
 
 # Remove development and kernel source packages
 yum -y remove gcc cpp kernel-devel kernel-headers perl;
 
-if [ "$distro" != 'red hat' ]; then
+if [ "$distro" != 'redhat' ]; then
   yum -y clean all;
 fi
 


### PR DESCRIPTION
`/etc/redhat-release` is owned by packages like redhat-release-server-6Server-6.7.0.3.el6.x86_64.rpm, centos-release-7-2.1511.el7.centos.2.10.x86_64.rpm, oraclelinux-release-7.2-1.0.5.el7.x86_64.rpm, sl-release-7.1-2.sl7.x86_64.rpm and can be used for a recognition between these distros at least 
