### PR TITLE
Speed up and slim CentOS builds

### DIFF
--- a/centos-7.3-x86_64.json
+++ b/centos-7.3-x86_64.json
@@ -2,7 +2,7 @@
   "builders": [
     {
       "boot_command": [
-        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
+        "<up><wait><tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
       ],
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
@@ -40,7 +40,7 @@
     },
     {
       "boot_command": [
-        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
+        "<up><wait><tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
       ],
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
@@ -68,7 +68,7 @@
     },
     {
       "boot_command": [
-        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
+        "<up><wait><tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
       ],
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
@@ -131,7 +131,7 @@
     },
     {
       "boot_command": [
-        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
+        "<up><wait><tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
       ],
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",

--- a/http/centos-6.9/ks.cfg
+++ b/http/centos-6.9/ks.cfg
@@ -62,6 +62,7 @@ virt-what
 -rt73usb-firmware
 -xorg-x11-drv-ati-firmware
 -zd1211-firmware
+-kernel-firmware
 
 %post
 # Force to set SELinux to a permissive mode

--- a/http/centos-7.3/ks.cfg
+++ b/http/centos-7.3/ks.cfg
@@ -60,6 +60,7 @@ bzip2
 -iwl6000g2b-firmware
 -iwl6050-firmware
 -iwl7260-firmware
+-iwl7265-firmware
 -libertas-usb8388-firmware
 -libertas-sd8686-firmware
 -libertas-sd8787-firmware
@@ -72,6 +73,8 @@ bzip2
 -rt73usb-firmware
 -xorg-x11-drv-ati-firmware
 -zd1211-firmware
+-alsa-tools-firmware
+-alsa-firmware
 %end
 
 %post

--- a/http/centos-7.3/ks.cfg
+++ b/http/centos-7.3/ks.cfg
@@ -75,6 +75,7 @@ bzip2
 -zd1211-firmware
 -alsa-tools-firmware
 -alsa-firmware
+-kernel-firmware
 %end
 
 %post


### PR DESCRIPTION
Avoid disk checks on installation and remove more firmware files to slim the disk sizes down.