### PR TITLE
Fix Fedora cleanup script not to cause unintended software removal.

### DIFF
--- a/fedora/scripts/cleanup.sh
+++ b/fedora/scripts/cleanup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eux
 echo "Removing development packages and cleaning up DNF data"
-dnf -y remove gcc cpp gc kernel-devel kernel-headers glibc-devel elfutils-libelf-devel glibc-headers kernel-devel kernel-headers make perl
+dnf -y remove gcc cpp gc kernel-devel kernel-headers glibc-devel elfutils-libelf-devel glibc-headers kernel-devel kernel-headers
 dnf -y autoremove
 dnf -y clean all --enablerepo=\*
 


### PR DESCRIPTION
We install additional software during the build process, such as Perl modules. Removing Perl at cleanup causes an unintended removal of those packages, therefore I changed cleanup.sh to not remove "make" and "perl". This is in line with other cleanup scripts like that from centos.