### PR TITLE
Autodetection is for the birds

### DIFF
--- a/bin/bento
+++ b/bin/bento
@@ -555,16 +555,12 @@ class TestRunner
   def test_box(boxname, providers)
     providers.each do |provider, provider_data|
 
-      plugin_list = Mixlib::ShellOut.new("vagrant plugin list | awk '{print $1}'")
-      plugin_list.run_command
-      plugins = plugin_list.stdout.split("\n")
-
       if provider == 'vmware_desktop'
-        case
-        when plugins.include?('vagrant-vmware-workstation')
-          provider = 'vmware_workstation'
-        when plugins.include?('vagrant-vmware-fusion')
+        case RUBY_PLATFORM
+        when /darwin/
           provider = 'vmware_fusion'
+        when /linux/
+          provider = 'vmware_workstation'
         end
       end
 


### PR DESCRIPTION
Discovering the plugins via a shellout is brittle and regardless of
plugin what we really care about is whether it's linux or osx. 

File under: Don't be clever