### PR TITLE
Avoid breaking of chef package resource on fedora

### DIFF
--- a/fedora-23-i386.json
+++ b/fedora-23-i386.json
@@ -143,6 +143,7 @@
         "scripts/fedora/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/fedora/build-tools.sh",
+        "scripts/fedora/yum.sh",
         "scripts/common/virtualbox.sh",
         "scripts/common/vmware.sh",
         "scripts/common/parallels.sh",

--- a/fedora-23-x86_64.json
+++ b/fedora-23-x86_64.json
@@ -147,6 +147,7 @@
         "scripts/common/metadata.sh",
         "scripts/fedora/fix-slow-dns.sh",
         "scripts/fedora/build-tools.sh",
+        "scripts/fedora/yum.sh",
         "scripts/common/sshd.sh",
         "scripts/common/virtualbox.sh",
         "scripts/common/vmware.sh",

--- a/fedora-24-i386.json
+++ b/fedora-24-i386.json
@@ -141,6 +141,7 @@
         "scripts/common/metadata.sh",
         "scripts/fedora/fix-slow-dns.sh",
         "scripts/fedora/build-tools.sh",
+        "scripts/fedora/yum.sh",
         "scripts/common/sshd.sh",
         "scripts/common/virtualbox.sh",
         "scripts/common/vmware.sh",

--- a/fedora-24-x86_64.json
+++ b/fedora-24-x86_64.json
@@ -147,6 +147,7 @@
         "scripts/common/metadata.sh",
         "scripts/fedora/fix-slow-dns.sh",
         "scripts/fedora/build-tools.sh",
+        "scripts/fedora/yum.sh",
         "scripts/common/sshd.sh",
         "scripts/common/virtualbox.sh",
         "scripts/common/vmware.sh",

--- a/scripts/fedora/yum.sh
+++ b/scripts/fedora/yum.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -eux
+# Installing yum for compatibility, especially for chef/kitchen tests
+# https://github.com/chef/chef/issues/5492
+dnf -y install yum


### PR DESCRIPTION
If you use chef with test-kitchen on bento fedora boxes and invoke the resource `package`, it will fail because of missing `yum` (there is no `dnf` provider yet, https://github.com/chef/chef/issues/3201).

This PR is a workaround for the time till chef gets the `dnf` provider.

See https://github.com/chef/chef/issues/5492 for details and logs
