### PR TITLE
Drop 100 megs from the Ubuntu images

### DIFF
--- a/scripts/ubuntu/cleanup.sh
+++ b/scripts/ubuntu/cleanup.sh
@@ -40,7 +40,10 @@ apt-get -y purge libx11-data xauth libxmuu1 libxcb1 libx11-6 libxext6;
 apt-get -y purge ppp pppconfig pppoeconf;
 
 # Delete oddities
-apt-get -y purge popularity-contest installation-report command-not-found command-not-found-data friendly-recovery;
+apt-get -y purge popularity-contest installation-report command-not-found command-not-found-data friendly-recovery bash-completion fonts-ubuntu-font-family-console laptop-detect;
+
+# Delete the massive firmware packages
+apt-get -y purge linux-firmware
 
 apt-get -y autoremove;
 apt-get -y clean;


### PR DESCRIPTION
linux-firmware is the killer fix here, but we get maybe another meg from the others

Signed-off-by: Tim Smith <tsmith@chef.io>