### PR TITLE
fedora, centos, rhel: added deltarpm to kickstart files

### DIFF
--- a/centos/http/7/ks.cfg
+++ b/centos/http/7/ks.cfg
@@ -33,6 +33,7 @@ wget
 nfs-utils
 net-tools
 bzip2
+deltarpm
 -fprintd-pam
 -intltool
 

--- a/fedora/http/ks.cfg
+++ b/fedora/http/ks.cfg
@@ -28,6 +28,7 @@ tar
 wget
 nfs-utils
 net-tools
+deltarpm
 -linux-firmware
 -plymouth
 -plymouth-core-libs


### PR DESCRIPTION
I think this one additional package do not hurt and can be save download size during update