### PR TITLE
Disable automated package upgrades on Debian-like boxes

### DIFF
--- a/http/debian-6.0/preseed.cfg
+++ b/http/debian-6.0/preseed.cfg
@@ -32,7 +32,7 @@ d-i passwd/user-password-again password vagrant
 d-i passwd/username string vagrant
 d-i pkgsel/include string openssh-server sudo bzip2 acpid cryptsetup zlib1g-dev wget curl dkms make nfs-common
 d-i pkgsel/install-language-support boolean false
-d-i pkgsel/update-policy select unattended-upgrades
+d-i pkgsel/update-policy select none
 d-i pkgsel/upgrade select full-upgrade
 # Prevent packaged version of VirtualBox Guest Additions being installed:
 d-i preseed/early_command string sed -i \

--- a/http/debian-7/preseed.cfg
+++ b/http/debian-7/preseed.cfg
@@ -32,7 +32,7 @@ d-i passwd/user-password-again password vagrant
 d-i passwd/username string vagrant
 d-i pkgsel/include string openssh-server sudo bzip2 acpid cryptsetup zlib1g-dev wget curl dkms make nfs-common
 d-i pkgsel/install-language-support boolean false
-d-i pkgsel/update-policy select unattended-upgrades
+d-i pkgsel/update-policy select none
 d-i pkgsel/upgrade select full-upgrade
 # Prevent packaged version of VirtualBox Guest Additions being installed:
 d-i preseed/early_command string sed -i \

--- a/http/debian-8/preseed.cfg
+++ b/http/debian-8/preseed.cfg
@@ -32,7 +32,7 @@ d-i passwd/user-password-again password vagrant
 d-i passwd/username string vagrant
 d-i pkgsel/include string sudo bzip2 acpid cryptsetup zlib1g-dev wget curl dkms make nfs-common
 d-i pkgsel/install-language-support boolean false
-d-i pkgsel/update-policy select unattended-upgrades
+d-i pkgsel/update-policy select none
 d-i pkgsel/upgrade select full-upgrade
 # Prevent packaged version of VirtualBox Guest Additions being installed:
 d-i preseed/early_command string sed -i \

--- a/http/ubuntu-10.04/preseed.cfg
+++ b/http/ubuntu-10.04/preseed.cfg
@@ -23,7 +23,7 @@ d-i passwd/user-password-again password vagrant
 d-i passwd/username string vagrant
 d-i pkgsel/include string openssh-server cryptsetup build-essential libssl-dev libreadline-dev zlib1g-dev linux-source dkms nfs-common
 d-i pkgsel/install-language-support boolean false
-d-i pkgsel/update-policy select unattended-upgrades
+d-i pkgsel/update-policy select none
 d-i pkgsel/upgrade select full-upgrade
 d-i time/zone string UTC
 d-i user-setup/allow-password-weak boolean true

--- a/http/ubuntu-12.04/preseed.cfg
+++ b/http/ubuntu-12.04/preseed.cfg
@@ -23,7 +23,7 @@ d-i passwd/user-password-again password vagrant
 d-i passwd/username string vagrant
 d-i pkgsel/include string openssh-server cryptsetup build-essential libssl-dev zlib1g-dev linux-source nfs-common linux-headers-$(uname -r) perl
 d-i pkgsel/install-language-support boolean false
-d-i pkgsel/update-policy select unattended-upgrades
+d-i pkgsel/update-policy select none
 d-i pkgsel/upgrade select full-upgrade
 d-i time/zone string UTC
 d-i user-setup/allow-password-weak boolean true

--- a/http/ubuntu-14.04/preseed.cfg
+++ b/http/ubuntu-14.04/preseed.cfg
@@ -23,7 +23,7 @@ d-i passwd/user-password-again password vagrant
 d-i passwd/username string vagrant
 d-i pkgsel/include string openssh-server cryptsetup build-essential libssl-dev libreadline-dev zlib1g-dev linux-source dkms nfs-common linux-headers-$(uname -r) perl
 d-i pkgsel/install-language-support boolean false
-d-i pkgsel/update-policy select unattended-upgrades
+d-i pkgsel/update-policy select none
 d-i pkgsel/upgrade select full-upgrade
 d-i time/zone string UTC
 d-i user-setup/allow-password-weak boolean true

--- a/http/ubuntu-14.10/preseed.cfg
+++ b/http/ubuntu-14.10/preseed.cfg
@@ -23,7 +23,7 @@ d-i passwd/user-password-again password vagrant
 d-i passwd/username string vagrant
 d-i pkgsel/include string openssh-server cryptsetup build-essential libssl-dev libreadline-dev zlib1g-dev linux-source dkms nfs-common
 d-i pkgsel/install-language-support boolean false
-d-i pkgsel/update-policy select unattended-upgrades
+d-i pkgsel/update-policy select none
 d-i pkgsel/upgrade select full-upgrade
 d-i time/zone string UTC
 d-i user-setup/allow-password-weak boolean true

--- a/http/ubuntu-15.04/preseed.cfg
+++ b/http/ubuntu-15.04/preseed.cfg
@@ -23,7 +23,7 @@ d-i passwd/user-password-again password vagrant
 d-i passwd/username string vagrant
 d-i pkgsel/include string openssh-server cryptsetup build-essential libssl-dev libreadline-dev zlib1g-dev linux-source dkms nfs-common
 d-i pkgsel/install-language-support boolean false
-d-i pkgsel/update-policy select unattended-upgrades
+d-i pkgsel/update-policy select none
 d-i pkgsel/upgrade select full-upgrade
 d-i time/zone string UTC
 d-i user-setup/allow-password-weak boolean true

--- a/http/ubuntu-15.10/preseed.cfg
+++ b/http/ubuntu-15.10/preseed.cfg
@@ -23,7 +23,7 @@ d-i passwd/user-password-again password vagrant
 d-i passwd/username string vagrant
 d-i pkgsel/include string openssh-server cryptsetup build-essential libssl-dev libreadline-dev zlib1g-dev linux-source dkms nfs-common linux-headers-$(uname -r) perl
 d-i pkgsel/install-language-support boolean false
-d-i pkgsel/update-policy select unattended-upgrades
+d-i pkgsel/update-policy select none
 d-i pkgsel/upgrade select full-upgrade
 d-i time/zone string UTC
 d-i user-setup/allow-password-weak boolean true


### PR DESCRIPTION
Currently unattended upgrades are enabled, causing unexpected behavior when the daily apt upgrade job runs (with cron.daily on sysv/upstart hosts, and at-boot plus semi-randomly twice a day on hosts with systemd).

Setting this value to none disables the upgrade jobs, in favor of package upgrades only happening when explicitly requested. This would resolve issue #609 