### PR TITLE
Add the headless option for QEMU builders. #567

### DIFF
--- a/centos-5.11-i386.json
+++ b/centos-5.11-i386.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/centos-5.11-x86_64.json
+++ b/centos-5.11-x86_64.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/centos-6.7-i386.json
+++ b/centos-6.7-i386.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/centos-6.7-x86_64.json
+++ b/centos-6.7-x86_64.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/centos-7.2-x86_64.json
+++ b/centos-7.2-x86_64.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-6.0.10-amd64.json
+++ b/debian-6.0.10-amd64.json
@@ -163,6 +163,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-6.0.10-i386.json
+++ b/debian-6.0.10-i386.json
@@ -163,6 +163,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-7.10-amd64.json
+++ b/debian-7.10-amd64.json
@@ -163,6 +163,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-7.10-i386.json
+++ b/debian-7.10-i386.json
@@ -163,6 +163,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-7.8-amd64.json
+++ b/debian-7.8-amd64.json
@@ -163,6 +163,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-7.8-i386.json
+++ b/debian-7.8-i386.json
@@ -163,6 +163,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-7.9-amd64.json
+++ b/debian-7.9-amd64.json
@@ -163,6 +163,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-7.9-i386.json
+++ b/debian-7.9-i386.json
@@ -163,6 +163,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-8.1-amd64.json
+++ b/debian-8.1-amd64.json
@@ -167,6 +167,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-8.1-i386.json
+++ b/debian-8.1-i386.json
@@ -167,6 +167,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-8.2-amd64.json
+++ b/debian-8.2-amd64.json
@@ -167,6 +167,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-8.2-i386.json
+++ b/debian-8.2-i386.json
@@ -167,6 +167,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-8.3-amd64.json
+++ b/debian-8.3-amd64.json
@@ -167,6 +167,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-8.3-i386.json
+++ b/debian-8.3-i386.json
@@ -167,6 +167,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-8.4-amd64.json
+++ b/debian-8.4-amd64.json
@@ -168,6 +168,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/debian-8.4-i386.json
+++ b/debian-8.4-i386.json
@@ -168,6 +168,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/fedora-20-i386.json
+++ b/fedora-20-i386.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/fedora-20-x86_64.json
+++ b/fedora-20-x86_64.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/fedora-21-i386.json
+++ b/fedora-21-i386.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/fedora-21-x86_64.json
+++ b/fedora-21-x86_64.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/fedora-22-i386.json
+++ b/fedora-22-i386.json
@@ -108,6 +108,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/fedora-22-x86_64.json
+++ b/fedora-22-x86_64.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/fedora-23-i386.json
+++ b/fedora-23-i386.json
@@ -108,6 +108,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/fedora-23-x86_64.json
+++ b/fedora-23-x86_64.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/freebsd-10.2-amd64.json
+++ b/freebsd-10.2-amd64.json
@@ -159,6 +159,7 @@
       ],
       "boot_wait": "7s",
       "disk_size": 10140,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/freebsd-10.2-i386.json
+++ b/freebsd-10.2-i386.json
@@ -159,6 +159,7 @@
       ],
       "boot_wait": "7s",
       "disk_size": 10140,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/freebsd-10.3-amd64.json
+++ b/freebsd-10.3-amd64.json
@@ -159,6 +159,7 @@
       ],
       "boot_wait": "7s",
       "disk_size": 10140,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/freebsd-10.3-i386.json
+++ b/freebsd-10.3-i386.json
@@ -159,6 +159,7 @@
       ],
       "boot_wait": "7s",
       "disk_size": 10140,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/freebsd-9.3-amd64.json
+++ b/freebsd-9.3-amd64.json
@@ -175,6 +175,7 @@
       ],
       "boot_wait": "7s",
       "disk_size": 10140,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/freebsd-9.3-i386.json
+++ b/freebsd-9.3-i386.json
@@ -175,6 +175,7 @@
       ],
       "boot_wait": "7s",
       "disk_size": 10140,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/opensuse-13.2-i386.json
+++ b/opensuse-13.2-i386.json
@@ -123,6 +123,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 20480,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/opensuse-13.2-x86_64.json
+++ b/opensuse-13.2-x86_64.json
@@ -123,6 +123,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 20480,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/opensuse-leap-42.1-x86_64.json
+++ b/opensuse-leap-42.1-x86_64.json
@@ -123,6 +123,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 20480,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/oracle-5.11-i386.json
+++ b/oracle-5.11-i386.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/oracle-5.11-x86_64.json
+++ b/oracle-5.11-x86_64.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/oracle-6.6-i386.json
+++ b/oracle-6.6-i386.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/oracle-6.6-x86_64.json
+++ b/oracle-6.6-x86_64.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/oracle-6.7-i386.json
+++ b/oracle-6.7-i386.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/oracle-6.7-x86_64.json
+++ b/oracle-6.7-x86_64.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/oracle-7.2-x86_64.json
+++ b/oracle-7.2-x86_64.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/rhel-5.11-i386.json
+++ b/rhel-5.11-i386.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/rhel-5.11-x86_64.json
+++ b/rhel-5.11-x86_64.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/rhel-6.6-i386.json
+++ b/rhel-6.6-i386.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/rhel-6.6-x86_64.json
+++ b/rhel-6.6-x86_64.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/rhel-6.7-i386.json
+++ b/rhel-6.7-i386.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/rhel-6.7-x86_64.json
+++ b/rhel-6.7-x86_64.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/rhel-7.2-x86_64.json
+++ b/rhel-7.2-x86_64.json
@@ -107,6 +107,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/sles-11-sp2-i386.json
+++ b/sles-11-sp2-i386.json
@@ -123,6 +123,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 20480,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "a0b34f6237b2b2a6b2174c82b40ed326",
       "iso_checksum_type": "md5",

--- a/sles-11-sp2-x86_64.json
+++ b/sles-11-sp2-x86_64.json
@@ -123,6 +123,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 20480,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "461d82ae6e15062b0807c1338f040497",
       "iso_checksum_type": "md5",

--- a/sles-11-sp3-i386.json
+++ b/sles-11-sp3-i386.json
@@ -123,6 +123,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 20480,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "5c30a409fc8fb3343b4dc90d93ff2c89",
       "iso_checksum_type": "md5",

--- a/sles-11-sp3-x86_64.json
+++ b/sles-11-sp3-x86_64.json
@@ -123,6 +123,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 20480,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "480b70d50cbb538382dc2b9325221e1b",
       "iso_checksum_type": "md5",

--- a/sles-11-sp4-i386.json
+++ b/sles-11-sp4-i386.json
@@ -123,6 +123,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 20480,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/sles-11-sp4-x86_64.json
+++ b/sles-11-sp4-x86_64.json
@@ -123,6 +123,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 20480,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/sles-12-x86_64.json
+++ b/sles-12-x86_64.json
@@ -123,6 +123,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 20480,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/ubuntu-10.04-amd64.json
+++ b/ubuntu-10.04-amd64.json
@@ -191,6 +191,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/ubuntu-10.04-i386.json
+++ b/ubuntu-10.04-i386.json
@@ -191,6 +191,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/ubuntu-12.04-amd64.json
+++ b/ubuntu-12.04-amd64.json
@@ -191,6 +191,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/ubuntu-12.04-i386.json
+++ b/ubuntu-12.04-i386.json
@@ -191,6 +191,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/ubuntu-14.04-amd64.json
+++ b/ubuntu-14.04-amd64.json
@@ -191,6 +191,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/ubuntu-14.04-i386.json
+++ b/ubuntu-14.04-i386.json
@@ -191,6 +191,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/ubuntu-14.10-amd64.json
+++ b/ubuntu-14.10-amd64.json
@@ -191,6 +191,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/ubuntu-14.10-i386.json
+++ b/ubuntu-14.10-i386.json
@@ -191,6 +191,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/ubuntu-15.04-amd64.json
+++ b/ubuntu-15.04-amd64.json
@@ -195,6 +195,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/ubuntu-15.04-i386.json
+++ b/ubuntu-15.04-i386.json
@@ -195,6 +195,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/ubuntu-15.10-amd64.json
+++ b/ubuntu-15.10-amd64.json
@@ -200,6 +200,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",

--- a/ubuntu-15.10-i386.json
+++ b/ubuntu-15.10-i386.json
@@ -200,6 +200,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": 40960,
+      "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",


### PR DESCRIPTION
Add the existing headless option, ``"{{user `headless`}}"``, to QEMU
builders.

See: https://github.com/chef/bento/issues/567