### PR TITLE
Build all changes since last passed build.

### DIFF
--- a/buildkite.rb
+++ b/buildkite.rb
@@ -1,24 +1,100 @@
 #!/usr/bin/env ruby
 
-git_output = `git log -m -1 --name-only --pretty=format:%n`
+require 'json'
+require 'net/http'
+require 'uri'
 
-# TODO: decide what, if anything, is rebuilt if bin/bento, buildkite.rb, scripts/common change.
-changed_files = git_output.split("\n").reject { |t| t.empty? || t.include?('gitignore') || t.include?('dummy_metadata') || t.include?('bin/bento') || t.include?('buildkite.rb') || t.include?('scripts/common') || t.include?('.md')}
+BUILDKITE_ACCESS_TOKEN = ENV['BUILDKITE_ACCESS_TOKEN']
+BUILDKITE_PROJECT = ENV['BUILDKITE_PROJECT'] ||= 'bento'
+BUILDKITE_ORGANIZATION = ENV['BUILDKITE_ORGANIZATION_SLUG'] ||= 'chef'
+IGNORED_FILES = %w(
+  gitignore
+  dummy_metadata
+  bin/bento
+  buildkite.rb
+  scripts/common
+  .md
+).freeze
+
+def buildkite_api_uri(args = {})
+  raise Exception.new('Missing project argument') if args[:project].nil?
+  raise Exception.new('Missing endpoint argument') if args[:endpoint].nil?
+
+  URI::HTTPS.build(
+    host:   'api.buildkite.com',
+    path:   "/v2/organizations/#{BUILDKITE_ORGANIZATION}/pipelines/#{args[:project]}/#{args[:endpoint]}",
+    query:  "access_token=#{BUILDKITE_ACCESS_TOKEN}"
+  )
+end
+
+# Returns an array of builds hashes for the environment defined project.
+def buildkite_builds
+  response = Net::HTTP.get_response(
+      buildkite_api_uri(project: BUILDKITE_PROJECT, endpoint: 'builds')
+  )
+
+  if response.code.to_i >= 400
+    raise Exception.new("Unexpected response from BuildKite API: #{response.code_type}")
+  else
+    JSON.parse(response.body)
+  end
+end
+
+# Returns a string
+def last_passed_build_git_hash
+  git_hash = ''
+
+  buildkite_builds.map do |build|
+    if build['state'] == 'passed'
+      git_hash = build['commit']
+      break
+    end
+  end
+
+  if git_hash.empty?
+    raise Exception.new('Unable to determine the commit hash of the last successful build.')
+  else
+    git_hash
+  end
+end
+
+
+# Return an array of files changed since the last successful build.
+# Sorry for the long function name.
+def changed_files_since_last_passed_build
+  # Cache fileset so we don't need to regenerate the result each time.
+  @changed_files_since_last_passed_build ||= begin
+    # `rev-list commit_x..HEAD` shows the commit hashes for each commit from a
+    # given commit to the current HEAD.
+    # `--objects` shows the actual files which have changed in the series of
+    # commits.
+    # We strip the commit IDs via awk because its cheap and a lazy way to get only
+    # the data back we need.
+    objects = `git rev-list #{last_passed_build_git_hash}..HEAD  --objects | awk '{print $2}'`.split.uniq
+    # Only return objects which are files, or files with a path.
+    objects.select { |object| File.file?(object) && !IGNORED_FILES.include?(object) }
+  end
+end
 
 # Compile the list of platforms whose boxes will be rebuilt.
 buildlist = []
 
-# If OS-specific scripts have changed, rebuild all boxes associated with that OS.  
-family = changed_files.select { |b| b.include?('scripts') || b.include?('floppy') || b.include?('http') }
+# TODO: decide what, if anything, is rebuilt if bin/bento, buildkite.rb, scripts/common change.
+# This expects the input array to only contain files and paths to files.
+# eg: [".travis.yml", "CHANGELOG.md","README.md", "debian-8.3-amd64.json"]
+# If OS-specific scripts have changed, rebuild all boxes associated with that OS.
+family = changed_files_since_last_passed_build.select { |b| b.include?('scripts') || b.include?('floppy') || b.include?('http') }
+require 'pry'; binding.pry
+
 unless family.empty?
-  all_templates = `ls *.json`.split("\n")
+  all_templates = Dir.glob('*.json')
 
   family.each do |f|
-    buildlist.concat(all_templates.collect { |a| a if a.include?(f.split('/')[1]) }.reject { |a| a.nil? })
+    buildlist.concat(all_templates.collect { |a| a if a.it nclude?(f.split('/')[1]) }.reject { |a| a.nil? })
   end
 end
 
-buildlist.concat(changed_files.select { |b| b.include?('.json') })
+buildlist.concat(changed_files_since_last_passed_build.select { |b| b.include?('.json') })
 buildlist.uniq!
 buildlist.collect! { |b| b.gsub!('.json', '') }
 system "bundle exec rake do_all[#{buildlist.join(',')}]"


### PR DESCRIPTION
Summary of Change
================
The previous implementation would only build changes since the last commit. However, this is somewhat flawed in that it may omit changes which were pushed in a series of commits. Moreover, failed builds which have subsequent commits to fix issues previously could have yeilded the incorrect buildset. This now queries the buildkite API to determine the last successful build, and the Git changeset ID associated with the build to determine what addtional changes we should look at since the last good build.

This script now has one new required environment variable which is not set by buildkite normally, which is the `BUILDKITE_ACCESS_TOKEN`.


Open Concerns
============
Given `BUILDKITE_ACCESS_TOKEN` is an environment variable it also exposes a potential security concern. I am not familiar enough with buildkite yet to know if users are able to echo this variable to stdout or pipe it into an email as part of a PR. If this is indeed the case, we may need to use command line options if they cannot view stdout or the command execution,  but this too still has security issues. 

Validation
=======
- [ ] Add the `BUILDKITE_ACCESS_TOKEN` environment variable to the bento buildkite job.
- [ ] Change multiple templates in separate commits and push them both in one push.
- [ ] Change one template or related file in one commit and push the change to make sure there is no regressions.

Suggested Reviewers
=================
- @yzl 
- @cheeseplus 
- @schisamo 