### PR TITLE
Fix #942

### DIFF
--- a/debian/scripts/update.sh
+++ b/debian/scripts/update.sh
@@ -1,18 +1,30 @@
 #!/bin/sh -eux
 
 arch="`uname -r | sed 's/^.*[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\(-[0-9]\{1,2\}\)-//'`"
+debian_version="`lsb_release -r | awk '{print $2}'`";
+major_version="`echo $debian_version | awk -F. '{print $1}'`";
 
 apt-get update;
 
+# Disable systemd apt timers/services
+if [ "$major_version" -ge "9" ]; then
+  systemctl stop apt-daily.timer;
+  systemctl stop apt-daily-upgrade.timer;
+  systemctl disable apt-daily.timer;
+  systemctl disable apt-daily-upgrade.timer;
+  systemctl mask apt-daily.service;
+  systemctl mask apt-daily-upgrade.service;
+  systemctl daemon-reload;
+fi
+
+# Disable periodic activities of apt
+cat <<EOF >/etc/apt/apt.conf.d/10periodic;
+APT::Periodic::Enable "0";
+APT::Periodic::Update-Package-Lists "0";
+APT::Periodic::Download-Upgradeable-Packages "0";
+APT::Periodic::AutocleanInterval "0";
+APT::Periodic::Unattended-Upgrade "0";
+EOF
+
 apt-get -y upgrade linux-image-$arch;
 apt-get -y install linux-headers-`uname -r`;
-
-if [ -d /etc/init ]; then
-    # update package index on boot
-    cat <<EOF >/etc/init/refresh-apt.conf;
-description "update package index"
-start on networking
-task
-exec /usr/bin/apt-get update
-EOF
-fi

--- a/ubuntu/scripts/update.sh
+++ b/ubuntu/scripts/update.sh
@@ -10,18 +10,29 @@ sed -i.bak 's/^Prompt=.*$/Prompt=never/' /etc/update-manager/release-upgrades;
 # Update the package list
 apt-get -y update;
 
-# update package index on boot
-cat <<EOF >/etc/init/refresh-apt.conf;
-description "update package index"
-start on networking
-task
-exec /usr/bin/apt-get update
+# Disable systemd apt timers/services
+if [ "$major_version" -ge "16" ]; then
+  systemctl stop apt-daily.timer;
+  systemctl stop apt-daily-upgrade.timer;
+  systemctl disable apt-daily.timer;
+  systemctl disable apt-daily-upgrade.timer;
+  systemctl mask apt-daily.service;
+  systemctl mask apt-daily-upgrade.service;
+  systemctl daemon-reload;
+fi
+
+# Disable periodic activities of apt to be safe
+cat <<EOF >/etc/apt/apt.conf.d/10periodic;
+APT::Periodic::Enable "0";
+APT::Periodic::Update-Package-Lists "0";
+APT::Periodic::Download-Upgradeable-Packages "0";
+APT::Periodic::AutocleanInterval "0";
+APT::Periodic::Unattended-Upgrade "0";
 EOF
 
-# Disable periodic activities of apt
-cat <<EOF >/etc/apt/apt.conf.d/10disable-periodic;
-APT::Periodic::Enable "0";
-EOF
+# Clean and nuke the package from orbit
+rm -rf /var/log/unattended-upgrades;
+apt-get -y purge unattended-upgrades;
 
 # Upgrade all installed packages incl. kernel and kernel headers
 apt-get -y dist-upgrade -o Dpkg::Options::="--force-confnew";


### PR DESCRIPTION
Nuke unattended-upgrades from orbit

Specifically, prevent systemd from being able to run it's apt related timers on Ubuntu 16.04+ and Debian 9+. For Ubuntu, we're also getting rid of the `unattended-upgrades` package and to be extra safe, let's also disable all the APT::Periodic settings explicitly.

Along with this we are no longer creating files in `/etc/init/` to run `apt-get update` and leave this to the user in their provisioning scripts or Vagrantfiles.



Signed-off-by: Seth Thomas <sthomas@chef.io>