### PR TITLE
Hyper-V Support for CentOS 7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,25 +10,25 @@ The following boxes are built from this repository's templates for publicly avai
 
 ### 64 bit
 
-|                    | VirtualBox                     | VMware                            | Parallels                     |
-|------------------- | ------------------------------ | --------------------------------- | ------------------------------|
-| centos-5.11        | [x86_64][centos_511_64_vbox]   | [x86_64][centos_511_64_vmware]    | [x86_64][centos_511_64_prl]   |
-| centos-6.8         | [x86_64][centos_68_64_vbox]    | [x86_64][centos_68_64_vmware]     | [x86_64][centos_68_64_prl]    |
-| centos-7.3         | [x86_64][centos_73_64_vbox]    | [x86_64][centos_73_64_vmware]     | [x86_64][centos_73_64_prl]    |
-| debian-7.11        | [amd64][debian_711_64_vbox]    | [amd64][debian_711_64_vmware]     | [amd64][debian_711_64_prl]    |
-| debian-8.7         | [amd64][debian_87_64_vbox]     | ~~[amd64][debian_87_64_vmware]~~  | [amd64][debian_87_64_prl]     |
-| fedora-24          | [x86_64][fedora_24_64_vbox]    | [x86_64][fedora_24_64_vmware]     | ~~[x86_64][fedora_24_64_prl]~~|
-| fedora-25          | [x86_64][fedora_25_64_vbox]    | [x86_64][fedora_25_64_vmware]     | [x86_64][fedora_25_64_prl]    |
-| freebsd-10.3       | [amd64][freebsd_103_64_vbox]   | ~~[amd64][freebsd_103_64_vmware]~~ | [amd64][freebsd_103_64_prl]  |
-| freebsd-11.0       | [amd64][freebsd_110_64_vbox]   | [amd64][freebsd_110_64_vmware]    | [amd64][freebsd_110_64_prl]   |
-| opensuse-leap-42.2 | [x86_64][leap_422_64_vbox]     | ~~[x86_64][leap_422_64_vmware]~~  | ~~[x86_64][leap_422_64_prl]~~ |
-| oracle-5.11        | [x86_64][oracle_511_64_vbox]   | [x86_64][oracle_511_64_vmware]    | [x86_64][oracle_511_64_prl]   |
-| oracle-6.8         | [x86_64][oracle_68_64_vbox]    | [x86_64][oracle_68_64_vmware]     | [x86_64][oracle_68_64_prl]    |
-| oracle-7.3         | [x86_64][oracle_73_64_vbox]    | [x86_64][oracle_73_64_vmware]     | [x86_64][oracle_73_64_prl]    |
-| ubuntu-12.04       | [amd64][ubuntu_1204_64_vbox]   | [amd64][ubuntu_1204_64_vmware]    | [amd64][ubuntu_1204_64_prl]   |
-| ubuntu-14.04       | [amd64][ubuntu_1404_64_vbox]   | [amd64][ubuntu_1404_64_vmware]    | [amd64][ubuntu_1404_64_prl]   |
-| ubuntu-16.04       | [amd64][ubuntu_1604_64_vbox]   | [amd64][ubuntu_1604_64_vmware]    | [amd64][ubuntu_1604_64_prl]   |
-| ubuntu-16.10       | [amd64][ubuntu_1610_64_vbox]   | [amd64][ubuntu_1610_64_vmware]    | [amd64][ubuntu_1610_64_prl]   |
+|                    | VirtualBox                     | VMware                            | Parallels                     |Hyper-V                       |
+|------------------- | ------------------------------ | --------------------------------- | ------------------------------|------------------------------|
+| centos-5.11        | [x86_64][centos_511_64_vbox]   | [x86_64][centos_511_64_vmware]    | [x86_64][centos_511_64_prl]   ||
+| centos-6.8         | [x86_64][centos_68_64_vbox]    | [x86_64][centos_68_64_vmware]     | [x86_64][centos_68_64_prl]    ||
+| centos-7.3         | [x86_64][centos_73_64_vbox]    | [x86_64][centos_73_64_vmware]     | [x86_64][centos_73_64_prl]    |[x86_64][centos_73_64_hyperv] |
+| debian-7.11        | [amd64][debian_711_64_vbox]    | [amd64][debian_711_64_vmware]     | [amd64][debian_711_64_prl]    ||
+| debian-8.7         | [amd64][debian_87_64_vbox]     | ~~[amd64][debian_87_64_vmware]~~  | [amd64][debian_87_64_prl]     ||
+| fedora-24          | [x86_64][fedora_24_64_vbox]    | [x86_64][fedora_24_64_vmware]     | ~~[x86_64][fedora_24_64_prl]~~||
+| fedora-25          | [x86_64][fedora_25_64_vbox]    | [x86_64][fedora_25_64_vmware]     | [x86_64][fedora_25_64_prl]    ||
+| freebsd-10.3       | [amd64][freebsd_103_64_vbox]   | ~~[amd64][freebsd_103_64_vmware]~~ | [amd64][freebsd_103_64_prl]  ||
+| freebsd-11.0       | [amd64][freebsd_110_64_vbox]   | [amd64][freebsd_110_64_vmware]    | [amd64][freebsd_110_64_prl]   ||
+| opensuse-leap-42.2 | [x86_64][leap_422_64_vbox]     | ~~[x86_64][leap_422_64_vmware]~~  | ~~[x86_64][leap_422_64_prl]~~ ||
+| oracle-5.11        | [x86_64][oracle_511_64_vbox]   | [x86_64][oracle_511_64_vmware]    | [x86_64][oracle_511_64_prl]   ||
+| oracle-6.8         | [x86_64][oracle_68_64_vbox]    | [x86_64][oracle_68_64_vmware]     | [x86_64][oracle_68_64_prl]    ||
+| oracle-7.3         | [x86_64][oracle_73_64_vbox]    | [x86_64][oracle_73_64_vmware]     | [x86_64][oracle_73_64_prl]    ||
+| ubuntu-12.04       | [amd64][ubuntu_1204_64_vbox]   | [amd64][ubuntu_1204_64_vmware]    | [amd64][ubuntu_1204_64_prl]   ||
+| ubuntu-14.04       | [amd64][ubuntu_1404_64_vbox]   | [amd64][ubuntu_1404_64_vmware]    | [amd64][ubuntu_1404_64_prl]   ||
+| ubuntu-16.04       | [amd64][ubuntu_1604_64_vbox]   | [amd64][ubuntu_1604_64_vmware]    | [amd64][ubuntu_1604_64_prl]   ||
+| ubuntu-16.10       | [amd64][ubuntu_1610_64_vbox]   | [amd64][ubuntu_1610_64_vmware]    | [amd64][ubuntu_1610_64_prl]   ||
 
 ### 32 bit
 

--- a/README.md
+++ b/README.md
@@ -10,25 +10,25 @@ The following boxes are built from this repository's templates for publicly avai
 
 ### 64 bit
 
-|                    | VirtualBox                     | VMware                            | Parallels                     |Hyper-V                       |
-|------------------- | ------------------------------ | --------------------------------- | ------------------------------|------------------------------|
-| centos-5.11        | [x86_64][centos_511_64_vbox]   | [x86_64][centos_511_64_vmware]    | [x86_64][centos_511_64_prl]   ||
-| centos-6.8         | [x86_64][centos_68_64_vbox]    | [x86_64][centos_68_64_vmware]     | [x86_64][centos_68_64_prl]    ||
-| centos-7.3         | [x86_64][centos_73_64_vbox]    | [x86_64][centos_73_64_vmware]     | [x86_64][centos_73_64_prl]    |[x86_64][centos_73_64_hyperv] |
-| debian-7.11        | [amd64][debian_711_64_vbox]    | [amd64][debian_711_64_vmware]     | [amd64][debian_711_64_prl]    ||
-| debian-8.7         | [amd64][debian_87_64_vbox]     | ~~[amd64][debian_87_64_vmware]~~  | [amd64][debian_87_64_prl]     ||
-| fedora-24          | [x86_64][fedora_24_64_vbox]    | [x86_64][fedora_24_64_vmware]     | ~~[x86_64][fedora_24_64_prl]~~||
-| fedora-25          | [x86_64][fedora_25_64_vbox]    | [x86_64][fedora_25_64_vmware]     | [x86_64][fedora_25_64_prl]    ||
-| freebsd-10.3       | [amd64][freebsd_103_64_vbox]   | ~~[amd64][freebsd_103_64_vmware]~~ | [amd64][freebsd_103_64_prl]  ||
-| freebsd-11.0       | [amd64][freebsd_110_64_vbox]   | [amd64][freebsd_110_64_vmware]    | [amd64][freebsd_110_64_prl]   ||
-| opensuse-leap-42.2 | [x86_64][leap_422_64_vbox]     | ~~[x86_64][leap_422_64_vmware]~~  | ~~[x86_64][leap_422_64_prl]~~ ||
-| oracle-5.11        | [x86_64][oracle_511_64_vbox]   | [x86_64][oracle_511_64_vmware]    | [x86_64][oracle_511_64_prl]   ||
-| oracle-6.8         | [x86_64][oracle_68_64_vbox]    | [x86_64][oracle_68_64_vmware]     | [x86_64][oracle_68_64_prl]    ||
-| oracle-7.3         | [x86_64][oracle_73_64_vbox]    | [x86_64][oracle_73_64_vmware]     | [x86_64][oracle_73_64_prl]    ||
-| ubuntu-12.04       | [amd64][ubuntu_1204_64_vbox]   | [amd64][ubuntu_1204_64_vmware]    | [amd64][ubuntu_1204_64_prl]   ||
-| ubuntu-14.04       | [amd64][ubuntu_1404_64_vbox]   | [amd64][ubuntu_1404_64_vmware]    | [amd64][ubuntu_1404_64_prl]   ||
-| ubuntu-16.04       | [amd64][ubuntu_1604_64_vbox]   | [amd64][ubuntu_1604_64_vmware]    | [amd64][ubuntu_1604_64_prl]   ||
-| ubuntu-16.10       | [amd64][ubuntu_1610_64_vbox]   | [amd64][ubuntu_1610_64_vmware]    | [amd64][ubuntu_1610_64_prl]   ||
+|                    | VirtualBox                     | VMware                            | Parallels                     |
+|------------------- | ------------------------------ | --------------------------------- | ------------------------------|
+| centos-5.11        | [x86_64][centos_511_64_vbox]   | [x86_64][centos_511_64_vmware]    | [x86_64][centos_511_64_prl]   |
+| centos-6.8         | [x86_64][centos_68_64_vbox]    | [x86_64][centos_68_64_vmware]     | [x86_64][centos_68_64_prl]    |
+| centos-7.3         | [x86_64][centos_73_64_vbox]    | [x86_64][centos_73_64_vmware]     | [x86_64][centos_73_64_prl]    |
+| debian-7.11        | [amd64][debian_711_64_vbox]    | [amd64][debian_711_64_vmware]     | [amd64][debian_711_64_prl]    |
+| debian-8.7         | [amd64][debian_87_64_vbox]     | ~~[amd64][debian_87_64_vmware]~~  | [amd64][debian_87_64_prl]     |
+| fedora-24          | [x86_64][fedora_24_64_vbox]    | [x86_64][fedora_24_64_vmware]     | ~~[x86_64][fedora_24_64_prl]~~|
+| fedora-25          | [x86_64][fedora_25_64_vbox]    | [x86_64][fedora_25_64_vmware]     | [x86_64][fedora_25_64_prl]    |
+| freebsd-10.3       | [amd64][freebsd_103_64_vbox]   | ~~[amd64][freebsd_103_64_vmware]~~ | [amd64][freebsd_103_64_prl]  |
+| freebsd-11.0       | [amd64][freebsd_110_64_vbox]   | [amd64][freebsd_110_64_vmware]    | [amd64][freebsd_110_64_prl]   |
+| opensuse-leap-42.2 | [x86_64][leap_422_64_vbox]     | ~~[x86_64][leap_422_64_vmware]~~  | ~~[x86_64][leap_422_64_prl]~~ |
+| oracle-5.11        | [x86_64][oracle_511_64_vbox]   | [x86_64][oracle_511_64_vmware]    | [x86_64][oracle_511_64_prl]   |
+| oracle-6.8         | [x86_64][oracle_68_64_vbox]    | [x86_64][oracle_68_64_vmware]     | [x86_64][oracle_68_64_prl]    |
+| oracle-7.3         | [x86_64][oracle_73_64_vbox]    | [x86_64][oracle_73_64_vmware]     | [x86_64][oracle_73_64_prl]    |
+| ubuntu-12.04       | [amd64][ubuntu_1204_64_vbox]   | [amd64][ubuntu_1204_64_vmware]    | [amd64][ubuntu_1204_64_prl]   |
+| ubuntu-14.04       | [amd64][ubuntu_1404_64_vbox]   | [amd64][ubuntu_1404_64_vmware]    | [amd64][ubuntu_1404_64_prl]   |
+| ubuntu-16.04       | [amd64][ubuntu_1604_64_vbox]   | [amd64][ubuntu_1604_64_vmware]    | [amd64][ubuntu_1604_64_prl]   |
+| ubuntu-16.10       | [amd64][ubuntu_1610_64_vbox]   | [amd64][ubuntu_1610_64_vmware]    | [amd64][ubuntu_1610_64_prl]   |
 
 ### 32 bit
 

--- a/centos-7.3-x86_64.json
+++ b/centos-7.3-x86_64.json
@@ -103,6 +103,34 @@
     },
     {
       "boot_command": [
+        "<wait5><tab> text ks=hd:fd0:/ks.cfg<enter><wait5><esc>"
+      ],
+      "boot_wait": "10s",
+      "cpu": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "http/centos-7.3/ks.cfg"
+      ],
+      "generation": "{{user `hyperv_generation`}}",
+      "guest_additions_mode": "{{user `hyperv_guest_additions_mode`}}",
+      "guest_additions_path": "{{user `hyperv_guest_additions_path`}}",
+      "http_directory": "http",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-hyperv",
+      "ram_size": "{{ user `memory` }}",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_timeout": "10000s",
+      "switch_name":"{{ user `hyperv_switch`}}",
+      "type": "hyperv-iso",
+      "vm_name": "{{ user `template` }}"
+    },
+    {
+      "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
       ],
       "boot_wait": "10s",
@@ -165,6 +193,10 @@
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
+    "hyperv_generation": "1" ,
+    "hyperv_guest_additions_mode": "disable",
+    "hyperv_guest_additions_path": "https://download.microsoft.com/download/6/8/F/68FE11B8-FAA4-4F8D-8C7D-74DA7F2CFC8C/LinuxIC-4.2.1.iso",
+    "hyperv_switch": "{{env `hyperv_switch`}}",
     "iso_checksum": "c455ee948e872ad2194bdddd39045b83634e8613249182b88f549bb2319d97eb",
     "iso_checksum_type": "sha256",
     "iso_name": "CentOS-7-x86_64-DVD-1611.iso",

--- a/centos-7.3-x86_64.json
+++ b/centos-7.3-x86_64.json
@@ -112,8 +112,7 @@
         "http/centos-7.3/ks.cfg"
       ],
       "generation": "{{user `hyperv_generation`}}",
-      "guest_additions_mode": "{{user `hyperv_guest_additions_mode`}}",
-      "guest_additions_path": "{{user `hyperv_guest_additions_path`}}",
+      "guest_additions_mode": "disable",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
@@ -194,8 +193,6 @@
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
     "hyperv_generation": "1" ,
-    "hyperv_guest_additions_mode": "disable",
-    "hyperv_guest_additions_path": "https://download.microsoft.com/download/6/8/F/68FE11B8-FAA4-4F8D-8C7D-74DA7F2CFC8C/LinuxIC-4.2.1.iso",
     "hyperv_switch": "{{env `hyperv_switch`}}",
     "iso_checksum": "c455ee948e872ad2194bdddd39045b83634e8613249182b88f549bb2319d97eb",
     "iso_checksum_type": "sha256",

--- a/http/centos-7.3/ks.cfg
+++ b/http/centos-7.3/ks.cfg
@@ -74,7 +74,7 @@ bzip2
 -zd1211-firmware
 %end
 
-%post --log=/root/ks-post.log
+%post
 # sudo
 echo "%vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
 

--- a/http/centos-7.3/ks.cfg
+++ b/http/centos-7.3/ks.cfg
@@ -2,7 +2,7 @@ install
 cdrom
 lang en_US.UTF-8
 keyboard us
-network --bootproto=dhcp
+network --bootproto=dhcp --onboot=on --device=eth0
 rootpw vagrant
 firewall --disabled
 selinux --permissive
@@ -16,7 +16,7 @@ clearpart --all --initlabel
 autopart
 auth --enableshadow --passalgo=sha512 --kickstart
 firstboot --disabled
-reboot
+reboot --eject
 user --name=vagrant --plaintext --password vagrant
 
 %packages --nobase --ignoremissing --excludedocs
@@ -74,7 +74,15 @@ bzip2
 -zd1211-firmware
 %end
 
-%post
+%post --log=/root/ks-post.log
 # sudo
 echo "%vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+
+#Enable hyper-v daemons only if using hyper-v virtualization
+if [ $(virt-what) == "hyperv" ]; then
+    yum -y install hyperv-daemons
+    systemctl enable hypervvssd
+    systemctl enable hypervkvpd
+fi
+
 %end


### PR DESCRIPTION
Due to the way Hyper-V handles virtual switches the name of the virtual switch must be passed as an environment variable. 

Can be obtained via: ```Get-VMSwitch``` in PowerShell. 

Example packer build command

```
packer build --only=hyperv-iso -var 'hyperv_switch="Your vSwitch Name"' .\centos-7.3-x86_
64.json
```

Several changes were required for the ks.cfg
* ```network --bootproto=dhcp --onboot=on --device=eth0``` forces the network to be available for %post
* ```reboot --eject``` forces ejection of the install media after first reboot, otherwise you end up in the installer again
