### PR TITLE
WIP: Blank netplan machine-id (DUID) so Ubuntu machines get unique ID generated on boot.

### DIFF
--- a/ubuntu/scripts/cleanup.sh
+++ b/ubuntu/scripts/cleanup.sh
@@ -67,5 +67,5 @@ find /var/cache -type f -exec rm -rf {} \;
 # delete any logs that have built up during the install
 find /var/log/ -name *.log -exec rm -f {} \;
 
-# Remove netplan machine-id (DUID) so machines get unique ID generated on boot.
-rm -rf /etc/machine-id
+# Blank netplan machine-id (DUID) so machines get unique ID generated on boot.
+truncate -s 0 /etc/machine-id

--- a/ubuntu/scripts/cleanup.sh
+++ b/ubuntu/scripts/cleanup.sh
@@ -66,3 +66,6 @@ find /var/cache -type f -exec rm -rf {} \;
 
 # delete any logs that have built up during the install
 find /var/log/ -name *.log -exec rm -f {} \;
+
+# Remove netplan machine-id (DUID) so machines get unique ID generated on boot.
+rm -rf /etc/machine-id


### PR DESCRIPTION
This fixes the issue in:
https://github.com/chef/bento/issues/1062

I have not done backtesting on versions other than 18.04, but I can't see why it would cause any issues. 