### PR TITLE
Simplify swap and clarify the build tools Fedora version

### DIFF
--- a/fedora-22-i386.json
+++ b/fedora-22-i386.json
@@ -141,7 +141,7 @@
         "scripts/common/metadata.sh",
         "scripts/fedora/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
-        "scripts/fedora/22-build-tools.sh",
+        "scripts/fedora/build-tools.sh",
         "scripts/common/vmtools.sh",
         "scripts/common/vagrant.sh",
         "scripts/fedora/cleanup.sh",

--- a/fedora-22-x86_64.json
+++ b/fedora-22-x86_64.json
@@ -145,7 +145,7 @@
         "scripts/common/metadata.sh",
         "scripts/fedora/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
-        "scripts/fedora/22-build-tools.sh",
+        "scripts/fedora/build-tools.sh",
         "scripts/common/vmtools.sh",
         "scripts/common/vagrant.sh",
         "scripts/fedora/cleanup.sh",

--- a/fedora-23-i386.json
+++ b/fedora-23-i386.json
@@ -141,7 +141,7 @@
         "scripts/common/metadata.sh",
         "scripts/fedora/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
-        "scripts/fedora/22-build-tools.sh",
+        "scripts/fedora/build-tools.sh",
         "scripts/common/vmtools.sh",
         "scripts/common/vagrant.sh",
         "scripts/fedora/cleanup.sh",

--- a/fedora-23-x86_64.json
+++ b/fedora-23-x86_64.json
@@ -144,7 +144,7 @@
       "scripts": [
         "scripts/common/metadata.sh",
         "scripts/fedora/fix-slow-dns.sh",
-        "scripts/fedora/22-build-tools.sh",
+        "scripts/fedora/build-tools.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",
         "scripts/common/vagrant.sh",

--- a/http/fedora-22/ks.cfg
+++ b/http/fedora-22/ks.cfg
@@ -13,12 +13,7 @@ text
 skipx
 zerombr
 clearpart --all --initlabel
-part /boot --fstype=ext4 --size=500
-part pv.2 --grow --size=500
-volgroup vg_vagrant --pesize=32768 pv.2
-logvol / --fstype=ext4 --name=lv_root --vgname=vg_vagrant --size=1024 --grow
-logvol swap --fstype=swap --name=lv_swap --vgname=vg_vagrant --size=528 --grow --maxsize=1056
-bootloader --location=mbr --append="norhgb biosdevname=0"
+autopart
 firstboot --disabled
 reboot
 user --name=vagrant --plaintext --password vagrant

--- a/http/fedora-23/ks.cfg
+++ b/http/fedora-23/ks.cfg
@@ -13,12 +13,7 @@ text
 skipx
 zerombr
 clearpart --all --initlabel
-part /boot --fstype=ext4 --size=500
-part pv.2 --grow --size=500
-volgroup vg_vagrant --pesize=32768 pv.2
-logvol / --fstype=ext4 --name=lv_root --vgname=vg_vagrant --size=1024 --grow
-logvol swap --fstype=swap --name=lv_swap --vgname=vg_vagrant --size=528 --grow --maxsize=1056
-bootloader --location=mbr --append="norhgb biosdevname=0"
+autopart
 firstboot --disabled
 reboot
 user --name=vagrant --plaintext --password vagrant
@@ -26,7 +21,7 @@ user --name=vagrant --plaintext --password vagrant
 %packages --ignoremissing --excludedocs
 bzip2
 # GCC won't install during kickstart
-#gcc
+# gcc
 kernel-devel
 kernel-headers
 tar

--- a/scripts/fedora/build-tools.sh
+++ b/scripts/fedora/build-tools.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -eux
-# Installing build tools here because Fedora 22 will not do so during kickstart
+# Installing build tools here because Fedora 22+ will not do so during kickstart
 dnf -y install kernel-headers-$(uname -r) kernel-devel-$(uname -r) gcc make perl


### PR DESCRIPTION
There's no reason to manually partition Fedora.  Let's just do the same thing we do on RHEL.  We get the same result.  Also let's remove the Fedora version from the build tools script since it impacts both 22 and 23.