### PR TITLE
Disable uploading vbox guest additions ISO, which is installed via pkg

### DIFF
--- a/freebsd/freebsd-10.3-amd64.json
+++ b/freebsd/freebsd-10.3-amd64.json
@@ -14,7 +14,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
-      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_mode": "disable",
       "guest_os_type": "FreeBSD_64",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/freebsd/freebsd-10.3-i386.json
+++ b/freebsd/freebsd-10.3-i386.json
@@ -14,7 +14,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
-      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_mode": "disable",
       "guest_os_type": "FreeBSD",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/freebsd/freebsd-10.4-amd64.json
+++ b/freebsd/freebsd-10.4-amd64.json
@@ -14,7 +14,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
-      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_mode": "disable",
       "guest_os_type": "FreeBSD_64",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/freebsd/freebsd-10.4-i386.json
+++ b/freebsd/freebsd-10.4-i386.json
@@ -14,7 +14,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
-      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_mode": "disable",
       "guest_os_type": "FreeBSD",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/freebsd/freebsd-11.1-amd64.json
+++ b/freebsd/freebsd-11.1-amd64.json
@@ -14,7 +14,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
-      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_mode": "disable",
       "guest_os_type": "FreeBSD_64",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/freebsd/freebsd-11.1-i386.json
+++ b/freebsd/freebsd-11.1-i386.json
@@ -14,7 +14,7 @@
       ],
       "boot_wait": "10s",
       "disk_size": "{{user `disk_size`}}",
-      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_mode": "disable",
       "guest_os_type": "FreeBSD",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",


### PR DESCRIPTION
To reduce box size.