### PR TITLE
Fix wrong en_US-8 boot parameter

### DIFF
--- a/sles-12-sp2-x86_64.json
+++ b/sles-12-sp2-x86_64.json
@@ -46,7 +46,7 @@
       "boot_command": [
         "<esc><enter><wait>",
         "linux netdevice=eth0 netsetup=dhcp install=cd:/<wait>",
-        " lang=en_US-8 autoyast=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `autoinst_cfg`}}<wait>",
+        " lang=en_US autoyast=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `autoinst_cfg`}}<wait>",
         " textmode=1<wait>",
         "<enter><wait>"
       ],


### PR DESCRIPTION
Replaced "en_US-8" to "en_US" to avoid manual intervention during unattended builds.