### PR TITLE
Simplify and cleanup issues with disabling Predicatable Interface Naming

### DIFF
--- a/debian/scripts/networking.sh
+++ b/debian/scripts/networking.sh
@@ -14,5 +14,12 @@ if [ "$major_version" -le "8" ]; then
   rm -rf /dev/.udev/ /var/lib/dhcp/*;
 fi
 
+if [ "$major_version" -ge "9" ]; then
+  # Disable Predictable Network Interface names and use eth0
+  sed -i 's/en[[:alnum:]]*/eth0/g' /etc/network/interfaces;
+  sed -ie 's/GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0 \1"/g' /etc/default/grub;
+  update-grub;
+fi
+
 # Adding a 2 sec delay to the interface up, to make the dhclient happy
 echo "pre-up sleep 2" >> /etc/network/interfaces

--- a/ubuntu/scripts/networking.sh
+++ b/ubuntu/scripts/networking.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -eux
+
 ubuntu_version="`lsb_release -r | awk '{print $2}'`";
+major_version="`echo $ubuntu_version | awk -F. '{print $1}'`";
 
 if [ "$ubuntu_version" = '17.10' ]; then
 echo "Create netplan config for eth0"
@@ -11,12 +13,13 @@ network:
       dhcp4: true
 EOF
 else
-  # Set up eth0 for pre-17.10
-  echo "auto eth0\niface eth0 inet dhcp" >> /etc/network/interfaces.d/eth0.cfg
   # Adding a 2 sec delay to the interface up, to make the dhclient happy
-  echo "pre-up sleep 2" >>/etc/network/interfaces;
+  echo "pre-up sleep 2" >> /etc/network/interfaces;
 fi
 
-# Seriously though eth0
-sed -ie 's/GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0 \1"/g' /etc/default/grub
-update-grub
+if [ "$major_version" -ge "16" ]; then
+  # Disable Predictable Network Interface names and use eth0
+  sed -i 's/en[[:alnum:]]*/eth0/g' /etc/network/interfaces;
+  sed -ie 's/GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0 \1"/g' /etc/default/grub;
+  update-grub;
+fi


### PR DESCRIPTION
- Fix #1003 
- Fix #1004 

For Debian family operating systems that ship with SystemD we create `/etc/network/interfaces.d/eth0.cfg` but don't clean up any prior `en*` entries in `/etc/network/interfaces`. Instead, we have gotten rid of the `eth0.cfg` and opted to rely on `/etc/network/interfaces`. As an improvement, the code has also been re-organized to only run the necessary steps on platforms that require them and we're now aligning Debian with Ubuntu so it's `eth0` across the board.

Signed-off-by: Seth Thomas <sthomas@chef.io>