### PR TITLE
Increase built time memory to 4GB on Windows boxes

### DIFF
--- a/windows/2008r2.json
+++ b/windows/2008r2.json
@@ -2,7 +2,7 @@
 	"builders": [{
 		"type": "virtualbox-iso",
 		"vboxmanage": [
-			["modifyvm", "{{.Name}}", "--memory", "2048"],
+			["modifyvm", "{{.Name}}", "--memory", "4096"],
 			["modifyvm", "{{.Name}}", "--vram", "48"],
 			["modifyvm", "{{.Name}}", "--cpus", "2"]
 		],

--- a/windows/2012r2.json
+++ b/windows/2012r2.json
@@ -2,7 +2,7 @@
 	"builders": [{
 		"type": "virtualbox-iso",
 		"vboxmanage": [
-			["modifyvm", "{{.Name}}", "--memory", "2048"],
+			["modifyvm", "{{.Name}}", "--memory", "4096"],
 			["modifyvm", "{{.Name}}", "--vram", "48"],
 			["modifyvm", "{{.Name}}", "--cpus", "2"]
 		],

--- a/windows/2016.json
+++ b/windows/2016.json
@@ -2,7 +2,7 @@
 	"builders": [{
 		"type": "virtualbox-iso",
 		"vboxmanage": [
-			["modifyvm", "{{.Name}}", "--memory", "2048"],
+			["modifyvm", "{{.Name}}", "--memory", "4096"],
 			["modifyvm", "{{.Name}}", "--vram", "48"],
 			["modifyvm", "{{.Name}}", "--cpus", "2"]
 		],


### PR DESCRIPTION
Avoid OOM issues

Signed-off-by: Tim Smith <tsmith@chef.io>