### PR TITLE
Add support for macOS Sierra 10.12

### DIFF
--- a/macosx-10.12.json
+++ b/macosx-10.12.json
@@ -1,0 +1,234 @@
+{
+  "builders": [
+    {
+      "boot_wait": "2s",
+      "disk_size": "{{user `disk_size`}}",
+      "guest_os_type": "darwin12-64",
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "output_directory": "packer-{{user `template`}}-vmware",
+      "shutdown_command": "echo 'vagrant'| sudo -S shutdown -h now",
+      "skip_compaction": true,
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "darwin",
+      "tools_upload_path": "/tmp/vmtools.iso",
+      "type": "vmware-iso",
+      "vm_name": "{{ user `template` }}",
+      "vmx_data": {
+        "cpuid.coresPerSocket": "1",
+        "ehci.present": "TRUE",
+        "firmware": "efi",
+        "hpet0.present": "TRUE",
+        "ich7m.present": "TRUE",
+        "keyboardAndMouseProfile": "macProfile",
+        "memsize": "{{ user `memory` }}",
+        "numvcpus": "{{ user `cpus` }}",
+        "smc.present": "TRUE",
+        "usb.present": "TRUE"
+      }
+    },
+    {
+      "boot_wait": "2s",
+      "disk_size": "{{user `disk_size`}}",
+      "guest_additions_mode": "disable",
+      "guest_os_type": "MacOS1011_64",
+      "hard_drive_interface": "sata",
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "output_directory": "packer-{{user `template`}}-virtualbox",
+      "shutdown_command": "echo 'vagrant'| sudo -S shutdown -h now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
+      "vboxmanage": [
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--audiocontroller",
+          "hda"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--boot1",
+          "dvd"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--boot2",
+          "disk"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--chipset",
+          "ich9"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "{{ user `cpus` }}"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--firmware",
+          "efi"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--hpet",
+          "on"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--keyboard",
+          "usb"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "{{ user `memory` }}"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--mouse",
+          "usbtablet"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--vram",
+          "9"
+        ],
+        [
+          "storageattach",
+          "{{.Name}}",
+          "--storagectl",
+          "SATA Controller",
+          "--port",
+          "{{ user `cpus` }}",
+          "--type",
+          "dvddrive",
+          "--medium",
+          "{{user `iso_url`}}"
+        ]
+      ],
+      "vboxmanage_post": [
+        [
+          "storageattach",
+          "{{.Name}}",
+          "--storagectl",
+          "SATA Controller",
+          "--port",
+          "{{ user `cpus` }}",
+          "--type",
+          "dvddrive",
+          "--medium",
+          "none"
+        ],
+        [
+          "storagectl",
+          "{{.Name}}",
+          "--name",
+          "IDE Controller",
+          "--remove"
+        ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "{{ user `template` }}"
+    },
+    {
+      "boot_wait": "2s",
+      "disk_size": "{{user `disk_size`}}",
+      "guest_os_type": "macosx",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `iso_url`}}",
+      "output_directory": "packer-{{user `template`}}-parallels",
+      "parallels_tools_flavor": "mac",
+      "prlctl": [
+        ["set", "{{.Name}}", "--memsize", "{{ user `memory` }}"],
+        ["set", "{{.Name}}", "--cpus", "{{ user `cpus` }}"],
+        ["set", "{{.Name}}", "--on-window-close", "keep-running"]
+      ],
+      "shutdown_command": "echo 'vagrant'| sudo -S shutdown -h now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
+      "vm_name": "{{ user `template` }}"
+    }
+  ],
+  "post-processors": [
+    {
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "type": "vagrant",
+      "vagrantfile_template": "vagrantfile_templates/macosx.rb"
+    }
+  ],
+  "provisioners": [
+    {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
+      "environment_vars": [
+        "HOME_DIR=/Users/vagrant",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo 'vagrant'| {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "scripts": [
+        "scripts/common/metadata.sh",
+        "scripts/macosx/hostname.sh",
+        "scripts/macosx/update.sh",
+        "scripts/macosx/networking.sh",
+        "scripts/macosx/disablesleep.sh",
+        "scripts/macosx/vagrant.sh",
+        "scripts/macosx/vmtools.sh",
+        "scripts/macosx/cleanup.sh",
+        "scripts/macosx/minimize.sh"
+      ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "_README": "You must provide a prepared Mac disk image (from https://github.com/timsutton/osx-vm-templates) and checksum value for this template to work. For more details, consult this project's README.md",
+    "box_basename": "macosx-10.12",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "cpus": "1",
+    "disk_size": "40960",
+    "git_revision": "__unknown_git_revision__",
+    "headless": "",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "iso_checksum": "__unset_iso_checksum__",
+    "iso_checksum_type": "md5",
+    "iso_url": "http://YOU-MUST-PROVIDE-YOUR-OWN-DMG.sorry",
+    "memory": "2048",
+    "metadata": "floppy/dummy_metadata.json",
+    "name": "macosx-10.11",
+    "no_proxy": "{{env `no_proxy`}}",
+    "template": "macosx-10.12",
+    "version": "2.1.TIMESTAMP"
+  }
+}


### PR DESCRIPTION
The template has been copied from `macosx-10.11.json` .I've verified it with `parallels-iso` builder - it works fine.

But I'm not sure - should I change `guest_os_type` value for `vmware-iso` and `virtualbox` builders or not. I'd appreciate if someone verifies the template with these builders.
