### PR TITLE
Remove CentOS requiretty sudoers workaround, this is now the default

### DIFF
--- a/http/centos-6.8/ks.cfg
+++ b/http/centos-6.8/ks.cfg
@@ -67,4 +67,3 @@ nfs-utils
 sed -i -e 's/\(^SELINUX=\).*$/\1permissive/' /etc/selinux/config
 # sudo
 echo "%vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
-sed -i "s/^[^#].*requiretty/#Defaults requiretty/" /etc/sudoers

--- a/http/centos-7.3/ks.cfg
+++ b/http/centos-7.3/ks.cfg
@@ -77,5 +77,4 @@ bzip2
 %post
 # sudo
 echo "%vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
-sed -i "s/^[^#].*requiretty/#Defaults requiretty/" /etc/sudoers
 %end


### PR DESCRIPTION
CentOS 7.3 includes `sudo-1.8.6p7-21` which disables requiretty by default.

CentOS 6 has not required this since at least 6.8.

See https://github.com/CentOS/sig-cloud-instance-build/pull/78 for more details.