### PR TITLE
Don't install src while creating box

### DIFF
--- a/freebsd/http/freebsd-11/installerconfig
+++ b/freebsd/http/freebsd-11/installerconfig
@@ -1,4 +1,4 @@
-DISTRIBUTIONS="base.txz lib32.txz kernel.txz src.txz"
+DISTRIBUTIONS="base.txz lib32.txz kernel.txz"
 
 # for variations in the root disk device name between VMware and Virtualbox
 if [ -e /dev/ada0 ]; then

--- a/freebsd/scripts/cleanup.sh
+++ b/freebsd/scripts/cleanup.sh
@@ -7,6 +7,5 @@ rm -f /var/db/freebsd-update/*-rollback;
 rm -rf /var/db/freebsd-update/install.*;
 rm -rf /boot/kernel.old;
 rm -f /boot/kernel*/*.symbols;
-rm -rf /usr/src/*;
 rm -f /*.core;
 rm -rf /var/cache/pkg;


### PR DESCRIPTION
This speeds up box creation a lot.  The box creation is using pkg(1)
to install software so doesn't need source files.  It doesn't make much
sense installing all the source files and then deleting them during
cleanup stage.