### PR TITLE
Don't upload ISO for VMware and cleanup any ISOs

### DIFF
--- a/freebsd/freebsd-10.3-amd64.json
+++ b/freebsd/freebsd-10.3-amd64.json
@@ -72,7 +72,6 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "tools_upload_flavor": "freebsd",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
       "vmx_data": {

--- a/freebsd/freebsd-10.3-i386.json
+++ b/freebsd/freebsd-10.3-i386.json
@@ -72,7 +72,6 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "tools_upload_flavor": "freebsd",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
       "vmx_data": {

--- a/freebsd/freebsd-10.4-amd64.json
+++ b/freebsd/freebsd-10.4-amd64.json
@@ -72,7 +72,6 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "tools_upload_flavor": "freebsd",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
       "vmx_data": {

--- a/freebsd/freebsd-10.4-i386.json
+++ b/freebsd/freebsd-10.4-i386.json
@@ -72,7 +72,6 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "tools_upload_flavor": "freebsd",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
       "vmx_data": {

--- a/freebsd/freebsd-11.1-amd64.json
+++ b/freebsd/freebsd-11.1-amd64.json
@@ -72,7 +72,6 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "tools_upload_flavor": "freebsd",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
       "vmx_data": {

--- a/freebsd/freebsd-11.1-i386.json
+++ b/freebsd/freebsd-11.1-i386.json
@@ -72,7 +72,6 @@
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
-      "tools_upload_flavor": "freebsd",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
       "vmx_data": {

--- a/freebsd/scripts/cleanup.sh
+++ b/freebsd/scripts/cleanup.sh
@@ -9,3 +9,4 @@ rm -rf /boot/kernel.old;
 rm -f /boot/kernel*/*.symbols;
 rm -f /*.core;
 rm -rf /var/cache/pkg;
+rm -f /usr/home/vagrant/*.iso;


### PR DESCRIPTION
Fixes #1009 

- the default for `tools_upload_flavor` is an empty string, we can remove this line as it's uploading a useless ISO
- remove any ISOs from the vagrant user's home dir just in case

Signed-off-by: Seth Thomas <sthomas@chef.io>