### PR TITLE
Clean up network configs

### DIFF
--- a/fedora/scripts/cleanup.sh
+++ b/fedora/scripts/cleanup.sh
@@ -12,3 +12,6 @@ rm -f /tmp/chef*rpm
 
 # delete any logs that have built up during the install
 find /var/log/ -name *.log -exec rm -f {} \;
+
+# Remove any non-loopback network configs
+find /etc/sysconfig/network-scripts -name "ifcfg-*" -not -name "ifcfg-lo" -exec rm -f {} \;


### PR DESCRIPTION
When using a box generated from the fedora-27.json, the network.service fails to restart cleanly because there are leftover network configuration files for non-existent devices.  This update removes anything that is non-loopback related.