### PR TITLE
Standardizing on 1024MB as default memory

### DIFF
--- a/opensuse-leap-42.3-x86_64.json
+++ b/opensuse-leap-42.3-x86_64.json
@@ -204,7 +204,7 @@
     "iso_checksum": "195baca6c5f3b7f3ad4d7984a7f7bd5c4a37be2eb67e58b65d07ac3a2b599e83",
     "iso_checksum_type": "sha256",
     "iso_name": "openSUSE-Leap-42.3-DVD-x86_64.iso",
-    "memory": "768",
+    "memory": "1024",
     "metadata": "floppy/dummy_metadata.json",
     "mirror": "http://suse.mobile-central.org/distribution",
     "mirror_directory": "leap/42.3/iso",


### PR DESCRIPTION
Signed-off-by: Seth Thomas <sthomas@chef.io>