### PR TITLE
Utilize sudoers.d for Ubuntu vagrant user settings

### DIFF
--- a/scripts/ubuntu/sudoers.sh
+++ b/scripts/ubuntu/sudoers.sh
@@ -1,4 +1,7 @@
 #!/bin/sh -eux
 
 sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=sudo' /etc/sudoers;
-sed -i -e 's/%sudo\s*ALL=(ALL:ALL) ALL/%sudo\tALL=(ALL) NOPASSWD:ALL/g' /etc/sudoers;
+
+# Set up password-less sudo for the vagrant user
+echo 'vagrant ALL=(ALL) NOPASSWD:ALL' >/etc/sudoers.d/99_vagrant;
+chmod 440 /etc/sudoers.d/99_vagrant;


### PR DESCRIPTION
This PR addresses issue #711.

It moves the `sudo` settings for the `vagrant` user out of `/etc/sudoers` and into a file under `/etc/sudoers.d` for all Ubuntu boxes.

Incidentally, this change also brings the Ubuntu boxes into line with the Debian bento boxes' practice of managing the `vagrant` user.