### PR TITLE
Disable udev hack on Debain Stretch+

### DIFF
--- a/scripts/debian/networking.sh
+++ b/scripts/debian/networking.sh
@@ -1,11 +1,18 @@
 #!/bin/sh -eux
 
-# Disable automatic udev rules for network interfaces in Ubuntu,
-# source: http://6.ptmc.org/164/
-rm -f /etc/udev/rules.d/70-persistent-net.rules;
-mkdir -p /etc/udev/rules.d/70-persistent-net.rules;
-rm -f /lib/udev/rules.d/75-persistent-net-generator.rules;
-rm -rf /dev/.udev/ /var/lib/dhcp/*;
+debian_version="`lsb_release -r | awk '{print $2}'`";
+major_version="`echo $debian_version | awk -F. '{print $1}'`";
+
+
+if [ "$major_version" -le "8" ]; then
+  echo "Disabling automatic udev rules for network interfaces in Debian"
+  # Disable automatic udev rules for network interfaces in Ubuntu,
+  # source: http://6.ptmc.org/164/
+  rm -f /etc/udev/rules.d/70-persistent-net.rules;
+  mkdir -p /etc/udev/rules.d/70-persistent-net.rules;
+  rm -f /lib/udev/rules.d/75-persistent-net-generator.rules;
+  rm -rf /dev/.udev/ /var/lib/dhcp/*;
+fi
 
 # Adding a 2 sec delay to the interface up, to make the dhclient happy
 echo "pre-up sleep 2" >> /etc/network/interfaces


### PR DESCRIPTION
Fixes https://github.com/chef/bento/issues/851 (I think).

This disables a [hack](http://6.ptmc.org/164/) that prevents automatic udev rule creation by placing a folder where there should be a file with udev rules in it. The existence of that folder prevents `libudev-dev` from being installed properly in debian stretch.

I *think* it's no longer necessary to apply this hack to prevent rules from being automatically created, according to comments in #851, but someone should corroborate that claim.