### PR TITLE
WIP adds hyper-v support for centos-6.9

### DIFF
--- a/centos-6.9-x86_64.json
+++ b/centos-6.9-x86_64.json
@@ -120,6 +120,30 @@
       "ssh_wait_timeout": "10000s",
       "type": "qemu",
       "vm_name": "{{ user `template` }}"
+    },
+    {
+      "boot_command": [
+        "<wait5><tab>  text ks=hd:fd0:/ks.cfg<enter><wait5><esc>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "http/centos-6.9/ks.cfg"
+      ],
+      "guest_additions_mode": "disable",
+      "http_directory": "http",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-qemu",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_timeout": "600s",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "switch_name":"{{ user `hyperv_switch`}}",
+      "type": "hyperv-iso",
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/http/centos-6.9/ks.cfg
+++ b/http/centos-6.9/ks.cfg
@@ -16,7 +16,7 @@ clearpart --all --initlabel
 autopart
 auth --enableshadow --passalgo=sha512 --kickstart
 firstboot --disabled
-reboot
+reboot --eject
 user --name=vagrant --plaintext --password vagrant
 key --skip
 
@@ -31,6 +31,7 @@ make
 perl
 wget
 nfs-utils
+hyperv-daemons
 -fprintd-pam
 -intltool
 
@@ -67,3 +68,12 @@ nfs-utils
 sed -i -e 's/\(^SELINUX=\).*$/\1permissive/' /etc/selinux/config
 # sudo
 echo "%vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+
+#Enable hyper-v daemons only if using hyper-v virtualization
+if [ $(virt-what) == "hyperv" ]; then
+    yum -y install hyperv-daemons
+    systemctl enable hypervvssd
+    systemctl enable hypervkvpd
+fi
+
+%end


### PR DESCRIPTION
Following @wickedviking example in #823 to help complete #724.

This seems to need an external hyperv virtual switch. Packer by default creates an internal one, so I needed to override from CLI/env:

```
packer build -only=hyperv-iso -var hyperv_switch=bento-hyperv .\centos-6.9-x86_64.json
```

Similarly to #823, I had to add `reboot --eject` to kickstart script, otherwise it was a constant install loop.

Unlike #823, adding `network --bootproto=dhcp --onboot=on --device=eth0` did not help force get the network available for %post, so I installed hyperv-daemons in `packages` section of kickstart script. There's probably a way to fix this...

Signed-off-by: Bakh Inamov <b@chef.io>