### PR TITLE
Updating all templates for Packer 1.1.0

### DIFF
--- a/centos/centos-6.9-i386.json
+++ b/centos/centos-6.9-i386.json
@@ -165,6 +165,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
         "../_common/sshd.sh",

--- a/centos/centos-6.9-x86_64.json
+++ b/centos/centos-6.9-x86_64.json
@@ -165,6 +165,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
         "../_common/sshd.sh",

--- a/centos/centos-7.4-x86_64.json
+++ b/centos/centos-7.4-x86_64.json
@@ -165,8 +165,8 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
-
         "scripts/update.sh",
         "../_common/sshd.sh",
         "scripts/networking.sh",

--- a/debian/debian-7.11-amd64.json
+++ b/debian/debian-7.11-amd64.json
@@ -194,6 +194,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
         "../_common/sshd.sh",

--- a/debian/debian-7.11-i386.json
+++ b/debian/debian-7.11-i386.json
@@ -194,6 +194,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
         "../_common/sshd.sh",

--- a/debian/debian-8.9-amd64.json
+++ b/debian/debian-8.9-amd64.json
@@ -199,6 +199,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
         "../_common/sshd.sh",

--- a/debian/debian-8.9-i386.json
+++ b/debian/debian-8.9-i386.json
@@ -199,6 +199,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
         "../_common/sshd.sh",

--- a/debian/debian-9.1-amd64.json
+++ b/debian/debian-9.1-amd64.json
@@ -199,6 +199,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
         "../_common/sshd.sh",

--- a/debian/debian-9.1-i386.json
+++ b/debian/debian-9.1-i386.json
@@ -199,6 +199,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
         "../_common/sshd.sh",

--- a/fedora/fedora-25-i386.json
+++ b/fedora/fedora-25-i386.json
@@ -133,6 +133,7 @@
     {
       "environment_vars": [],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/swap.sh",
         "scripts/fix-slow-dns.sh",

--- a/fedora/fedora-25-x86_64.json
+++ b/fedora/fedora-25-x86_64.json
@@ -139,6 +139,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/swap.sh",
         "scripts/fix-slow-dns.sh",

--- a/fedora/fedora-26-x86_64.json
+++ b/fedora/fedora-26-x86_64.json
@@ -139,6 +139,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/swap.sh",
         "scripts/fix-slow-dns.sh",

--- a/freebsd/freebsd-10.3-amd64.json
+++ b/freebsd/freebsd-10.3-amd64.json
@@ -191,6 +191,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} su -m root -c 'sh -eux {{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
         "scripts/postinstall.sh",

--- a/freebsd/freebsd-10.3-i386.json
+++ b/freebsd/freebsd-10.3-i386.json
@@ -191,6 +191,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} su -m root -c 'sh -eux {{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
         "scripts/postinstall.sh",

--- a/freebsd/freebsd-11.1-amd64.json
+++ b/freebsd/freebsd-11.1-amd64.json
@@ -191,6 +191,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} su -m root -c 'sh -eux {{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
         "scripts/postinstall.sh",

--- a/macos/macos-10.12.json
+++ b/macos/macos-10.12.json
@@ -208,6 +208,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant'| {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/hostname.sh",
         "scripts/update.sh",

--- a/macos/macosx-10.10.json
+++ b/macos/macosx-10.10.json
@@ -208,6 +208,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant'| {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/hostname.sh",
         "scripts/update.sh",

--- a/macos/macosx-10.11.json
+++ b/macos/macosx-10.11.json
@@ -208,6 +208,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant'| {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/hostname.sh",
         "scripts/update.sh",

--- a/macos/macosx-10.9.json
+++ b/macos/macosx-10.9.json
@@ -208,6 +208,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant'| {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/hostname.sh",
         "scripts/update.sh",

--- a/opensuse/opensuse-leap-42.3-x86_64.json
+++ b/opensuse/opensuse-leap-42.3-x86_64.json
@@ -174,6 +174,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "../_common/sshd.sh",
         "../_common/vagrant.sh",

--- a/oraclelinux/oracle-5.11-i386.json
+++ b/oraclelinux/oracle-5.11-i386.json
@@ -138,6 +138,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "../centos/scripts/update.sh",
         "../_common/vagrant.sh",

--- a/oraclelinux/oracle-5.11-x86_64.json
+++ b/oraclelinux/oracle-5.11-x86_64.json
@@ -144,6 +144,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "../centos/scripts/update.sh",
         "../_common/vagrant.sh",

--- a/oraclelinux/oracle-6.9-i386.json
+++ b/oraclelinux/oracle-6.9-i386.json
@@ -138,6 +138,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "../centos/scripts/update.sh",
         "../centos/scripts/networking.sh",

--- a/oraclelinux/oracle-6.9-x86_64.json
+++ b/oraclelinux/oracle-6.9-x86_64.json
@@ -138,6 +138,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "../centos/scripts/update.sh",
         "../centos/scripts/networking.sh",

--- a/oraclelinux/oracle-7.3-x86_64.json
+++ b/oraclelinux/oracle-7.3-x86_64.json
@@ -138,6 +138,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "../centos/scripts/update.sh",
         "../centos/scripts/networking.sh",

--- a/rhel/rhel-5.11-i386.json
+++ b/rhel/rhel-5.11-i386.json
@@ -138,6 +138,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "../_common/vagrant.sh",
         "../_common/sshd.sh",

--- a/rhel/rhel-5.11-x86_64.json
+++ b/rhel/rhel-5.11-x86_64.json
@@ -144,6 +144,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "../_common/vagrant.sh",
         "../_common/sshd.sh",

--- a/rhel/rhel-6.9-i386.json
+++ b/rhel/rhel-6.9-i386.json
@@ -138,6 +138,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "../centos/scripts/networking.sh",
         "../_common/sshd.sh",

--- a/rhel/rhel-6.9-x86_64.json
+++ b/rhel/rhel-6.9-x86_64.json
@@ -138,6 +138,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "../centos/scripts/networking.sh",
         "../_common/sshd.sh",

--- a/rhel/rhel-7.4-x86_64.json
+++ b/rhel/rhel-7.4-x86_64.json
@@ -138,6 +138,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "../centos/scripts/networking.sh",
         "../_common/sshd.sh",

--- a/sles/sles-12-sp2-x86_64.json
+++ b/sles/sles-12-sp2-x86_64.json
@@ -154,6 +154,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "../_common/sshd.sh",
         "../_common/vagrant.sh",

--- a/sles/sles-12-sp3-x86_64.json
+++ b/sles/sles-12-sp3-x86_64.json
@@ -154,6 +154,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "../_common/sshd.sh",
         "../_common/vagrant.sh",

--- a/solaris/solaris-10.11-x86.json
+++ b/solaris/solaris-10.11-x86.json
@@ -105,6 +105,7 @@
     {
       "environment_vars": [],
       "execute_command": "/usr/local/bin/sudo {{.Path}}",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/solaris-10/vmtools.sh",
         "scripts/solaris-10/minimize.sh"

--- a/solaris/solaris-11-x86.json
+++ b/solaris/solaris-11-x86.json
@@ -125,6 +125,7 @@
     {
       "environment_vars": [],
       "execute_command": "echo 'vagrant'|sudo -S bash {{.Path}}",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
         "scripts/vagrant.sh",

--- a/ubuntu/ubuntu-14.04-amd64.json
+++ b/ubuntu/ubuntu-14.04-amd64.json
@@ -257,6 +257,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
         "../_common/sshd.sh",

--- a/ubuntu/ubuntu-14.04-i386.json
+++ b/ubuntu/ubuntu-14.04-i386.json
@@ -222,6 +222,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
         "../_common/sshd.sh",

--- a/ubuntu/ubuntu-16.04-amd64.json
+++ b/ubuntu/ubuntu-16.04-amd64.json
@@ -266,6 +266,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
         "../_common/sshd.sh",

--- a/ubuntu/ubuntu-16.04-i386.json
+++ b/ubuntu/ubuntu-16.04-i386.json
@@ -230,6 +230,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
         "../_common/sshd.sh",

--- a/ubuntu/ubuntu-17.04-amd64.json
+++ b/ubuntu/ubuntu-17.04-amd64.json
@@ -262,6 +262,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
         "../_common/sshd.sh",

--- a/ubuntu/ubuntu-17.04-i386.json
+++ b/ubuntu/ubuntu-17.04-i386.json
@@ -232,6 +232,7 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
         "../_common/sshd.sh",


### PR DESCRIPTION
Adds `expect_disconnect` to all script provisioners because we do reboots and don't want that to blow up.

Signed-off-by: Seth Thomas <sthomas@chef.io>