### PR TITLE
Rename debian-9 to debian-9.0

### DIFF
--- a/debian-9.0-amd64.json
+++ b/debian-9.0-amd64.json
@@ -221,7 +221,7 @@
     }
   ],
   "variables": {
-    "box_basename": "debian-9",
+    "box_basename": "debian-9.0",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "40960",
@@ -236,7 +236,7 @@
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://cdimage.debian.org/cdimage/release",
     "mirror_directory": "9.0.0/amd64/iso-cd",
-    "name": "debian-9",
+    "name": "debian-9.0",
     "no_proxy": "{{env `no_proxy`}}",
     "preseed_path": "debian-8/preseed.cfg",
     "template": "debian-9.0-amd64",


### PR DESCRIPTION
There's going to be 10 more releases of debian 9 before they're done.

Signed-off-by: Tim Smith <tsmith@chef.io>