### PR TITLE
Set default HOME_DIR in virtualbox.sh

### DIFF
--- a/_common/virtualbox.sh
+++ b/_common/virtualbox.sh
@@ -1,8 +1,11 @@
 #!/bin/sh -eux
 
+# set a default HOME_DIR environment variable if not set
+HOME_DIR="${HOME_DIR:-/home/vagrant}";
+
 case "$PACKER_BUILDER_TYPE" in
 virtualbox-iso|virtualbox-ovf)
-    VER="`cat /home/vagrant/.vbox_version`";
+    VER="`cat $HOME_DIR/.vbox_version`";
     ISO="VBoxGuestAdditions_$VER.iso";
     mkdir -p /tmp/vbox;
     mount -o loop $HOME_DIR/$ISO /tmp/vbox;


### PR DESCRIPTION
This is consistent with the other builder scripts. Also, removing the
hardcoded /home/vagrant string allows non-vagrant user images to be
created.