### PR TITLE
Possible fix for Fedora 23 vmware issue

### DIFF
--- a/fedora-23-x86_64.json
+++ b/fedora-23-x86_64.json
@@ -61,6 +61,7 @@
       "vm_name": "{{ user `template` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
+        "ethernet0.pciSlotNumber": "32",
         "memsize": "{{ user `memory` }}",
         "numvcpus": "{{ user `cpus` }}"
       }


### PR DESCRIPTION
Similar to how the latest vmware and vagrant has issues related to the pci slot change, this seems to fix #521