### PR TITLE
Use the zroot/usr/home file system as location for the vagrant home directory

### DIFF
--- a/freebsd/http/freebsd-11/installerconfig
+++ b/freebsd/http/freebsd-11/installerconfig
@@ -42,10 +42,11 @@ EOT
 touch /etc/fstab
 
 # Set up user accounts
-echo "vagrant" | pw -V /etc useradd vagrant -h 0 -s /bin/sh -G wheel -d /home/vagrant -c "Vagrant User"
+echo "vagrant" | pw -V /etc useradd vagrant -h 0 -s /bin/sh -G wheel -d /usr/home/vagrant -c "Vagrant User"
 echo "vagrant" | pw -V /etc usermod root
 
-mkdir -p /home/vagrant
-chown 1001:1001 /home/vagrant
+mkdir -p /usr/home/vagrant
+chown 1001:1001 /usr/home/vagrant
+ln -s /usr/home /home
 
 reboot


### PR DESCRIPTION
There is a dedicated ZFS filesystem in zroot/usr/home and mounted under ``/usr/home``, but the ``vagrant`` user uses ``/home``.
On FreeBSD, both variants are valid, but since a dedicated dataset exists, it is less bewildering for FreeBSD users to use that as the home directory location.
For compatibility and convenience, there is also a symlink from ``/home`` to ``/usr/home``.