### PR TITLE
update apt sources to use archive.debian.org for packages

### DIFF
--- a/debian-6.0.10-amd64.json
+++ b/debian-6.0.10-amd64.json
@@ -200,6 +200,7 @@
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/common/metadata.sh",
+        "scripts/debian/debian6-apt.sh",
         "scripts/debian/update.sh",
         "scripts/common/sshd.sh",
         "scripts/debian/networking.sh",

--- a/debian-6.0.10-i386.json
+++ b/debian-6.0.10-i386.json
@@ -200,6 +200,7 @@
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "scripts": [
         "scripts/common/metadata.sh",
+        "scripts/debian/debian6-apt.sh",
         "scripts/debian/update.sh",
         "scripts/common/sshd.sh",
         "scripts/debian/networking.sh",

--- a/scripts/debian/debian6-apt.sh
+++ b/scripts/debian/debian6-apt.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -eux
+
+sed -i 's/mirrors.kernel.org/archive.debian.org/g' /etc/apt/sources.list


### PR DESCRIPTION
I have added a script to set the debian6 sources to point to archive.debian.org instead of mirrors.kernel.org which is now deprecated for debian6