### PR TITLE
Reduce size of Linux images

### DIFF
--- a/scripts/common/minimize.sh
+++ b/scripts/common/minimize.sh
@@ -4,6 +4,18 @@ case "$PACKER_BUILDER_TYPE" in
   qemu) exit 0 ;;
 esac
 
+# Whiteout root
+count=$(df --sync -kP / | tail -n1  | awk -F ' ' '{print $4}')
+count=$(($count-1))
+dd if=/dev/zero of=/tmp/whitespace bs=1M count=$count || echo "dd exit code $? is suppressed";
+rm /tmp/whitespace
+
+# Whiteout /boot
+count=$(df --sync -kP /boot | tail -n1 | awk -F ' ' '{print $4}')
+count=$(($count-1))
+dd if=/dev/zero of=/boot/whitespace bs=1M count=$count || echo "dd exit code $? is suppressed";
+rm /boot/whitespace
+
 set +e
 swapuuid="`/sbin/blkid -o value -l -s UUID -t TYPE=swap`";
 case "$?" in
@@ -21,8 +33,4 @@ if [ "x${swapuuid}" != "x" ]; then
     /sbin/mkswap -U "$swapuuid" "$swappart";
 fi
 
-dd if=/dev/zero of=/EMPTY bs=1M || echo "dd exit code $? is suppressed";
-rm -f /EMPTY;
-# Block until the empty file has been removed, otherwise, Packer
-# will try to kill the box while the disk is still full and that's bad
 sync;

--- a/scripts/ubuntu/cleanup.sh
+++ b/scripts/ubuntu/cleanup.sh
@@ -50,5 +50,8 @@ rm -f VBoxGuestAdditions_*.iso VBoxGuestAdditions_*.iso.?;
 # Remove docs
 rm -rf /usr/share/doc/*
 
+# Remove caches
+find /var/cache -type f -exec rm -rf {} \;
+
 # delete any logs that have built up during the install
 find /var/log/ -name *.log -exec rm -f {} \;

--- a/scripts/ubuntu/cleanup.sh
+++ b/scripts/ubuntu/cleanup.sh
@@ -34,7 +34,7 @@ apt-get -y purge libx11-data xauth libxmuu1 libxcb1 libx11-6 libxext6;
 apt-get -y purge ppp pppconfig pppoeconf;
 
 # Delete oddities
-apt-get -y purge popularity-contest;
+apt-get -y purge popularity-contest installation-report command-not-found command-not-found-data friendly-recovery;
 
 apt-get -y autoremove;
 apt-get -y clean;

--- a/scripts/ubuntu/cleanup.sh
+++ b/scripts/ubuntu/cleanup.sh
@@ -27,6 +27,12 @@ dpkg --list \
     | grep -- '-dev$' \
     | xargs apt-get -y purge;
 
+# delete docs packages
+dpkg --list \
+    | awk '{ print $2 }' \
+    | grep -- '-doc$' \
+    | xargs apt-get -y purge;
+
 # Delete X11 libraries
 apt-get -y purge libx11-data xauth libxmuu1 libxcb1 libx11-6 libxext6;
 

--- a/scripts/ubuntu/cleanup.sh
+++ b/scripts/ubuntu/cleanup.sh
@@ -40,3 +40,6 @@ apt-get -y autoremove;
 apt-get -y clean;
 
 rm -f VBoxGuestAdditions_*.iso VBoxGuestAdditions_*.iso.?;
+
+# delete any logs that have built up during the install
+find /var/log/ -name *.log -exec rm -f {} \;

--- a/scripts/ubuntu/cleanup.sh
+++ b/scripts/ubuntu/cleanup.sh
@@ -11,7 +11,7 @@ dpkg --list \
 # e.g. 'linux-image-generic', etc.
 dpkg --list \
     | awk '{ print $2 }' \
-    | grep 'linux-image-3.*-generic' \
+    | grep 'linux-image-.*-generic' \
     | grep -v `uname -r` \
     | xargs apt-get -y purge;
 

--- a/scripts/ubuntu/cleanup.sh
+++ b/scripts/ubuntu/cleanup.sh
@@ -47,5 +47,8 @@ apt-get -y clean;
 
 rm -f VBoxGuestAdditions_*.iso VBoxGuestAdditions_*.iso.?;
 
+# Remove docs
+rm -rf /usr/share/doc/*
+
 # delete any logs that have built up during the install
 find /var/log/ -name *.log -exec rm -f {} \;


### PR DESCRIPTION
In response to issue #717 

The kernel I noticed myself. The others are care of boxcutter. Thanks folks:

- On Ubuntu make sure we cleanup kernels version 4.X instead of just 3.X. This frees up 200+ megs on disk and 50 megs on the image
- Cleanup /var/log files. < 100k on disk
- Purge additional packages. 4.5 megs on disk
- Purge docs packages. 3 megs on disk
- Purge docs
- Purge caches
- Whiteout not only /, but /boot

With these changes my original Ubuntu 16.04 image was 682.7MB and the final file is 481.9MB.

Signed-off-by: Tim Smith <tsmith@chef.io>