### PR TITLE
Fix network persistence on openSUSE

### DIFF
--- a/opensuse/scripts/cleanup.sh
+++ b/opensuse/scripts/cleanup.sh
@@ -3,5 +3,9 @@
 
 zypper -n rm -u gcc make kernel-default-devel kernel-devel
 
+# Clean up network interface persistence
+rm -f /etc/udev/rules.d/70-persistent-net.rules;
+touch /etc/udev/rules.d/75-persistent-net-generator.rules;
+
 # delete any logs that have built up during the install
 find /var/log/ -name *.log -exec rm -f {} \;


### PR DESCRIPTION
The cleanup scripts for openSUSE were not disabling udev rules similar to how CentOS is set up.  This creates a problem when mutating the box (using `vagrant-mutate`) for use with libvirt.  The box will hang because the network can't initialize properly.

This is my first PR to bento, so if there is a specific format or anything I should tweak just let me know.