### PR TITLE
fixing guest_os_type for sles-12-sp(2|3)-x86_64 setting it to sles12-64

### DIFF
--- a/sles/sles-12-sp2-x86_64.json
+++ b/sles/sles-12-sp2-x86_64.json
@@ -52,7 +52,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
-      "guest_os_type": "sles11-64",
+      "guest_os_type": "sles12-64",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",

--- a/sles/sles-12-sp3-x86_64.json
+++ b/sles/sles-12-sp3-x86_64.json
@@ -52,7 +52,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
-      "guest_os_type": "sles11-64",
+      "guest_os_type": "sles12-64",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
       "iso_checksum": "{{user `iso_checksum`}}",


### PR DESCRIPTION
* fixing issue #936
* tested on VMware Workstation 12 Pro (for sles-12-sp3-x86_64)