### PR TITLE
opensuse: Create a new 'vagrant' group for vagrant user

### DIFF
--- a/opensuse/opensuse-leap-42.3-x86_64.json
+++ b/opensuse/opensuse-leap-42.3-x86_64.json
@@ -176,6 +176,7 @@
         "../_common/virtualbox.sh",
         "../_common/vmware.sh",
         "../_common/parallels.sh",
+        "scripts/vagrant_group.sh",
         "scripts/sudoers.sh",
         "scripts/zypper-locks.sh",
         "scripts/remove-dvd-source.sh",

--- a/opensuse/scripts/vagrant_group.sh
+++ b/opensuse/scripts/vagrant_group.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -eux
+
+# User 'vagrant' belogs to the 'users' group by default so we need to
+# create a new group 'vagrant' and put our user there.
+
+groupadd -f vagrant
+gpasswd -a vagrant vagrant


### PR DESCRIPTION
openSUSE does not create a group with the same name as the user and this
breaks some assumptions that user files are owned by 'vagrant:vagrant'.
As such, lets create such a group and put the vagrant user in it.