### PR TITLE
🚑 Update path to preseed-hyperv.cfg to remove ubuntu/ folder path

### DIFF
--- a/ubuntu/ubuntu-14.04-amd64.json
+++ b/ubuntu/ubuntu-14.04-amd64.json
@@ -221,7 +221,7 @@
         "<esc><wait10><esc><esc><enter><wait>",
         "set gfxpayload=keep<enter><wait>",
         "linux /install/vmlinuz ",
-        "preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/ubuntu/preseed-hyperv.cfg ",
+        "preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/preseed-hyperv.cfg ",
         "debian-installer=en_US auto locale=en_US kbd-chooser/method=us ",
         "hostname={{.Name}} ",
         "fb=false debconf/frontend=noninteractive ",

--- a/ubuntu/ubuntu-16.04-amd64.json
+++ b/ubuntu/ubuntu-16.04-amd64.json
@@ -230,7 +230,7 @@
         "<esc><wait10><esc><esc><enter><wait>",
         "set gfxpayload=1024x768<enter>",
         "linux /install/vmlinuz ",
-        "preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/ubuntu/preseed-hyperv.cfg ",
+        "preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/preseed-hyperv.cfg ",
         "debian-installer=en_US auto locale=en_US kbd-chooser/method=us ",
         "hostname={{.Name}} ",
         "fb=false debconf/frontend=noninteractive ",

--- a/ubuntu/ubuntu-17.04-amd64.json
+++ b/ubuntu/ubuntu-17.04-amd64.json
@@ -226,7 +226,7 @@
         "<esc><wait10><esc><esc><enter><wait>",
         "set gfxpayload=1024x768<enter>",
         "linux /install/vmlinuz ",
-        "preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/ubuntu/preseed-hyperv.cfg ",
+        "preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/preseed-hyperv.cfg ",
         "debian-installer=en_US auto locale=en_US kbd-chooser/method=us ",
         "hostname={{.Name}} ",
         "fb=false debconf/frontend=noninteractive ",


### PR DESCRIPTION
Noticed when trying to build a hyper-v version of the ubuntu 16.04 AMD64 box that the path was wrong for the preseed file. This PR updates the path to where you should no longer get the `Failed to retrieve the preconfigureation file` error during the build process.