### PR TITLE
Fix new-style device naming from Network Manager on RHEL/CentOS 7

### DIFF
--- a/scripts/centos/cleanup.sh
+++ b/scripts/centos/cleanup.sh
@@ -23,4 +23,36 @@ for ndev in `ls -1 /etc/sysconfig/network-scripts/ifcfg-*`; do
     fi
 done
 
+# new-style network device naming for centos7
+if grep -q -i "release 7" /etc/redhat-release ; then
+  # radio off & remove all interface configration
+  nmcli radio all off
+  /bin/systemctl stop NetworkManager.service
+  for ifcfg in `ls /etc/sysconfig/network-scripts/ifcfg-* |grep -v ifcfg-lo` ; do
+    rm -f $ifcfg
+  done
+  rm -rf /var/lib/NetworkManager/*
+
+  echo "==> Setup /etc/rc.d/rc.local for CentOS7"
+  cat <<_EOF_ | cat >> /etc/rc.d/rc.local
+#BENTO-BEGIN
+LANG=C
+# delete all connection
+for con in \`nmcli -t -f uuid con\`; do
+  if [ "\$con" != "" ]; then
+    nmcli con del \$con
+  fi
+done
+# add gateway interface connection.
+gwdev=\`nmcli dev | grep ethernet | egrep -v 'unmanaged' | head -n 1 | awk '{print \$1}'\`
+if [ "\$gwdev" != "" ]; then
+  nmcli c add type eth ifname \$gwdev con-name \$gwdev
+fi
+sed -i "/^#BENTO-BEGIN/,/^#BENTO-END/d" /etc/rc.d/rc.local
+chmod -x /etc/rc.d/rc.local
+#BENTO-END
+_EOF_
+  chmod +x /etc/rc.d/rc.local
+fi
+
 rm -f VBoxGuestAdditions_*.iso VBoxGuestAdditions_*.iso.?;


### PR DESCRIPTION
Fixes https://github.com/chef/bento/issues/388 and https://github.com/Parallels/vagrant-parallels/issues/265
Details about the root of issue: https://github.com/Parallels/vagrant-parallels/issues/265#issuecomment-226960702

The solution has been taken from Boxcutter: https://github.com/boxcutter/centos/commit/be4174ea6e8c053d25f970d524d1801c6b21c55f

It might look not very clear, so any other solutions are welcome. The current implementation does the following (_only on RHEL/CentOS 7_):
- Cleans up the NetworkManager state and settings before the box packaging
- Appends `/etc/rc.d/rc.local` by the script, which fixes names of network devices in NM configuration
- Being executed only on the first boot, the script mentioned above removes itself from the `/etc/rc.d/rc.local`.

I've verified it with `centos-7.2-x86_64.json` template and `parallels` provider