### PR TITLE
Fix 983

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,7 @@
 
 ks.cfg eol=lf
 preseed.cfg eol=lf
+installerconfig eol=lf
 
 # Force CRLF line ending on these files
 *.bat eol=crlf

--- a/freebsd/http/freebsd-11/installerconfig
+++ b/freebsd/http/freebsd-11/installerconfig
@@ -1,5 +1,4 @@
 DISTRIBUTIONS="base.txz kernel.txz"
-
 if [ `uname -m` = "amd64" ]; then
   DISTRIBUTIONS="${DISTRIBUTIONS} lib32.txz"
 fi


### PR DESCRIPTION
I fixed the line endings of the freebsd 11 installerconfig file using a rule in .gitattributes.