### PR TITLE
Install VMware Tools on OS X 10.10 and earlier from a specific ISO

### DIFF
--- a/macos/macosx-10.10.json
+++ b/macos/macosx-10.10.json
@@ -15,7 +15,7 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "tools_upload_flavor": "darwin",
+      "tools_upload_flavor": "darwinPre15",
       "tools_upload_path": "/tmp/vmtools.iso",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",

--- a/macos/macosx-10.9.json
+++ b/macos/macosx-10.9.json
@@ -15,7 +15,7 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "tools_upload_flavor": "darwin",
+      "tools_upload_flavor": "darwinPre15",
       "tools_upload_path": "/tmp/vmtools.iso",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",


### PR DESCRIPTION
Starting since VMware Tools 10.0.12, there is a dedicated image for
guest OS X 10.10 and older: `"darwinPre15.iso"`
https://docs.vmware.com/en/VMware-Tools/10.0/rn/vmware-tools-10012-release-notes.html

Otherwise, the installation fails, because `darwin.iso` supports only macOS 10.11 and higher.

I've verified that on VMware Fusion 10.1.1. There is a chance that this PR will break the compatibility of Packer templates with VMware Fusion 8.* and older (and an appropriate versions of VMware Workstation missing `"darwinPre15.iso"`)