### PR TITLE
Set correct permissions on /etc/sudoers.d/vagrant

### DIFF
--- a/centos/http/6/ks.cfg
+++ b/centos/http/6/ks.cfg
@@ -69,6 +69,7 @@ virt-what
 sed -i -e 's/\(^SELINUX=\).*$/\1permissive/' /etc/selinux/config
 # sudo
 echo "%vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant
 
 #Enable hyper-v daemons only if using hyper-v virtualization
 if [ $(virt-what) == "hyperv" ]; then

--- a/centos/http/7/ks.cfg
+++ b/centos/http/7/ks.cfg
@@ -64,6 +64,7 @@ deltarpm
 %post
 # sudo
 echo "%vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant
 
 #Enable hyper-v daemons only if using hyper-v virtualization
 if [ $(virt-what) == "hyperv" ]; then


### PR DESCRIPTION
'visudo -c' reports that /etc/sudoers.d/vagrant should have its mode set to 0440, but it is set to 0644.