### PR TITLE
Fix #985 - Disable snapshots

### DIFF
--- a/opensuse/http/autoinst.xml
+++ b/opensuse/http/autoinst.xml
@@ -42,6 +42,7 @@
   </timezone>
   <partitioning config:type="list">
     <drive>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
       <initialize config:type="boolean">true</initialize>
       <partitions config:type="list">
         <partition>
@@ -155,6 +156,7 @@
       <package>telnet</package>
       <package>virtualbox-guest-kmp-default</package>
       <package>virtualbox-guest-tools</package>
+      <package>snapper-zypp-plugin</package>
     </remove-packages>
   </software>
   <services-manager>

--- a/opensuse/opensuse-leap-42.3-x86_64.json
+++ b/opensuse/opensuse-leap-42.3-x86_64.json
@@ -191,7 +191,7 @@
     "box_basename": "opensuse-leap-42.3",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
-    "disk_size": "20480",
+    "disk_size": "65536",
     "git_revision": "__unknown_git_revision__",
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",


### PR DESCRIPTION
Fix #985 which was due to snapper (via btrfs) creating snapshots on a small (20GB) drive. Automatic snapshots really aren't sensible for our goals of sane base box defaults and thankfully AutoYast has a [toggle](https://www.suse.com/documentation/sles-12/singlehtml/book_autoyast/book_autoyast.html#CreateProfile.Partitioning.config). Also bumping the disk size to be in line with other platforms.

Signed-off-by: Seth Thomas <sthomas@chef.io>