### PR TITLE
Make Ubuntu APT use archive.ubuntu.com rather than the US domain

### DIFF
--- a/http/ubuntu/preseed.cfg
+++ b/http/ubuntu/preseed.cfg
@@ -5,6 +5,10 @@ d-i clock-setup/utc-auto boolean true
 d-i finish-install/reboot_in_progress note
 d-i grub-installer/only_debian boolean true
 d-i grub-installer/with_other_os boolean true
+d-i mirror/country string manual
+d-i mirror/http/directory string /ubuntu/
+d-i mirror/http/hostname string archive.ubuntu.com
+d-i mirror/http/proxy string
 d-i partman-auto-lvm/guided_size string max
 d-i partman-auto/choose_recipe select atomic
 d-i partman-auto/method string lvm


### PR DESCRIPTION
By default the Ubuntu installer sets the repository hostnames in `/etc/apt/sources.list` to the country-specific mirrors based on the locale chosen, which for this image is `us.archive.ubuntu.com`.

The US mirror is slow for users outside the US, so a better option is to use `archive.ubuntu.com`, which automatically resolves to the closest official country mirror to them. This is also the hostname used in the official Ubuntu Docker images.

Fixes #810.