### PR TITLE
Fix Travis CI: travis-ci/travis-ci#5156 and travis-ci/travis-ci#5059

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
+dist: trusty
 sudo: false
+
+env:
+  - PACKER_VERSION="0.12.2"
 
 rvm:
   - 2.3.1
@@ -7,7 +11,7 @@ branches:
   only:
     - master
 
-before_install: wget --no-check-certificate https://releases.hashicorp.com/packer/0.10.2/packer_0.10.2_linux_amd64.zip && unzip -d packer packer_0.10.2_linux_amd64.zip
+before_install: wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip && unzip -d packer packer_${PACKER_VERSION}_linux_amd64.zip
 before_script: export PATH=$PATH:$PWD/packer
 
-script: ./bin/bento normalize
+script: bento normalize


### PR DESCRIPTION
This commit is to fix Travis CI tests, also passing `PACKER_VERSION` as a parameter so it's easier to maintain.

The only problem is that `bento-ya` is failing due to generated empty var-file, I think the problem is in this [lines](https://github.com/cheeseplus/bento-ya/blob/57bf488c807592a52591fcce6322452dc43fd569/lib/bento/packerexec.rb#L7-L8). Unfortunately my Ruby knowledge is very basic and don't know how to fix.

```
Andres-MacBook-Pro:bento andres$ bento normalize --debug
==> Normalizing for templates: ["centos-5.11-i386", "centos-5.11-x86_64", "centos-6.8-i386", "centos-6.8-x86_64", "centos-7.3-x86_64", "debian-7.11-amd64", "debian-7.11-i386", "debian-8.6-amd64", "debian-8.6-i386", "debian-8.7-amd64", "de
bian-8.7-i386", "fedora-24-i386", "fedora-24-x86_64", "fedora-25-i386", "fedora-25-x86_64", "freebsd-10.3-amd64", "freebsd-10.3-i386", "freebsd-11.0-amd64", "freebsd-9.3-amd64", "freebsd-9.3-i386", "macos-10.12", "macosx-10.10", "macosx-1
0.11", "macosx-10.7", "macosx-10.8", "macosx-10.9", "omnios-r151014", "omnios-r151018", "opensuse-13.2-i386", "opensuse-13.2-x86_64", "opensuse-leap-42.2-x86_64", "oracle-5.11-i386", "oracle-5.11-x86_64", "oracle-6.8-i386", "oracle-6.8-x8
6_64", "oracle-7.3-x86_64", "rhel-5.11-i386", "rhel-5.11-x86_64", "rhel-6.8-i386", "rhel-6.8-x86_64", "rhel-7.3-x86_64", "sles-12-sp1-x86_64", "sles-12-sp2-x86_64", "sles-12-x86_64", "solaris-10.11-x86", "solaris-11-x86", "ubuntu-12.04-am
d64", "ubuntu-12.04-i386", "ubuntu-14.04-amd64", "ubuntu-14.04-i386", "ubuntu-15.10-amd64", "ubuntu-15.10-i386", "ubuntu-16.04-amd64", "ubuntu-16.04-i386", "ubuntu-16.10-amd64", "ubuntu-16.10-i386", "windows-nano-tp3"]
==> [centos-5.11-i386] Validating: 'packer validate -var-file=/var/folders/xl/t0zszpc14z5g5wpvl5_bby1m0000gn/T/centos-5.11-i386-metadata-var-file20170131-19149-7n1s13 centos-5.11-i386.json'
==> [centos-5.11-i386] DEBUG: var_file(/var/folders/xl/t0zszpc14z5g5wpvl5_bby1m0000gn/T/centos-5.11-i386-metadata-var-file20170131-19149-7n1s13) is:

==> [centos-5.11-i386] DEBUG: md_file(/var/folders/xl/t0zszpc14z5g5wpvl5_bby1m0000gn/T/centos-5.11-i386-metadata.json20170131-19149-1cpmsoo) is:
{
  "name": "centos-5.11-i386",
  "version": "2.1.20170131163916",
  "build_timestamp": "20170131163916",
  "git_revision": "0971320b9b6060954848378745dbaf2068c9ad76",
  "box_basename": "centos-5.11-i386-2.1.20170131163916",
  "template": "centos-5.11-i386",
  "cpus": "1",
  "memory": "1024"
}
invalid value "/var/folders/xl/t0zszpc14z5g5wpvl5_bby1m0000gn/T/centos-5.11-i386-metadata-var-file20170131-19149-7n1s13" for flag -var-file: Error reading variables in '/var/folders/xl/t0zszpc14z5g5wpvl5_bby1m0000gn/T/centos-5.11-i386-met
adata-var-file20170131-19149-7n1s13': EOF
Usage: packer validate [options] TEMPLATE

  Checks the template is valid by parsing the template and also
  checking the configuration with the various builders, provisioners, etc.

  If it is not valid, the errors will be shown and the command will exit
  with a non-zero exit status. If it is valid, it will exit with a zero
  exit status.

Options:

  -syntax-only           Only check syntax. Do not verify config of the template.
  -except=foo,bar,baz    Validate all builds other than these
  -only=foo,bar,baz      Validate only these builds
  -var 'key=value'       Variable for templates, can be used multiple times.
  -var-file=path         JSON file containing user variables.
>>> [centos-5.11-i386] Error validating, exited pid 19151 exit 1
```

Thanks!

Signed-off-by: Andres Montalban <amontalban@devopx.com>