### PR TITLE
centos, rhel, oracle: remove previous kernels to minimize image size

### DIFF
--- a/centos/scripts/cleanup.sh
+++ b/centos/scripts/cleanup.sh
@@ -57,3 +57,7 @@ fi
 
 # delete any logs that have built up during the install
 find /var/log/ -name *.log -exec rm -f {} \;
+
+# remove previous kernels that yum preserved for rollback
+yum install -y yum-utils
+package-cleanup --oldkernels --count=1 -y


### PR DESCRIPTION
`yum update` keeps several kernel versions installed at the same time by default (installonly_limit). 
So, `bento/centos-6.9` image v201803.24.0 has two installed kernels: `kernel-2.6.32-696.el6.x86_64` and `kernel-2.6.32-696.23.1.el6.x86_64` . 
Removal of the unused one would reduce the image size by about 50 megs.

1. The proposal is to delete via `package-cleanup` from `yum-utils`, which probably should take care for `kernel-uek`  in the Oracle Linux.

2. Alternative approach could be direct manipulation:
    ```bash
    unused_kernels=("`rpm -q kernel kernel-uek | grep -v "\`uname -r\`"`")
    if [ ${#unused_kernels[@]} -gt 0 ]; then yum remove -y ${unused_kernels[@]}; fi
    ```

### bento/centos-6.9 v201803.24.0 kernels
```bash
[vagrant@localhost ~]$ rpm -qi kernel
Name        : kernel                       Relocations: (not relocatable)
Version     : 2.6.32                            Vendor: CentOS
Release     : 696.el6                       Build Date: Tue 21 Mar 2017 07:56:16 PM UTC
Install Date: Sat 24 Mar 2018 02:35:41 PM UTC      Build Host: c1bm.rdu2.centos.org
Group       : System Environment/Kernel     Source RPM: kernel-2.6.32-696.el6.src.rpm
Size        : 137522245                        License: GPLv2
Signature   : RSA/SHA1, Thu 23 Mar 2017 03:02:10 PM UTC, Key ID 0946fca2c105b9de
Packager    : CentOS BuildSystem <http://bugs.centos.org>
URL         : http://www.kernel.org/
Summary     : The Linux kernel
Description :
The kernel package contains the Linux kernel (vmlinuz), the core of any
Linux operating system.  The kernel handles the basic functions
of the operating system: memory allocation, process allocation, device
input and output, etc.

Name        : kernel                       Relocations: (not relocatable)
Version     : 2.6.32                            Vendor: CentOS
Release     : 696.23.1.el6                  Build Date: Tue 13 Mar 2018 11:01:52 PM UTC
Install Date: Sat 24 Mar 2018 02:36:48 PM UTC      Build Host: x86-01.bsys.centos.org
Group       : System Environment/Kernel     Source RPM: kernel-2.6.32-696.23.1.el6.src.rpm
Size        : 139542045                        License: GPLv2
Signature   : RSA/SHA1, Wed 14 Mar 2018 02:39:08 PM UTC, Key ID 0946fca2c105b9de
Packager    : CentOS BuildSystem <http://bugs.centos.org>
URL         : http://www.kernel.org/
Summary     : The Linux kernel
```

