### PR TITLE
Use app.vagrantapp.com instead of atlas in gh-pages

### DIFF
--- a/index.md
+++ b/index.md
@@ -13,7 +13,7 @@ This project is managed by the CHEF Release Engineering team. For more informati
 
 ## Pre-built Boxes
 
-The following boxes are built from this repository's templates for publicly available platforms and are currently hosted via  Atlas in the [bento organization](https://atlas.hashicorp.com/bento/).
+The following boxes are built from this repository's templates for publicly available platforms and are currently hosted via  Atlas in the [bento organization](https://app.vagrantup.com/bento).
 
 ### 64 bit
 |               | VirtualBox                   | VMware                         | Parallels                   |


### PR DESCRIPTION
### Problem

http://chef.github.io/bento/ is out of date.

### Expected

Bento organization's pre-built boxes url points to https://app.vagrantup.com/bento instead of 
https://atlas.hashicorp.com/bento/.

### Actual

Bento organization pre-built boxes link points to atlas.
box images which are listed in pre built boxes are out of date.
