### PR TITLE
Update mirror URL for Debian 8.2

### DIFF
--- a/debian-8.2-amd64.json
+++ b/debian-8.2-amd64.json
@@ -226,7 +226,7 @@
     "iso_checksum_type": "sha256",
     "iso_name": "debian-8.2.0-amd64-CD-1.iso",
     "metadata": "floppy/dummy_metadata.json",
-    "mirror": "http://cdimage.debian.org/cdimage/release",
+    "mirror": "http://cdimage.debian.org/cdimage/archive",
     "mirror_directory": "8.2.0/amd64/iso-cd",
     "name": "debian-8.2",
     "no_proxy": "{{env `no_proxy`}}",

--- a/debian-8.2-i386.json
+++ b/debian-8.2-i386.json
@@ -226,7 +226,7 @@
     "iso_checksum_type": "sha256",
     "iso_name": "debian-8.2.0-i386-CD-1.iso",
     "metadata": "floppy/dummy_metadata.json",
-    "mirror": "http://cdimage.debian.org/cdimage/release",
+    "mirror": "http://cdimage.debian.org/cdimage/archive",
     "mirror_directory": "8.2.0/i386/iso-cd",
     "name": "debian-8.2-i386",
     "no_proxy": "{{env `no_proxy`}}",


### PR DESCRIPTION
Debian 8.2 has been moved to the "archive", so the default URL should be updated