### PR TITLE
Fix iso_name in ubuntu-16.04-i386.json

### DIFF
--- a/ubuntu-16.04-i386.json
+++ b/ubuntu-16.04-i386.json
@@ -259,7 +259,7 @@
     "https_proxy": "{{env `https_proxy`}}",
     "iso_checksum": "8d52f3127f2b7ffa97698913b722e3219187476a9b936055d737f3e00aecd24d",
     "iso_checksum_type": "sha256",
-    "iso_name": "ubuntu-16.04-server-i386.iso ",
+    "iso_name": "ubuntu-16.04-server-i386.iso",
     "memory": "512",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://releases.ubuntu.com",


### PR DESCRIPTION
There is a trailing space in `iso_url` value. Being represented as %20 in URL, it causes a build error:

```
==> parallels-iso: Downloading or copying ISO
2016/04/27 21:19:10 ui:     parallels-iso: Downloading or copying: http://releases.ubuntu.com/16.04/ubuntu-16.04-server-i386.iso%20
    parallels-iso: Downloading or copying: http://releases.ubuntu.com/16.04/ubuntu-16.04-server-i386.iso%20
2016/04/27 21:19:10 packer: 2016/04/27 21:19:10 Acquiring lock to download: http://releases.ubuntu.com/16.04/ubuntu-16.04-server-i386.iso%20
2016/04/27 21:19:10 packer: 2016/04/27 21:19:10 Parsed URL: &url.URL{Scheme:"http", Opaque:"", User:(*url.Userinfo)(nil), Host:"releases.ubuntu.com", Path:"/16.04/ubuntu-16.04-server-i386.iso ", RawPath:"", RawQuery:"", Fragment:""}
2016/04/27 21:19:10 packer: 2016/04/27 21:19:10 [DEBUG] Downloading: http://releases.ubuntu.com/16.04/ubuntu-16.04-server-i386.iso%20
2016/04/27 21:19:10 packer: 2016/04/27 21:19:10 Starting download: http://releases.ubuntu.com/16.04/ubuntu-16.04-server-i386.iso%20
2016/04/27 21:19:11 packer: 2016/04/27 21:19:11 Verifying checksum of /opt/bento/packer_cache/71e06f8d4efe7da296f68faf71509be470bd2a44231079cb76d882475293dd6b.iso
2016/04/27 21:19:11 ui:     parallels-iso: Error downloading: checksums didn't match expected: 8d52f3127f2b7ffa97698913b722e3219187476a9b936055d737f3e00aecd24d
2016/04/27 21:19:11 ui error: ==> parallels-iso: ISO download failed.
    parallels-iso: Error downloading: checksums didn't match expected: 8d52f3127f2b7ffa97698913b722e3219187476a9b936055d737f3e00aecd24d
==> parallels-iso: ISO download failed.
2016/04/27 21:19:11 ui error: Build 'parallels-iso' errored: ISO download failed.
```

This PR fixes that issue.