### PR TITLE
Speed up booting process for FreeBSD saving 10 seconds in boot time

### DIFF
--- a/scripts/freebsd/vmtools.sh
+++ b/scripts/freebsd/vmtools.sh
@@ -23,6 +23,9 @@ virtualbox-iso|virtualbox-ovf)
     echo 'virtio_balloon_load="YES"' >>/boot/loader.conf;
     echo 'if_vtnet_load="YES"' >>/boot/loader.conf;
 
+    # Don't waste 10 seconds waiting for boot
+    echo 'autoboot_delay="-1"' >>/boot/loader.conf;
+
     echo 'ifconfig_vtnet0_name="em0"' >>/etc/rc.conf;
     echo 'ifconfig_vtnet1_name="em1"' >>/etc/rc.conf;
     echo 'ifconfig_vtnet2_name="em2"' >>/etc/rc.conf;


### PR DESCRIPTION
For more info check: https://www.freebsd.org/cgi/man.cgi?loader(8)

     autoboot_delay
       Number of seconds autoboot will wait before booting.  Ifthis
       variableis not defined,autoboot will default to 10 seconds.

       If set to NO'', no autoboot will be automatically attempted
       after processing/boot/loader.rc, thoughexplicit autoboot's
       will be processed normally, defaulting to 10 seconds delay.

       If set to 0'',no delay will be inserted, but user still will
       be able to interrupt autoboot process and escapeinto the
       interactive modeby pressing some key onthe console while ker-
       nel and modules are being loaded.

       If set to -1'', no delay will be inserted and loader will
       engage interactive mode only if autoboothas failed for some
       reason.