### PR TITLE
[macos-10.12] Allow Packer to pick up memory user var.

### DIFF
--- a/macos-10.12.json
+++ b/macos-10.12.json
@@ -26,7 +26,7 @@
         "hpet0.present": "TRUE",
         "ich7m.present": "TRUE",
         "keyboardAndMouseProfile": "macProfile",
-        "memsize": "{{ user `memory` }}",
+        "memsize": "{{ user `memsize` }}",
         "numvcpus": "{{ user `cpus` }}",
         "smc.present": "TRUE",
         "usb.present": "TRUE"
@@ -102,7 +102,7 @@
           "modifyvm",
           "{{.Name}}",
           "--memory",
-          "{{ user `memory` }}"
+          "{{ user `memsize` }}"
         ],
         [
           "modifyvm",
@@ -167,7 +167,7 @@
           "set",
           "{{.Name}}",
           "--memsize",
-          "{{ user `memory` }}"
+          "{{ user `memsize` }}"
         ],
         [
           "set",
@@ -239,7 +239,7 @@
     "iso_checksum": "__unset_iso_checksum__",
     "iso_checksum_type": "md5",
     "iso_url": "http://YOU-MUST-PROVIDE-YOUR-OWN-DMG.sorry",
-    "memory": "2048",
+    "memsize": "2048",
     "metadata": "floppy/dummy_metadata.json",
     "name": "macos-10.12",
     "no_proxy": "{{env `no_proxy`}}",


### PR DESCRIPTION
I'm not 100% sure if this is an issue--it might need to be confirmed but I could not finish building this box without this fix…

---

For some reason with Pack 0.12.3, the current `"memory"` user variable
is not being picked up and a default value of `1024` is always being
used, leading to macOS 10.12 not being able to finish its installation.
For some reason, changing the user variable from `"memory"` to almost
anything else (in this case, `"memsize"`) allows the user variable to be
picked up.

Note that this was observed with the `vmware-iso` builder and may be the
only affected one. I verified this behavior by running:

```
env PACKER_LOG=1 bundle exec bento build --only=vmware-iso --debug macos-10.12
```
