### PR TITLE
Use correct preseed config with virtualbox/vmware Ubuntu 16.04 boxes 

### DIFF
--- a/http/ubuntu/preseed-hyperv.cfg
+++ b/http/ubuntu/preseed-hyperv.cfg
@@ -5,6 +5,10 @@ d-i clock-setup/utc-auto boolean true
 d-i finish-install/reboot_in_progress note
 d-i grub-installer/only_debian boolean true
 d-i grub-installer/with_other_os boolean true
+d-i mirror/country string manual
+d-i mirror/http/directory string /ubuntu/
+d-i mirror/http/hostname string archive.ubuntu.com
+d-i mirror/http/proxy string
 d-i partman-auto-lvm/guided_size string max
 d-i partman-auto/choose_recipe select atomic
 d-i partman-auto/method string lvm

--- a/ubuntu-16.04-amd64.json
+++ b/ubuntu-16.04-amd64.json
@@ -308,7 +308,7 @@
     "mirror_directory": "16.04.2",
     "name": "ubuntu-16.04",
     "no_proxy": "{{env `no_proxy`}}",
-    "preseed_path": "ubuntu/preseed-hyperv.cfg",
+    "preseed_path": "ubuntu/preseed.cfg",
     "template": "ubuntu-16.04-amd64",
     "version": "TIMESTAMP"
   }


### PR DESCRIPTION
**1) Don't use Hyper-V preseed on virtualbox/vmware Ubuntu 16.04 boxes.**
This reverts the change inadvertently made in #844.

**2) Make Hyper-V Ubuntu boxes use archive.ubuntu.com too**
Applies the fix from #838 to the Hyper-V preseed config added in #844.

Fixes #864.