### PR TITLE
fixing bad language-setting in sles/sles12-sp3-x86_64

### DIFF
--- a/sles/sles-12-sp3-x86_64.json
+++ b/sles/sles-12-sp3-x86_64.json
@@ -46,7 +46,7 @@
       "boot_command": [
         "<esc><enter><wait>",
         "linux netdevice=eth0 netsetup=dhcp install=cd:/<wait>",
-        " lang=en_US-8 autoyast=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `autoinst_cfg`}}<wait>",
+        " lang=en_US autoyast=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `autoinst_cfg`}}<wait>",
         " textmode=1<wait>",
         "<enter><wait>"
       ],


### PR DESCRIPTION
fixing bad language-setting in vmware-iso builder of sles/sles12-sp3-x86_64

* this fixes issue #932
