### PR TITLE
Fixed a mis-spelling of `output_directory` inside the FreeBSD templates.

### DIFF
--- a/freebsd/freebsd-10.3-amd64.json
+++ b/freebsd/freebsd-10.3-amd64.json
@@ -66,7 +66,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../builds/packer-{{user `template`}}-vmare",
+      "output_directory": "../builds/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,

--- a/freebsd/freebsd-10.3-i386.json
+++ b/freebsd/freebsd-10.3-i386.json
@@ -66,7 +66,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../builds/packer-{{user `template`}}-vmare",
+      "output_directory": "../builds/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,

--- a/freebsd/freebsd-10.4-amd64.json
+++ b/freebsd/freebsd-10.4-amd64.json
@@ -66,7 +66,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../builds/packer-{{user `template`}}-vmare",
+      "output_directory": "../builds/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,

--- a/freebsd/freebsd-10.4-i386.json
+++ b/freebsd/freebsd-10.4-i386.json
@@ -66,7 +66,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../builds/packer-{{user `template`}}-vmare",
+      "output_directory": "../builds/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,

--- a/freebsd/freebsd-11.1-amd64.json
+++ b/freebsd/freebsd-11.1-amd64.json
@@ -66,7 +66,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../builds/packer-{{user `template`}}-vmare",
+      "output_directory": "../builds/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,

--- a/freebsd/freebsd-11.1-i386.json
+++ b/freebsd/freebsd-11.1-i386.json
@@ -66,7 +66,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../builds/packer-{{user `template`}}-vmare",
+      "output_directory": "../builds/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,


### PR DESCRIPTION
The value for `output_directory` in the VMware section of the FreeBSD templates (freebsd/*.json) is spelled incorrectly as `-vmare` which just results in an inconsistent default name when building everything. This PR simply updates it to the correct spelling of `-vmware`.