### PR TITLE
Update omnios ISO SHAs

### DIFF
--- a/omnios-r151014.json
+++ b/omnios-r151014.json
@@ -221,7 +221,7 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "iso_checksum": "c2cdcb6e7a51a119fc73528e3c3c24c9ef146185",
+    "iso_checksum": "16fd303c81521db72fe6b0b5e891cffb5f9caa60",
     "iso_checksum_type": "sha1",
     "iso_name": "OmniOS_Text_r151014.iso",
     "metadata": "floppy/dummy_metadata.json",

--- a/omnios-r151018.json
+++ b/omnios-r151018.json
@@ -221,7 +221,7 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "iso_checksum": "562f0e35010717c43169bb2dc15169ec08c62bbf",
+    "iso_checksum": "5378cfdf9c7197c886231eb622bd9b19de597dba",
     "iso_checksum_type": "sha1",
     "iso_name": "OmniOS_Text_r151018.iso",
     "metadata": "floppy/dummy_metadata.json",


### PR DESCRIPTION
OmniOS re-released the ISOs with fixes, but maintained the same release
numbers so the SHAs need to get updated.  These are straight from their
site and confirmed to be valid locally.