### PR TITLE
Reduce FreeBSD 10.3 image size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
+dist: trusty
 sudo: false
+
+env:
+  - PACKER_VERSION="0.12.2"
 
 rvm:
   - 2.3.1
@@ -7,7 +11,7 @@ branches:
   only:
     - master
 
-before_install: wget --no-check-certificate https://releases.hashicorp.com/packer/0.10.2/packer_0.10.2_linux_amd64.zip && unzip -d packer packer_0.10.2_linux_amd64.zip
+before_install: wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip && unzip -d packer packer_${PACKER_VERSION}_linux_amd64.zip
 before_script: export PATH=$PATH:$PWD/packer
 
-script: ./bin/bento normalize
+script: bento normalize

--- a/scripts/freebsd/cleanup.sh
+++ b/scripts/freebsd/cleanup.sh
@@ -6,5 +6,7 @@ mkdir -p /var/db/freebsd-update/files;
 rm -f /var/db/freebsd-update/*-rollback;
 rm -rf /var/db/freebsd-update/install.*;
 rm -rf /boot/kernel.old;
+rm -f /boot/kernel*/*.symbols;
 rm -rf /usr/src/*;
 rm -f /*.core;
+rm -rf /var/cache/pkg;

--- a/scripts/freebsd/minimize.sh
+++ b/scripts/freebsd/minimize.sh
@@ -4,16 +4,24 @@ case "$PACKER_BUILDER_TYPE" in
   qemu) exit 0 ;;
 esac
 
-COMPRESSION=$(zfs get -H compression zroot | cut -f3);
+major_version="`uname -r | awk -F. '{print $1}'`";
 
-zfs set compression=off zroot;
+if [ "$major_version" -eq 10 ]; then
+  ZROOT="zroot"
+else
+  ZROOT="zroot/ROOT/default"
+fi
+
+COMPRESSION=$(zfs get -H compression $ZROOT | cut -f3);
+
+zfs set compression=off $ZROOT;
 dd if=/dev/zero of=/EMPTY bs=1m &
 PID=$!;
 
-avail=$(zfs get -pH avail zroot/ROOT/default | cut -f3);
+avail=$(zfs get -pH avail $ZROOT | cut -f3);
 while [ "$avail" -ne 0 ]; do
   sleep 15;
-  avail=$(zfs get -pH avail zroot/ROOT/default | cut -f3);
+  avail=$(zfs get -pH avail $ZROOT | cut -f3);
 done
 
 kill $PID || echo "dd already exited";
@@ -22,4 +30,4 @@ rm -f /EMPTY;
 # Block until the empty file has been removed, otherwise, Packer
 # will try to kill the box while the disk is still full and that's bad
 sync;
-zfs set compression=$COMPRESSION zroot;
+zfs set compression=$COMPRESSION $ZROOT;


### PR DESCRIPTION
FreeBSD 10.3 image is too big (1.2Gb):

```
Andres-MacBook-Pro:bento andres$ ls -lah builds/
-rw-r--r--   1 andres  staff   1.2G Jan 31 11:26 freebsd-10.3.virtualbox.box
```

With this change the image is reduced by **670.8Mb**!

```
Andres-MacBook-Pro:bento andres$ ls -lah builds/
-rw-r--r--   1 andres  staff   558M Jan 31 10:58 freebsd-10.3.virtualbox.box
```

The causes are the following:

```
root@freebsd-10:/boot/kernel # du -sh
509M    .
root@freebsd-10:/boot/kernel # rm *.symbols
root@freebsd-10:/boot/kernel # du -sh
 97M    .
```

According to FreeBSD docs this can be safely removed as shown [here]

Also `/var/cache/pkg` can be deleted as it's only used for storing cache of installed packages:

```
root@freebsd-10:/var/cache # du -d 1 -h
 72M    ./pkg
 72M    .
```

Then the scripts/freebsd/minimize.sh script is not working properly with FreeBSD 10 due to zroot path:

```
    virtualbox-iso: + rm -f '/*.core'
    virtualbox-iso: + rm -rf /var/cache/pkg
    virtualbox-iso: Password:
==> virtualbox-iso: Provisioning with shell script: scripts/freebsd/minimize.sh
    virtualbox-iso: + zfs get -H compression zroot
    virtualbox-iso: + cut -f3
    virtualbox-iso: + COMPRESSION=off
    virtualbox-iso: + zfs set compression=off zroot
    virtualbox-iso: + PID=21073
    virtualbox-iso: + dd if=/dev/zero of=/EMPTY bs=1m
    virtualbox-iso: + zfs get -pH avail zroot/ROOT/default
    virtualbox-iso: + cut -f3
    virtualbox-iso: cannot open 'zroot/ROOT/default': dataset does not exist
    virtualbox-iso: + avail=''
    virtualbox-iso: + [ '' -ne 0 ]
    virtualbox-iso: [: : bad number
    virtualbox-iso: + kill 21073
    virtualbox-iso: + rm -f /EMPTY
    virtualbox-iso: + sync
    virtualbox-iso: + zfs set compression=off zroot
    virtualbox-iso: Password:
==> virtualbox-iso: Gracefully halting virtual machine...
```

**FREEBSD 10:**

```
root@freebsd-10:~ # zfs list
NAME                        USED  AVAIL  REFER  MOUNTPOINT
zroot                      3.12G  35.4G   129M  legacy
zroot/swap                 2.06G  37.4G  3.95M  -
zroot/tmp                    22K  35.4G    22K  /tmp
zroot/usr                   844M  35.4G   788M  /usr
zroot/usr/home             56.8M  35.4G    19K  /usr/home
zroot/usr/home/vagrant     56.8M  35.4G  56.8M  /usr/home/vagrant
zroot/usr/ports              57K  35.4G    19K  /usr/ports
zroot/usr/ports/distfiles    19K  35.4G    19K  /usr/ports/distfiles
zroot/usr/ports/packages     19K  35.4G    19K  /usr/ports/packages
zroot/usr/src                39K  35.4G    39K  /usr/src
zroot/var                   105M  35.4G  71.7M  /var
zroot/var/crash              19K  35.4G    19K  /var/crash
zroot/var/db               33.2M  35.4G  1.94M  /var/db
zroot/var/db/pkg           31.3M  35.4G  31.3M  /var/db/pkg
zroot/var/empty              19K  35.4G    19K  /var/empty
zroot/var/log              36.5K  35.4G  36.5K  /var/log
zroot/var/mail               19K  35.4G    19K  /var/mail
zroot/var/run                35K  35.4G    35K  /var/run
zroot/var/tmp                19K  35.4G    19K  /var/tmp
```

**FREEBSD 11:**

```
root@:~ # zfs list
NAME                 USED  AVAIL  REFER  MOUNTPOINT
zroot                715M  35.9G    96K  /zroot
zroot/ROOT           710M  35.9G    96K  none
zroot/ROOT/default   710M  35.9G   710M  /
zroot/tmp            116K  35.9G   116K  /tmp
zroot/usr            552K  35.9G    96K  /usr
zroot/usr/home        96K  35.9G    96K  /usr/home
zroot/usr/ports       96K  35.9G    96K  /usr/ports
zroot/usr/src        264K  35.9G   264K  /usr/src
zroot/var            608K  35.9G    96K  /var
zroot/var/audit       96K  35.9G    96K  /var/audit
zroot/var/crash       96K  35.9G    96K  /var/crash
zroot/var/log        128K  35.9G   128K  /var/log
zroot/var/mail        96K  35.9G    96K  /var/mail
zroot/var/tmp         96K  35.9G    96K  /var/tmp
```

[here]: https://www.freebsd.org/doc/faq/kernelconfig.html#idp59131240