### PR TITLE
Add script to disable system sleep for Mac OS X

### DIFF
--- a/macosx-10.10.json
+++ b/macosx-10.10.json
@@ -202,6 +202,7 @@
         "scripts/macosx/hostname.sh",
         "scripts/macosx/update.sh",
         "scripts/macosx/networking.sh",
+        "scripts/macosx/disablesleep.sh",
         "scripts/macosx/vagrant.sh",
         "scripts/macosx/vmtools.sh",
         "scripts/macosx/cleanup.sh",

--- a/macosx-10.11.json
+++ b/macosx-10.11.json
@@ -202,6 +202,7 @@
         "scripts/macosx/hostname.sh",
         "scripts/macosx/update.sh",
         "scripts/macosx/networking.sh",
+        "scripts/macosx/disablesleep.sh",
         "scripts/macosx/vagrant.sh",
         "scripts/macosx/vmtools.sh",
         "scripts/macosx/cleanup.sh",

--- a/macosx-10.7.json
+++ b/macosx-10.7.json
@@ -202,6 +202,7 @@
         "scripts/macosx/hostname.sh",
         "scripts/macosx/update.sh",
         "scripts/macosx/networking.sh",
+        "scripts/macosx/disablesleep.sh",
         "scripts/macosx/vagrant.sh",
         "scripts/macosx/vmtools.sh",
         "scripts/macosx/cleanup.sh",

--- a/macosx-10.8.json
+++ b/macosx-10.8.json
@@ -202,6 +202,7 @@
         "scripts/macosx/hostname.sh",
         "scripts/macosx/update.sh",
         "scripts/macosx/networking.sh",
+        "scripts/macosx/disablesleep.sh",
         "scripts/macosx/vagrant.sh",
         "scripts/macosx/vmtools.sh",
         "scripts/macosx/cleanup.sh",

--- a/macosx-10.9.json
+++ b/macosx-10.9.json
@@ -202,6 +202,7 @@
         "scripts/macosx/hostname.sh",
         "scripts/macosx/update.sh",
         "scripts/macosx/networking.sh",
+        "scripts/macosx/disablesleep.sh",
         "scripts/macosx/vagrant.sh",
         "scripts/macosx/vmtools.sh",
         "scripts/macosx/cleanup.sh",

--- a/scripts/macosx/disablesleep.sh
+++ b/scripts/macosx/disablesleep.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -eux
+
+# disable system sleep
+pmset -a sleep 0


### PR DESCRIPTION
By default, Mac OS X will sleep after a certain time period. This isn't optimal for Vagrant boxes as you can't SSH to the box when it is sleeping. This change disables sleep at box creation.