### PR TITLE
Update CentOS 6.9 -> 6.10

### DIFF
--- a/builds.yml
+++ b/builds.yml
@@ -6,11 +6,11 @@ providers:
 
 public:
 - 'centos-7.5'
-- 'centos-6.9'
-- 'centos-6.9-i386'
+- 'centos-6.10'
+- 'centos-6.10-i386'
 - 'oracle-7.5'
-- 'oracle-6.9'
-- 'oracle-6.9-i386'
+- 'oracle-6.10'
+- 'oracle-6.10-i386'
 - 'ubuntu-18.04'
 - 'ubuntu-16.04'
 - 'ubuntu-16.04-i386'
@@ -33,7 +33,7 @@ public:
 
 slugs:
   'centos-7': 'centos-7.5'
-  'centos-6': 'centos-6.9'
+  'centos-6': 'centos-6.10'
   'debian-9': 'debian-9.4'
   'debian-8': 'debian-8.10'
   'freebsd-11': 'freebsd-11.2'

--- a/centos/centos-6.10-i386.json
+++ b/centos/centos-6.10-i386.json
@@ -181,7 +181,7 @@
     }
   ],
   "variables": {
-    "box_basename": "centos-6.9-i386",
+    "box_basename": "centos-6.10-i386",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",
@@ -190,16 +190,16 @@
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
     "hyperv_generation": "1",
-    "iso_checksum": "0724a468ec0c4ac46ac6a1daba0273be697a37bb7f4e9fed8ad84ad270cdee2f",
+    "iso_checksum": "25d95b3f178e59bd672fa97e043a9191cbf73bb6cd12f5df9b540fa88076cae8",
     "iso_checksum_type": "sha256",
-    "iso_name": "CentOS-6.9-i386-bin-DVD1.iso",
+    "iso_name": "CentOS-6.10-i386-bin-DVD1.iso",
     "ks_path": "6/ks.cfg",
     "memory": "1024",
     "mirror": "http://mirrors.kernel.org/centos",
-    "mirror_directory": "6.9/isos/i386",
-    "name": "centos-6.9-i386",
+    "mirror_directory": "6.10/isos/i386",
+    "name": "centos-6.10-i386",
     "no_proxy": "{{env `no_proxy`}}",
-    "template": "centos-6.9-i386",
+    "template": "centos-6.10-i386",
     "version": "TIMESTAMP"
   }
 }

--- a/centos/centos-6.10-x86_64.json
+++ b/centos/centos-6.10-x86_64.json
@@ -181,7 +181,7 @@
     }
   ],
   "variables": {
-    "box_basename": "centos-6.9",
+    "box_basename": "centos-6.10",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",
@@ -190,16 +190,16 @@
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
     "hyperv_generation": "1",
-    "iso_checksum": "d27cf37a40509c17ad70f37bc743f038c1feba00476fe6b69682aa424c399ea6",
+    "iso_checksum": "a68e46970678d4d297d46086ae2efdd3e994322d6d862ff51dcce25a0759e41c",
     "iso_checksum_type": "sha256",
-    "iso_name": "CentOS-6.9-x86_64-bin-DVD1.iso",
+    "iso_name": "CentOS-6.10-x86_64-bin-DVD1.iso",
     "ks_path": "6/ks.cfg",
     "memory": "1024",
     "mirror": "http://mirrors.kernel.org/centos",
-    "mirror_directory": "6.9/isos/x86_64",
-    "name": "centos-6.9",
+    "mirror_directory": "6.10/isos/x86_64",
+    "name": "centos-6.10",
     "no_proxy": "{{env `no_proxy`}}",
-    "template": "centos-6.9-x86_64",
+    "template": "centos-6.10-x86_64",
     "version": "TIMESTAMP"
   }
 }


### PR DESCRIPTION
The last CentOS 6...can't come soon enough.

Signed-off-by: Tim Smith <tsmith@chef.io>