### PR TITLE
Enable autologin for vagrant user on macOS

### DIFF
--- a/macos/macos-10.12.json
+++ b/macos/macos-10.12.json
@@ -201,8 +201,14 @@
   ],
   "provisioners": [
     {
+      "destination": "/private/tmp/set_kcpassword.py",
+      "source": "scripts/support/set_kcpassword.py",
+      "type": "file"
+    },
+    {
       "environment_vars": [
         "HOME_DIR=/Users/vagrant",
+        "AUTOLOGIN={{user `autologin`}}",
         "http_proxy={{user `http_proxy`}}",
         "https_proxy={{user `https_proxy`}}",
         "no_proxy={{user `no_proxy`}}"
@@ -215,6 +221,7 @@
         "scripts/networking.sh",
         "scripts/disablesleep.sh",
         "scripts/vagrant.sh",
+        "scripts/autologin.sh",
         "scripts/vmtools.sh",
         "scripts/cleanup.sh",
         "scripts/minimize.sh"
@@ -224,6 +231,7 @@
   ],
   "variables": {
     "_README": "You must provide a prepared Mac disk image (from https://github.com/timsutton/osx-vm-templates) and checksum value for this template to work. For more details, consult this project's README.md",
+    "autologin": "true",
     "box_basename": "macos-10.12",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/macos/macosx-10.10.json
+++ b/macos/macosx-10.10.json
@@ -201,8 +201,14 @@
   ],
   "provisioners": [
     {
+      "destination": "/private/tmp/set_kcpassword.py",
+      "source": "scripts/support/set_kcpassword.py",
+      "type": "file"
+    },
+    {
       "environment_vars": [
         "HOME_DIR=/Users/vagrant",
+        "AUTOLOGIN={{user `autologin`}}",
         "http_proxy={{user `http_proxy`}}",
         "https_proxy={{user `https_proxy`}}",
         "no_proxy={{user `no_proxy`}}"
@@ -215,6 +221,7 @@
         "scripts/networking.sh",
         "scripts/disablesleep.sh",
         "scripts/vagrant.sh",
+        "scripts/autologin.sh",
         "scripts/vmtools.sh",
         "scripts/cleanup.sh",
         "scripts/minimize.sh"
@@ -224,6 +231,7 @@
   ],
   "variables": {
     "_README": "You must provide a prepared Mac disk image (from https://github.com/timsutton/osx-vm-templates) and checksum value for this template to work. For more details, consult this project's README.md",
+    "autologin": "true",
     "box_basename": "macosx-10.10",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/macos/macosx-10.11.json
+++ b/macos/macosx-10.11.json
@@ -201,8 +201,14 @@
   ],
   "provisioners": [
     {
+      "destination": "/private/tmp/set_kcpassword.py",
+      "source": "scripts/support/set_kcpassword.py",
+      "type": "file"
+    },
+    {
       "environment_vars": [
         "HOME_DIR=/Users/vagrant",
+        "AUTOLOGIN={{user `autologin`}}",
         "http_proxy={{user `http_proxy`}}",
         "https_proxy={{user `https_proxy`}}",
         "no_proxy={{user `no_proxy`}}"
@@ -215,6 +221,7 @@
         "scripts/networking.sh",
         "scripts/disablesleep.sh",
         "scripts/vagrant.sh",
+        "scripts/autologin.sh",
         "scripts/vmtools.sh",
         "scripts/cleanup.sh",
         "scripts/minimize.sh"
@@ -224,6 +231,7 @@
   ],
   "variables": {
     "_README": "You must provide a prepared Mac disk image (from https://github.com/timsutton/osx-vm-templates) and checksum value for this template to work. For more details, consult this project's README.md",
+    "autologin": "true",
     "box_basename": "macosx-10.11",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/macos/macosx-10.9.json
+++ b/macos/macosx-10.9.json
@@ -201,8 +201,14 @@
   ],
   "provisioners": [
     {
+      "destination": "/private/tmp/set_kcpassword.py",
+      "source": "scripts/support/set_kcpassword.py",
+      "type": "file"
+    },
+    {
       "environment_vars": [
         "HOME_DIR=/Users/vagrant",
+        "AUTOLOGIN={{user `autologin`}}",
         "http_proxy={{user `http_proxy`}}",
         "https_proxy={{user `https_proxy`}}",
         "no_proxy={{user `no_proxy`}}"
@@ -215,6 +221,7 @@
         "scripts/networking.sh",
         "scripts/disablesleep.sh",
         "scripts/vagrant.sh",
+        "scripts/autologin.sh",
         "scripts/vmtools.sh",
         "scripts/cleanup.sh",
         "scripts/minimize.sh"
@@ -224,6 +231,7 @@
   ],
   "variables": {
     "_README": "You must provide a prepared Mac disk image (from https://github.com/timsutton/osx-vm-templates) and checksum value for this template to work. For more details, consult this project's README.md",
+    "autologin": "true",
     "box_basename": "macosx-10.9",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",

--- a/macos/scripts/autologin.sh
+++ b/macos/scripts/autologin.sh
@@ -1,0 +1,12 @@
+#!/bin/sh -eux
+
+if [ "$AUTOLOGIN" != "true" ] && [ "$AUTOLOGIN" != "1" ] ; then
+  exit
+fi
+
+# Generate /etc/kcpassword. It contains an encrypted password and allows to run
+# the next command without a password prompt.
+python /private/tmp/set_kcpassword.py "vagrant"
+
+# Enable the autologin for the 'vagrant' user
+/usr/bin/defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser "vagrant"

--- a/macos/scripts/support/set_kcpassword.py
+++ b/macos/scripts/support/set_kcpassword.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+# Port of Gavin Brock's Perl kcpassword generator to Python, by Tom Taylor
+# <tom@tomtaylor.co.uk>.
+# Perl version: http://www.brock-family.org/gavin/perl/kcpassword.html
+
+import sys
+import os
+
+def kcpassword(passwd):
+    # The magic 11 bytes - these are just repeated
+    # 0x7D 0x89 0x52 0x23 0xD2 0xBC 0xDD 0xEA 0xA3 0xB9 0x1F
+    key = [125,137,82,35,210,188,221,234,163,185,31]
+    key_len = len(key)
+
+    passwd = [ord(x) for x in list(passwd)]
+    # pad passwd length out to an even multiple of key length
+    r = len(passwd) % key_len
+    if (r > 0):
+        passwd = passwd + [0] * (key_len - r)
+
+    for n in range(0, len(passwd), len(key)):
+        ki = 0
+        for j in range(n, min(n+len(key), len(passwd))):
+            passwd[j] = passwd[j] ^ key[ki]
+            ki += 1
+
+    passwd = [chr(x) for x in passwd]
+    return "".join(passwd)
+
+if __name__ == "__main__":
+    passwd = kcpassword(sys.argv[1])
+    fd = os.open('/etc/kcpassword', os.O_WRONLY | os.O_CREAT, 0o600)
+    file = os.fdopen(fd, 'w')
+    file.write(passwd)
+    file.close()


### PR DESCRIPTION
Scripts are taken from the project https://github.com/boxcutter/macos
Having "autologin" set to "true" (the default behavior), we will get the "vagrant" user's GUI session started automatically on the VM boot.

It might be required for different provisioning purposes. 

For example, if we use such VM as an [Omnibus](https://github.com/chef/omnibus) builder, then `dmg` packager will fail if there is no GUI session running on the machine:

```
[Compressor::DMG] I | 2018-01-17T09:37:00+01:00 | Rendering `/Users/vagrant/.bundle/ruby/2.4.0/omnibus-fff89b2e4b0c/resources/dmg/create_dmg.osascript.erb' to `/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/myproj20180117-464-rvez6y/create_dmg.osascript'
[Compressor::DMG] I | 2018-01-17T09:37:01+01:00 | Packaging time: 15.551s
The following shell command exited with status 1:

$ osascript "/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/myproj20180117-464-rvez6y/create_dmg.osascript"


Output:

(nothing)

Error:

_RegisterApplication(), FAILED TO establish the default connection to the WindowServer, _CGSDefaultConnection() is NULL.
/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/myproj20180117-464-rvez6y/create_dmg.osascript:302:308: execution error: An error of type -10810 has occurred. (-10810)
```

P.s. All suggestions are welcome. Let me know if you want the python script being added to the `.sh`.