### PR TITLE
Added guest_additions_url as a user-variable for VirtualBox builds.

### DIFF
--- a/centos/centos-6.9-i386.json
+++ b/centos/centos-6.9-i386.json
@@ -7,6 +7,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "RedHat",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -181,6 +182,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "box_basename": "centos-6.9-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/centos/centos-6.9-x86_64.json
+++ b/centos/centos-6.9-x86_64.json
@@ -7,6 +7,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "RedHat_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -181,6 +182,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "box_basename": "centos-6.9",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/centos/centos-7.4-x86_64.json
+++ b/centos/centos-7.4-x86_64.json
@@ -7,6 +7,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "RedHat_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -181,6 +182,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "box_basename": "centos-7.4",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/debian/debian-7.11-amd64.json
+++ b/debian/debian-7.11-amd64.json
@@ -21,6 +21,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "Debian_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -211,6 +212,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "box_basename": "debian-7.11",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/debian/debian-7.11-i386.json
+++ b/debian/debian-7.11-i386.json
@@ -21,6 +21,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "Debian",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -211,6 +212,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "box_basename": "debian-7.11-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/debian/debian-8.10-amd64.json
+++ b/debian/debian-8.10-amd64.json
@@ -22,6 +22,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "Debian_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -217,6 +218,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "box_basename": "debian-8.10",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/debian/debian-8.10-i386.json
+++ b/debian/debian-8.10-i386.json
@@ -22,6 +22,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "Debian",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -217,6 +218,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "box_basename": "debian-8.10-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/debian/debian-9.3-amd64.json
+++ b/debian/debian-9.3-amd64.json
@@ -22,6 +22,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "Debian_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -217,6 +218,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "box_basename": "debian-9.3",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/debian/debian-9.3-i386.json
+++ b/debian/debian-9.3-i386.json
@@ -22,6 +22,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "Debian",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -217,6 +218,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "box_basename": "debian-9.3-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/fedora/fedora-26-x86_64.json
+++ b/fedora/fedora-26-x86_64.json
@@ -7,6 +7,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "Fedora_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -156,6 +157,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "arch": "64",
     "box_basename": "fedora-26",
     "build_timestamp": "{{isotime \"20060102150405\"}}",

--- a/fedora/fedora-27-x86_64.json
+++ b/fedora/fedora-27-x86_64.json
@@ -7,6 +7,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "Fedora_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -156,6 +157,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "arch": "64",
     "box_basename": "fedora-27",
     "build_timestamp": "{{isotime \"20060102150405\"}}",

--- a/freebsd/freebsd-10.3-amd64.json
+++ b/freebsd/freebsd-10.3-amd64.json
@@ -15,6 +15,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "FreeBSD_64",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
@@ -205,6 +206,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "box_basename": "freebsd-10.3",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/freebsd/freebsd-10.3-i386.json
+++ b/freebsd/freebsd-10.3-i386.json
@@ -15,6 +15,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "FreeBSD",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
@@ -205,6 +206,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "box_basename": "freebsd-10.3-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/freebsd/freebsd-10.4-amd64.json
+++ b/freebsd/freebsd-10.4-amd64.json
@@ -15,6 +15,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "FreeBSD_64",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
@@ -205,6 +206,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "box_basename": "freebsd-10.4",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/freebsd/freebsd-10.4-i386.json
+++ b/freebsd/freebsd-10.4-i386.json
@@ -15,6 +15,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "FreeBSD",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
@@ -205,6 +206,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "box_basename": "freebsd-10.4-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/freebsd/freebsd-11.1-amd64.json
+++ b/freebsd/freebsd-11.1-amd64.json
@@ -15,6 +15,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "FreeBSD_64",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
@@ -205,6 +206,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "box_basename": "freebsd-11.1",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/macos/macos-10.12.json
+++ b/macos/macos-10.12.json
@@ -37,6 +37,7 @@
       "boot_wait": "2s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_mode": "disable",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "MacOS1011_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -223,6 +224,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "_README": "You must provide a prepared Mac disk image (from https://github.com/timsutton/osx-vm-templates) and checksum value for this template to work. For more details, consult this project's README.md",
     "box_basename": "macos-10.12",
     "build_timestamp": "{{isotime \"20060102150405\"}}",

--- a/macos/macosx-10.10.json
+++ b/macos/macosx-10.10.json
@@ -37,6 +37,7 @@
       "boot_wait": "2s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_mode": "disable",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "MacOS109_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -223,6 +224,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "_README": "You must provide a prepared Mac disk image (from https://github.com/timsutton/osx-vm-templates) and checksum value for this template to work. For more details, consult this project's README.md",
     "box_basename": "macosx-10.10",
     "build_timestamp": "{{isotime \"20060102150405\"}}",

--- a/macos/macosx-10.11.json
+++ b/macos/macosx-10.11.json
@@ -37,6 +37,7 @@
       "boot_wait": "2s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_mode": "disable",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "MacOS1011_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -223,6 +224,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "_README": "You must provide a prepared Mac disk image (from https://github.com/timsutton/osx-vm-templates) and checksum value for this template to work. For more details, consult this project's README.md",
     "box_basename": "macosx-10.11",
     "build_timestamp": "{{isotime \"20060102150405\"}}",

--- a/macos/macosx-10.9.json
+++ b/macos/macosx-10.9.json
@@ -37,6 +37,7 @@
       "boot_wait": "2s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_mode": "disable",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "MacOS109_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -223,6 +224,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "_README": "You must provide a prepared Mac disk image (from https://github.com/timsutton/osx-vm-templates) and checksum value for this template to work. For more details, consult this project's README.md",
     "box_basename": "macosx-10.9",
     "build_timestamp": "{{isotime \"20060102150405\"}}",

--- a/opensuse/opensuse-leap-42.3-x86_64.json
+++ b/opensuse/opensuse-leap-42.3-x86_64.json
@@ -16,6 +16,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "OpenSUSE_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -186,6 +187,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "arch": "64",
     "autoinst_cfg": "autoinst.xml",
     "box_basename": "opensuse-leap-42.3",

--- a/oraclelinux/oracle-5.11-i386.json
+++ b/oraclelinux/oracle-5.11-i386.json
@@ -7,6 +7,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "Oracle",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -153,6 +154,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "arch": "32",
     "box_basename": "oracle-5.11-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",

--- a/oraclelinux/oracle-5.11-x86_64.json
+++ b/oraclelinux/oracle-5.11-x86_64.json
@@ -7,6 +7,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "Oracle_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -159,6 +160,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "arch": "64",
     "box_basename": "oracle-5.11",
     "build_timestamp": "{{isotime \"20060102150405\"}}",

--- a/oraclelinux/oracle-6.9-i386.json
+++ b/oraclelinux/oracle-6.9-i386.json
@@ -7,6 +7,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "Oracle",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -154,6 +155,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "arch": "32",
     "box_basename": "oracle-6.9-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",

--- a/oraclelinux/oracle-6.9-x86_64.json
+++ b/oraclelinux/oracle-6.9-x86_64.json
@@ -7,6 +7,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "Oracle_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -154,6 +155,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "arch": "64",
     "box_basename": "oracle-6.9",
     "build_timestamp": "{{isotime \"20060102150405\"}}",

--- a/oraclelinux/oracle-7.3-x86_64.json
+++ b/oraclelinux/oracle-7.3-x86_64.json
@@ -7,6 +7,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "Oracle_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -154,6 +155,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "arch": "64",
     "box_basename": "oracle-7.3",
     "build_timestamp": "{{isotime \"20060102150405\"}}",

--- a/rhel/rhel-5.11-i386.json
+++ b/rhel/rhel-5.11-i386.json
@@ -7,6 +7,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "RedHat",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -152,6 +153,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "arch": "32",
     "box_basename": "rhel-5.11-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",

--- a/rhel/rhel-5.11-x86_64.json
+++ b/rhel/rhel-5.11-x86_64.json
@@ -7,6 +7,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "RedHat_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -158,6 +159,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "arch": "64",
     "box_basename": "rhel-5.11",
     "build_timestamp": "{{isotime \"20060102150405\"}}",

--- a/rhel/rhel-6.9-i386.json
+++ b/rhel/rhel-6.9-i386.json
@@ -7,6 +7,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "RedHat",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -153,6 +154,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "arch": "32",
     "box_basename": "rhel-6.9-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",

--- a/rhel/rhel-6.9-x86_64.json
+++ b/rhel/rhel-6.9-x86_64.json
@@ -7,6 +7,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "RedHat_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -153,6 +154,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "arch": "64",
     "box_basename": "rhel-6.9",
     "build_timestamp": "{{isotime \"20060102150405\"}}",

--- a/rhel/rhel-7.4-x86_64.json
+++ b/rhel/rhel-7.4-x86_64.json
@@ -7,6 +7,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "RedHat_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -153,6 +154,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "arch": "64",
     "box_basename": "rhel-7.4",
     "build_timestamp": "{{isotime \"20060102150405\"}}",

--- a/sles/sles-12-sp2-x86_64.json
+++ b/sles/sles-12-sp2-x86_64.json
@@ -11,6 +11,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "OpenSUSE_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -172,6 +173,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "_DOWNLOAD_SITE": "https://www.suse.com/products/server/download",
     "_README": "You must download the automated installer iso from the following page, and then place it in the packer_cache dir",
     "arch": "64",

--- a/sles/sles-12-sp3-x86_64.json
+++ b/sles/sles-12-sp3-x86_64.json
@@ -11,6 +11,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "OpenSUSE_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -172,6 +173,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "_DOWNLOAD_SITE": "https://www.suse.com/products/server/download",
     "_README": "You must download the automated installer iso from the following page, and then place it in the packer_cache dir",
     "arch": "64",

--- a/solaris/solaris-10.11-x86.json
+++ b/solaris/solaris-10.11-x86.json
@@ -20,6 +20,7 @@
         "floppy/finish.sh"
       ],
       "guest_additions_mode": "upload",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "Solaris_64",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
@@ -114,6 +115,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "_DOWNLOAD_SITE": "http://www.oracle.com/technetwork/server-storage/solaris10/downloads/index.html",
     "_README": "You must download the automated installer iso from the following page, and then place it somewhere that packer can fetch it",
     "arch": "64",

--- a/solaris/solaris-11-x86.json
+++ b/solaris/solaris-11-x86.json
@@ -31,6 +31,7 @@
       "boot_wait": "5s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_mode": "attach",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "Solaris11_64",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
@@ -136,6 +137,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "_DOWNLOAD_SITE": "http://www.oracle.com/technetwork/server-storage/solaris11/downloads/index.html",
     "_README": "You must download the automated installer iso from the following page, and then place it in the packer_cache dir",
     "arch": "64",

--- a/ubuntu/ubuntu-14.04-amd64.json
+++ b/ubuntu/ubuntu-14.04-amd64.json
@@ -28,6 +28,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "Ubuntu_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -285,6 +286,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "box_basename": "ubuntu-14.04",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/ubuntu/ubuntu-14.04-i386.json
+++ b/ubuntu/ubuntu-14.04-i386.json
@@ -28,6 +28,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "Ubuntu",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -249,6 +250,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "box_basename": "ubuntu-14.04-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/ubuntu/ubuntu-16.04-amd64.json
+++ b/ubuntu/ubuntu-16.04-amd64.json
@@ -30,6 +30,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "Ubuntu_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -294,6 +295,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "box_basename": "ubuntu-16.04",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/ubuntu/ubuntu-16.04-i386.json
+++ b/ubuntu/ubuntu-16.04-i386.json
@@ -30,6 +30,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "Ubuntu",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -257,6 +258,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "box_basename": "ubuntu-16.04-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/ubuntu/ubuntu-17.04-amd64.json
+++ b/ubuntu/ubuntu-17.04-amd64.json
@@ -29,6 +29,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "Ubuntu_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -290,6 +291,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "box_basename": "ubuntu-17.04",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/ubuntu/ubuntu-17.04-i386.json
+++ b/ubuntu/ubuntu-17.04-i386.json
@@ -29,6 +29,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "Ubuntu",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -254,6 +255,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "box_basename": "ubuntu-17.04-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/ubuntu/ubuntu-17.10-amd64.json
+++ b/ubuntu/ubuntu-17.10-amd64.json
@@ -29,6 +29,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "Ubuntu_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -290,6 +291,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "box_basename": "ubuntu-17.10",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/ubuntu/ubuntu-17.10-i386.json
+++ b/ubuntu/ubuntu-17.10-i386.json
@@ -29,6 +29,7 @@
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "Ubuntu",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
@@ -254,6 +255,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "box_basename": "ubuntu-17.10-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/windows/windows-nano-tp3.json
+++ b/windows/windows-nano-tp3.json
@@ -11,6 +11,7 @@
         "scripts/postunattend.xml"
       ],
       "guest_additions_mode": "disable",
+      "guest_additions_url": "{{user `guest_additions_url`}}",
       "guest_os_type": "Windows2012_64",
       "headless": "{{ user `headless` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
@@ -67,6 +68,7 @@
     }
   ],
   "variables": {
+    "guest_additions_url": "",
     "box_basename": "windows-nano",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "2",


### PR DESCRIPTION
By exposing `guest_additions_url` as a variable, one can force packer to use the correct guest-additions iso for VirtualBox instead of packer trusting the results of the global settings (which may be distribution-specific). If an empty string is specified as `guest_additions_url`, packer will resort to the previous behavior.

This would allow the user to work around issue #958 or any similar ones without having to modify the templates directly.