### PR TITLE
Leave existing kernel and headers

### DIFF
--- a/scripts/centos/cleanup.sh
+++ b/scripts/centos/cleanup.sh
@@ -3,9 +3,6 @@
 # should output one of 'redhat' 'centos' 'oraclelinux'
 distro="`rpm -qf --queryformat '%{NAME}' /etc/redhat-release | cut -f 1 -d '-'`" 
 
-# Remove development and kernel source packages
-yum -y remove gcc cpp kernel-devel kernel-headers perl;
-
 if [ "$distro" != 'redhat' ]; then
   yum -y clean all;
 fi


### PR DESCRIPTION
We need to leave those packages, cuz there is no way to get then anymore if kernel version was updated.