### PR TITLE
Added support to install Configuration Management clients

### DIFF
--- a/_common/cmprovisioners.sh
+++ b/_common/cmprovisioners.sh
@@ -1,0 +1,44 @@
+#!/bin/sh -eux
+
+# Variables
+URL=""
+INSTALL_SCRIPT="install.sh"
+VERSION_CMD=""
+
+saltminion () {
+  URL="https://bootstrap.saltstack.com"
+  VERSION_CMD="-P stable"
+}
+
+chefclient () {
+  URL="https://omnitruck.chef.io/install.sh"
+  VERSION_CMD="-v"
+}
+
+install () {
+  curl -o $INSTALL_SCRIPT -L $URL
+  if [ -z "$CM_VERSION" ];
+  then
+    bash $INSTALL_SCRIPT
+  else
+    echo "Version: $CM_VERSION"
+    bash $INSTALL_SCRIPT $VERSION_CMD $CM_VERSION
+  fi
+  echo "Removing script: bootstrap.sh"
+  rm $INSTALL_SCRIPT
+}
+
+case "$CM_PROVISIONER" in
+  saltminion)
+  echo "Installing Salt Minion"
+  saltminion
+  install
+  salt-minion --versions-report
+  ;;
+  chefclient)
+  echo "Installing Chef Client"
+  chefclient
+  install
+  chef-client --version
+  ;;
+esac

--- a/centos/centos-6.9-i386.json
+++ b/centos/centos-6.9-i386.json
@@ -162,12 +162,15 @@
         "HOME_DIR=/home/vagrant",
         "http_proxy={{user `http_proxy`}}",
         "https_proxy={{user `https_proxy`}}",
-        "no_proxy={{user `no_proxy`}}"
+        "no_proxy={{user `no_proxy`}}",
+        "CM_PROVISIONER={{user `cm_provisioner`}}",
+        "CM_VERSION={{user `cm_version`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
+        "../_common/cmprovisioners.sh",
         "../_common/sshd.sh",
         "scripts/networking.sh",
         "../_common/vagrant.sh",
@@ -199,6 +202,8 @@
     "mirror_directory": "6.9/isos/i386",
     "name": "centos-6.9-i386",
     "no_proxy": "{{env `no_proxy`}}",
+    "cm_provisioner": "",
+    "cm_version": "",
     "template": "centos-6.9-i386",
     "version": "TIMESTAMP"
   }

--- a/centos/centos-6.9-x86_64.json
+++ b/centos/centos-6.9-x86_64.json
@@ -162,12 +162,15 @@
         "HOME_DIR=/home/vagrant",
         "http_proxy={{user `http_proxy`}}",
         "https_proxy={{user `https_proxy`}}",
-        "no_proxy={{user `no_proxy`}}"
+        "no_proxy={{user `no_proxy`}}",
+        "CM_PROVISIONER={{user `cm_provisioner`}}",
+        "CM_VERSION={{user `cm_version`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
+        "../_common/cmprovisioners.sh",
         "../_common/sshd.sh",
         "scripts/networking.sh",
         "../_common/vagrant.sh",
@@ -199,6 +202,8 @@
     "mirror_directory": "6.9/isos/x86_64",
     "name": "centos-6.9",
     "no_proxy": "{{env `no_proxy`}}",
+    "cm_provisioner": "",
+    "cm_version": "",
     "template": "centos-6.9-x86_64",
     "version": "TIMESTAMP"
   }

--- a/centos/centos-7.4-x86_64.json
+++ b/centos/centos-7.4-x86_64.json
@@ -162,12 +162,15 @@
         "HOME_DIR=/home/vagrant",
         "http_proxy={{user `http_proxy`}}",
         "https_proxy={{user `https_proxy`}}",
-        "no_proxy={{user `no_proxy`}}"
+        "no_proxy={{user `no_proxy`}}",
+        "CM_PROVISIONER={{user `cm_provisioner`}}",
+        "CM_VERSION={{user `cm_version`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
+        "../_common/cmprovisioners.sh",
         "../_common/sshd.sh",
         "scripts/networking.sh",
         "../_common/vagrant.sh",
@@ -200,6 +203,8 @@
     "mirror_directory": "7.4.1708/isos/x86_64",
     "name": "centos-7.4",
     "no_proxy": "{{env `no_proxy`}}",
+    "cm_provisioner": "",
+    "cm_version": "",
     "template": "centos-7.4-x86_64",
     "version": "TIMESTAMP"
   }

--- a/ubuntu/ubuntu-14.04-amd64.json
+++ b/ubuntu/ubuntu-14.04-amd64.json
@@ -264,12 +264,15 @@
         "HOME_DIR=/home/vagrant",
         "http_proxy={{user `http_proxy`}}",
         "https_proxy={{user `https_proxy`}}",
-        "no_proxy={{user `no_proxy`}}"
+        "no_proxy={{user `no_proxy`}}",
+        "CM_PROVISIONER={{user `cm_provisioner`}}",
+        "CM_VERSION={{user `cm_version`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
+        "../_common/cmprovisioners.sh",
         "../_common/sshd.sh",
         "scripts/networking.sh",
         "scripts/sudoers.sh",
@@ -303,6 +306,8 @@
     "mirror_directory": "14.04.1",
     "name": "ubuntu-14.04",
     "no_proxy": "{{env `no_proxy`}}",
+    "cm_provisioner": "",
+    "cm_version": "",
     "preseed_path": "preseed.cfg",
     "template": "ubuntu-14.04-amd64",
     "version": "TIMESTAMP"

--- a/ubuntu/ubuntu-14.04-i386.json
+++ b/ubuntu/ubuntu-14.04-i386.json
@@ -229,12 +229,15 @@
         "HOME_DIR=/home/vagrant",
         "http_proxy={{user `http_proxy`}}",
         "https_proxy={{user `https_proxy`}}",
-        "no_proxy={{user `no_proxy`}}"
+        "no_proxy={{user `no_proxy`}}",
+        "CM_PROVISIONER={{user `cm_provisioner`}}",
+        "CM_VERSION={{user `cm_version`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
+        "../_common/cmprovisioners.sh",
         "../_common/sshd.sh",
         "scripts/networking.sh",
         "scripts/sudoers.sh",
@@ -265,6 +268,8 @@
     "mirror_directory": "14.04.1",
     "name": "ubuntu-14.04-i386",
     "no_proxy": "{{env `no_proxy`}}",
+    "cm_provisioner": "",
+    "cm_version": "",
     "preseed_path": "preseed.cfg",
     "template": "ubuntu-14.04-i386",
     "version": "TIMESTAMP"

--- a/ubuntu/ubuntu-16.04-amd64.json
+++ b/ubuntu/ubuntu-16.04-amd64.json
@@ -273,12 +273,15 @@
         "HOME_DIR=/home/vagrant",
         "http_proxy={{user `http_proxy`}}",
         "https_proxy={{user `https_proxy`}}",
-        "no_proxy={{user `no_proxy`}}"
+        "no_proxy={{user `no_proxy`}}",
+        "CM_PROVISIONER={{user `cm_provisioner`}}",
+        "CM_VERSION={{user `cm_version`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
+        "../_common/cmprovisioners.sh",
         "../_common/sshd.sh",
         "scripts/networking.sh",
         "scripts/sudoers.sh",
@@ -312,6 +315,8 @@
     "mirror_directory": "16.04.3",
     "name": "ubuntu-16.04",
     "no_proxy": "{{env `no_proxy`}}",
+    "cm_provisioner": "",
+    "cm_version": "",
     "preseed_path": "preseed.cfg",
     "template": "ubuntu-16.04-amd64",
     "version": "TIMESTAMP"

--- a/ubuntu/ubuntu-16.04-i386.json
+++ b/ubuntu/ubuntu-16.04-i386.json
@@ -237,12 +237,15 @@
         "HOME_DIR=/home/vagrant",
         "http_proxy={{user `http_proxy`}}",
         "https_proxy={{user `https_proxy`}}",
-        "no_proxy={{user `no_proxy`}}"
+        "no_proxy={{user `no_proxy`}}",
+        "CM_PROVISIONER={{user `cm_provisioner`}}",
+        "CM_VERSION={{user `cm_version`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
+        "../_common/cmprovisioners.sh",
         "../_common/sshd.sh",
         "scripts/networking.sh",
         "scripts/sudoers.sh",
@@ -273,6 +276,8 @@
     "mirror_directory": "16.04.3",
     "name": "ubuntu-16.04-i386",
     "no_proxy": "{{env `no_proxy`}}",
+    "cm_provisioner": "",
+    "cm_version": "",
     "preseed_path": "preseed.cfg",
     "template": "ubuntu-16.04-i386",
     "version": "TIMESTAMP"

--- a/ubuntu/ubuntu-17.04-amd64.json
+++ b/ubuntu/ubuntu-17.04-amd64.json
@@ -269,12 +269,15 @@
         "HOME_DIR=/home/vagrant",
         "http_proxy={{user `http_proxy`}}",
         "https_proxy={{user `https_proxy`}}",
-        "no_proxy={{user `no_proxy`}}"
+        "no_proxy={{user `no_proxy`}}",
+        "CM_PROVISIONER={{user `cm_provisioner`}}",
+        "CM_VERSION={{user `cm_version`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
+        "../_common/cmprovisioners.sh",
         "../_common/sshd.sh",
         "scripts/networking.sh",
         "scripts/sudoers.sh",
@@ -308,6 +311,8 @@
     "mirror_directory": "17.04",
     "name": "ubuntu-17.04",
     "no_proxy": "{{env `no_proxy`}}",
+    "cm_provisioner": "",
+    "cm_version": "",
     "preseed_path": "preseed.cfg",
     "template": "ubuntu-17.04-amd64",
     "version": "TIMESTAMP"

--- a/ubuntu/ubuntu-17.04-i386.json
+++ b/ubuntu/ubuntu-17.04-i386.json
@@ -234,12 +234,15 @@
         "HOME_DIR=/home/vagrant",
         "http_proxy={{user `http_proxy`}}",
         "https_proxy={{user `https_proxy`}}",
-        "no_proxy={{user `no_proxy`}}"
+        "no_proxy={{user `no_proxy`}}",
+        "CM_PROVISIONER={{user `cm_provisioner`}}",
+        "CM_VERSION={{user `cm_version`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
+        "../_common/cmprovisioners.sh",
         "../_common/sshd.sh",
         "scripts/networking.sh",
         "scripts/sudoers.sh",
@@ -270,6 +273,8 @@
     "mirror_directory": "17.04",
     "name": "ubuntu-17.04-i386",
     "no_proxy": "{{env `no_proxy`}}",
+    "cm_provisioner": "",
+    "cm_version": "",
     "preseed_path": "preseed.cfg",
     "template": "ubuntu-17.04-i386",
     "version": "TIMESTAMP"

--- a/ubuntu/ubuntu-17.10-amd64.json
+++ b/ubuntu/ubuntu-17.10-amd64.json
@@ -269,12 +269,15 @@
         "HOME_DIR=/home/vagrant",
         "http_proxy={{user `http_proxy`}}",
         "https_proxy={{user `https_proxy`}}",
-        "no_proxy={{user `no_proxy`}}"
+        "no_proxy={{user `no_proxy`}}",
+        "CM_PROVISIONER={{user `cm_provisioner`}}",
+        "CM_VERSION={{user `cm_version`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
+        "../_common/cmprovisioners.sh",
         "../_common/sshd.sh",
         "scripts/networking.sh",
         "scripts/sudoers.sh",
@@ -308,6 +311,8 @@
     "mirror_directory": "17.10",
     "name": "ubuntu-17.10",
     "no_proxy": "{{env `no_proxy`}}",
+    "cm_provisioner": "",
+    "cm_version": "",
     "preseed_path": "preseed.cfg",
     "template": "ubuntu-17.10-amd64",
     "version": "TIMESTAMP"

--- a/ubuntu/ubuntu-17.10-i386.json
+++ b/ubuntu/ubuntu-17.10-i386.json
@@ -234,12 +234,15 @@
         "HOME_DIR=/home/vagrant",
         "http_proxy={{user `http_proxy`}}",
         "https_proxy={{user `https_proxy`}}",
-        "no_proxy={{user `no_proxy`}}"
+        "no_proxy={{user `no_proxy`}}",
+        "CM_PROVISIONER={{user `cm_provisioner`}}",
+        "CM_VERSION={{user `cm_version`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "expect_disconnect": true,
       "scripts": [
         "scripts/update.sh",
+        "../_common/cmprovisioners.sh",
         "../_common/sshd.sh",
         "scripts/networking.sh",
         "scripts/sudoers.sh",
@@ -270,6 +273,8 @@
     "mirror_directory": "17.10",
     "name": "ubuntu-17.10-i386",
     "no_proxy": "{{env `no_proxy`}}",
+    "cm_provisioner": "",
+    "cm_version": "",
     "preseed_path": "preseed.cfg",
     "template": "ubuntu-17.10-i386",
     "version": "TIMESTAMP"


### PR DESCRIPTION
This change is necessary because:

* Every time that we provision a vagrant box via Kitchen CI, we spend some minutes waiting for the
Configuration Management client to be installed on the target machine.

The issue is resolved in this commit by:

* Add a script that installs the relevant client based on two environment variables:

 1.   CM_PROVISIONER | Supported clients "saltminion" & "chefclient"
 2.   CM_VERSION | The client version that you want to be installed. Default "latest"