### PR TITLE
Fix SLES builds

### DIFF
--- a/scripts/sles/remove-dvd-source.sh
+++ b/scripts/sles/remove-dvd-source.sh
@@ -1,29 +1,4 @@
 #!/bin/sh -eux
 
-if [ 'x86_64' == `uname -m` ]; then
-  arch_suffix=x64
-else
-  arch_suffix=x86
-fi
-
-oslevel=`grep VERSION /etc/SuSE-release | awk '{ print $3 }'`
-patchlevel=`grep PATCHLEVEL /etc/SuSE-release | awk '{ print $3 }'`
-
-if [ $oslevel == '11' ]; then
-  if [ $patchlevel == '2' ]; then
-    repo_ver="11.2.2-1.234"
-  elif [ $patchlevel == '3' ]; then
-    repo_ver="11.3.3-1.138"
-  elif [ $patchlevel == '4' ]; then
-    repo_ver="11.4.4-1.109"
-  else
-    echo "Failed to remove DVD source; don't know how to deal with patchlevel $patchlevel"
-    exit 1
-  fi
-  zypper removerepo "SUSE-Linux-Enterprise-Server-11-SP$patchlevel $repo_ver"
-
-elif [ $oslevel == '12' ]; then
-  zypper removerepo "SLES12-12-$patchlevel";
-fi
-
+zypper removerepo `zypper repos | grep 'SLES' | awk '{ print $3 }'`;
 zypper refresh

--- a/sles-12-sp1-x86_64.json
+++ b/sles-12-sp1-x86_64.json
@@ -163,7 +163,9 @@
         "scripts/common/sshd.sh",
         "scripts/common/vagrant.sh",
         "scripts/sles/unsupported-modules.sh",
-        "scripts/common/vmtools.sh",
+        "scripts/common/virtualbox.sh",
+        "scripts/common/vmware.sh",
+        "scripts/common/parallels.sh",
         "scripts/sles/sudoers.sh",
         "scripts/sles/zypper-locks.sh",
         "scripts/sles/remove-dvd-source.sh",
@@ -174,6 +176,8 @@
     }
   ],
   "variables": {
+    "_DOWNLOAD_SITE": "https://www.suse.com/products/server/download",
+    "_README": "You must download the automated installer iso from the following page, and then place it in the packer_cache dir",
     "arch": "64",
     "autoinst_cfg": "sles-12/sles-12-sp1-x86_64-autoinst.xml",
     "box_basename": "sles-12-sp1",
@@ -189,7 +193,7 @@
     "iso_name": "SLE-12-SP1-Server-DVD-x86_64-GM-DVD1.iso",
     "memory": "1024",
     "metadata": "floppy/dummy_metadata.json",
-    "mirror": "http://cdn.novell.com/prot/oq2T_Vmjsms~",
+    "mirror": "./packer_cache",
     "name": "sles-12-sp1",
     "template": "sles-12-sp1-x86_64",
     "version": "2.2.TIMESTAMP"

--- a/sles-12-x86_64.json
+++ b/sles-12-x86_64.json
@@ -176,6 +176,8 @@
     }
   ],
   "variables": {
+    "_DOWNLOAD_SITE": "https://www.suse.com/products/server/download",
+    "_README": "You must download the automated installer iso from the following page, and then place it in the packer_cache dir",
     "arch": "64",
     "autoinst_cfg": "sles-12/sles-12-x86_64-autoinst.xml",
     "box_basename": "sles-12",
@@ -191,7 +193,7 @@
     "iso_name": "SLE-12-Server-DVD-x86_64-GM-DVD1.iso",
     "memory": "512",
     "metadata": "floppy/dummy_metadata.json",
-    "mirror": "http://cdn.novell.com/prot/1RBC-NrdggI~",
+    "mirror": "./packer_cache",
     "name": "sles-12",
     "template": "sles-12-x86_64",
     "version": "2.2.TIMESTAMP"


### PR DESCRIPTION
1) Suse is Oracle style now and requires a token to download the image
2) Fix the vm tools installs

Signed-off-by: Tim Smith <tsmith@chef.io>