### PR TITLE
Update VMware tools to fix CentOS 7.3 build

### DIFF
--- a/centos-7.3-x86_64.json
+++ b/centos-7.3-x86_64.json
@@ -135,6 +135,12 @@
       "type": "file"
     },
     {
+      "destination": "/tmp/VMwareTools-10.1.0-4449150.tar.gz",
+      "source": "VMwareTools-10.1.0-4449150.tar.gz",
+      "type": "file",
+	  "only": ["vmware-iso"]
+    },
+    {
       "environment_vars": [
         "HOME_DIR=/home/vagrant",
         "http_proxy={{user `http_proxy`}}",
@@ -148,7 +154,7 @@
         "scripts/centos/networking.sh",
         "scripts/common/vagrant.sh",
         "scripts/common/virtualbox.sh",
-        "scripts/common/vmware.sh",
+        "scripts/centos/vmware.sh",
         "scripts/common/parallels.sh",
         "scripts/centos/cleanup.sh",
         "scripts/common/minimize.sh"

--- a/scripts/centos/vmware.sh
+++ b/scripts/centos/vmware.sh
@@ -1,8 +1,26 @@
 #!/bin/sh -eux
 
+# set a default HOME_DIR environment variable if not set
+HOME_DIR="${HOME_DIR:-/home/vagrant}";
+
 case "$PACKER_BUILDER_TYPE" in
 vmware-iso|vmware-vmx)
-    yum install -y open-vm-tools;
-    mkdir /mnt/hgfs;
-    echo "platform specific vmware.sh executed";
+    mkdir -p /tmp/vmware-archive;
+    TOOLS_PATH="/tmp/VMwareTools-10.1.0-4449150.tar.gz";
+    VER="`echo "${TOOLS_PATH}" | cut -f2 -d'-'`";
+    MAJ_VER="`echo ${VER} | cut -d '.' -f 1`";
+
+    echo "VMware Tools Version: $VER";
+
+    tar xzf ${TOOLS_PATH} -C /tmp/vmware-archive;
+	ls -alh /tmp/vmware-archive;
+    if [ "${MAJ_VER}" -lt "10" ]; then
+        /tmp/vmware-archive/vmware-tools-distrib/vmware-install.pl --default;
+    else
+        /tmp/vmware-archive/vmware-tools-distrib/vmware-install.pl --default --force-install;
+    fi
+    rm -rf  /tmp/vmware-archive;
+	rm -rf /tmp/VMwareTools-10.1.0-4449150.tar.gz;
+    rm -f $HOME_DIR/*.iso;
+    ;;
 esac


### PR DESCRIPTION
There isn't an easy way to grab the latest vmtools from the open web, in this case 10.1.0, so we're using Packer's File provisioner to sideload it just for 7.3 vmware-iso.

Fixes #742

Signed-off-by: Seth Thomas <sthomas@chef.io>