### PR TITLE
Fixing typo on box_basename for oracle linux 6.8 x86_64

### DIFF
--- a/oracle-6.8-x86_64.json
+++ b/oracle-6.8-x86_64.json
@@ -158,7 +158,7 @@
   ],
   "variables": {
     "arch": "64",
-    "box_basename": "oracle-6.7",
+    "box_basename": "oracle-6.8",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "40960",


### PR DESCRIPTION
json is for 6.8 oracle, but box_basename was 6.7

Signed-off-by: JiSoo Kim <jskim910118@gmail.com>