### PR TITLE
Do not remove perl during cleanup process

### DIFF
--- a/scripts/centos/cleanup.sh
+++ b/scripts/centos/cleanup.sh
@@ -4,7 +4,7 @@
 distro="`rpm -qf --queryformat '%{NAME}' /etc/redhat-release | cut -f 1 -d '-'`" 
 
 # Remove development and kernel source packages
-yum -y remove gcc cpp kernel-devel kernel-headers perl;
+yum -y remove gcc cpp kernel-devel kernel-headers;
 
 if [ "$distro" != 'redhat' ]; then
   yum -y clean all;

--- a/scripts/fedora/cleanup.sh
+++ b/scripts/fedora/cleanup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eux
-yum -y remove gcc cpp kernel-devel kernel-headers perl
+yum -y remove gcc cpp kernel-devel kernel-headers
 yum -y clean all
 rm -rf VBoxGuestAdditions_*.iso VBoxGuestAdditions_*.iso.?
 rm -f /tmp/chef*rpm

--- a/scripts/opensuse/cleanup.sh
+++ b/scripts/opensuse/cleanup.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -eux
 # These were only needed for building VMware/Virtualbox extensions:
-zypper -n rm -u binutils gcc make perl ruby kernel-default-devel kernel-devel
+zypper -n rm -u binutils gcc make ruby kernel-default-devel kernel-devel


### PR DESCRIPTION
Perl is required for installing/compiling and running too many programs to make it worth removing - users will simply need to install it back.