### PR TITLE
Partially revert #638. Fix #667

### DIFF
--- a/centos-7.2-x86_64.json
+++ b/centos-7.2-x86_64.json
@@ -148,7 +148,7 @@
         "scripts/centos/networking.sh",
         "scripts/common/vagrant.sh",
         "scripts/common/virtualbox.sh",
-        "scripts/centos/vmware.sh",
+        "scripts/common/vmware.sh",
         "scripts/common/parallels.sh",
         "scripts/centos/cleanup.sh",
         "scripts/common/minimize.sh"


### PR DESCRIPTION
As per #667, HGFS isn't shipped with open-vm-tools so we need to use
the propietary tools if we want shared folders and I believe most
bento users would agree they want those.