### PR TITLE
Fix vagrant.sh failing on Solaris nodes

### DIFF
--- a/scripts/solaris/vagrant.sh
+++ b/scripts/solaris/vagrant.sh
@@ -1,0 +1,19 @@
+#!/bin/sh -eux
+
+# set a default HOME_DIR environment variable if not set
+HOME_DIR="${HOME_DIR:-/export/home/vagrant}";
+
+pubkey_url="https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub";
+mkdir -p $HOME_DIR/.ssh;
+if command -v wget >/dev/null 2>&1; then
+    wget --no-check-certificate "$pubkey_url" -O $HOME_DIR/.ssh/authorized_keys;
+elif command -v curl >/dev/null 2>&1; then
+    curl --insecure --location "$pubkey_url" > $HOME_DIR/.ssh/authorized_keys;
+elif command -v fetch >/dev/null 2>&1; then
+    fetch -am -o $HOME_DIR/.ssh/authorized_keys "$pubkey_url";
+else
+    echo "Cannot download vagrant public key";
+    exit 1;
+fi
+chown -R vagrant $HOME_DIR/.ssh;
+chmod -R go-rwsx $HOME_DIR/.ssh;

--- a/solaris-11-x86.json
+++ b/solaris-11-x86.json
@@ -133,7 +133,7 @@
         "scripts/common/metadata.sh",
         "scripts/solaris/update.sh",
         "scripts/solaris/vmtools.sh",
-        "scripts/common/vagrant.sh",
+        "scripts/solaris/vagrant.sh",
         "scripts/solaris/minimize.sh"
       ],
       "type": "shell"
@@ -141,7 +141,7 @@
   ],
   "variables": {
     "_DOWNLOAD_SITE": "http://www.oracle.com/technetwork/server-storage/solaris11/downloads/index.html",
-    "_README": "You must download the automated installer iso from the following page, and then place it somewhere that packer can fetch it",
+    "_README": "You must download the automated installer iso from the following page, and then place it in the packer_cache dir",
     "arch": "64",
     "box_basename": "solaris-11.3",
     "build_timestamp": "{{isotime \"20060102150405\"}}",


### PR DESCRIPTION
Redefining home to /home/vagrant fails since that doesn't exist on
Solaris

Signed-off-by: Tim Smith <tsmith@chef.io>