### PR TITLE
Renames "ubuntu-server" task -> "server" for Ubuntu 14.04

### DIFF
--- a/http/ubuntu-12.04/preseed.cfg
+++ b/http/ubuntu-12.04/preseed.cfg
@@ -28,4 +28,4 @@ d-i pkgsel/upgrade select full-upgrade
 d-i time/zone string UTC
 d-i user-setup/allow-password-weak boolean true
 d-i user-setup/encrypt-home boolean false
-tasksel tasksel/first multiselect standard, ubuntu-server
+tasksel tasksel/first multiselect standard, server

--- a/http/ubuntu-14.04/preseed.cfg
+++ b/http/ubuntu-14.04/preseed.cfg
@@ -28,4 +28,4 @@ d-i pkgsel/upgrade select full-upgrade
 d-i time/zone string UTC
 d-i user-setup/allow-password-weak boolean true
 d-i user-setup/encrypt-home boolean false
-tasksel tasksel/first multiselect standard, ubuntu-server
+tasksel tasksel/first multiselect standard, server

--- a/http/ubuntu-15.10/preseed.cfg
+++ b/http/ubuntu-15.10/preseed.cfg
@@ -28,4 +28,4 @@ d-i pkgsel/upgrade select full-upgrade
 d-i time/zone string UTC
 d-i user-setup/allow-password-weak boolean true
 d-i user-setup/encrypt-home boolean false
-tasksel tasksel/first multiselect standard, ubuntu-server
+tasksel tasksel/first multiselect standard, server


### PR DESCRIPTION
The Ubuntu 14.04 config was using tasksel to add the "ubuntu-server" task, which doesn't exist. Maybe it used to. The "server" task is actually what we want, and pulls in packages for a headless setup, such
as tmux.

The "ubuntu-server" task was essentially a no-op, so it didn't break anything, but it did cause a lot of packages to be omitted. See [full comparison here](https://gist.github.com/conorsch/7123209a86a2c577ba465b80cb05b0ef).

Closes #653.