### PR TITLE
Fix disk space on SLES 12 and bring back SLES 11

### DIFF
--- a/sles/http/sles-11-sp4-x86_64-autoinst.xml
+++ b/sles/http/sles-11-sp4-x86_64-autoinst.xml
@@ -82,7 +82,7 @@
           <partition_nr config:type="integer">2</partition_nr>
           <raid_options/>
           <resize config:type="boolean">false</resize>
-          <size>64424509440</size>
+          <size>max</size>
         </partition>
       </partitions>
       <pesize></pesize>

--- a/sles/http/sles-11-sp4-x86_64-autoinst.xml
+++ b/sles/http/sles-11-sp4-x86_64-autoinst.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <general>
+    <ask-list config:type="list"/>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+    <mouse>
+      <id>none</id>
+    </mouse>
+    <proposals config:type="list"/>
+    <signature-handling>
+      <accept_file_without_checksum config:type="boolean">true</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file config:type="boolean">true</accept_unsigned_file>
+      <accept_verification_failed config:type="boolean">false</accept_verification_failed>
+      <import_gpg_key config:type="boolean">true</import_gpg_key>
+    </signature-handling>
+    <storage/>
+  </general>
+  <login_settings/>
+  <networking>
+    <dhcp_options>
+      <dhclient_client_id></dhclient_client_id>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">false</dhcp_hostname>
+      <domain>vagrantup.com</domain>
+      <hostname>vagrant-sles-11sp4-x64</hostname>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <searchlist config:type="list">
+        <search>vagrantup.com</search>
+      </searchlist>
+      <write_hostname config:type="boolean">true</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <device>eth0</device>
+        <startmode>auto</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+    <managed config:type="boolean">false</managed>
+    <routing>
+      <ip_forward config:type="boolean">false</ip_forward>
+    </routing>
+  </networking>
+  <partitioning config:type="list">
+    <drive>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>defaults</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>swap</mount>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">130</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <raid_options/>
+          <resize config:type="boolean">false</resize>
+          <size>1561492992</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">ext3</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>acl,user_xattr</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>/</mount>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <raid_options/>
+          <resize config:type="boolean">false</resize>
+          <size>64424509440</size>
+        </partition>
+      </partitions>
+      <pesize></pesize>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <software>
+
+    <packages config:type="list">
+      <package>openssh</package>
+      <package>kernel-default-devel</package>
+      <package>sudo</package>
+      <package>gcc</package>
+      <package>wget</package>
+      <package>make</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>Minimal</pattern>
+      <pattern>apparmor</pattern>
+    </patterns>
+    <remove-packages config:type="list">
+    </remove-packages>
+  </software>
+  <user_defaults>
+    <expire></expire>
+    <group>100</group>
+    <groups>video,dialout</groups>
+    <home>/home</home>
+    <inactive>-1</inactive>
+    <shell>/bin/bash</shell>
+    <skel>/etc/skel</skel>
+    <umask>022</umask>
+  </user_defaults>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>vagrant</fullname>
+      <gid>100</gid>
+      <home>/home/vagrant</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>$2y$05$NA1Li9ZKJOLRW5mMTXm6/e5r8dltWS5RpDZpvHrI82aLE00V51tdi</user_password>
+      <username>vagrant</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max></max>
+        <min></min>
+        <warn></warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>$2y$05$NA1Li9ZKJOLRW5mMTXm6/e5r8dltWS5RpDZpvHrI82aLE00V51tdi</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/sles/http/sles-12-sp2-x86_64-autoinst.xml
+++ b/sles/http/sles-12-sp2-x86_64-autoinst.xml
@@ -101,12 +101,13 @@
   <partitioning config:type="list">
     <drive>
       <!--
-        definition of device not needed (starting with SLES 11 SP2 
+        definition of device not needed (starting with SLES 11 SP2
         YaST will pickup the first harddisk.
         This is useful if someone wants to deploy using VirtualBox and/or KVM/virtio
       -->
       <!-- <device>/dev/sda</device> -->
       <!-- This section may be removed entirely if we want to simply reuse YaST defaults -->
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
       <initialize config:type="boolean">true</initialize>
       <partitions config:type="list">
         <partition>
@@ -223,6 +224,8 @@
       <package>postfix</package>
       <package>samba-libs</package>
       <package>ucode-intel</package>
+      <package>snapper</package>
+      <package>snapper-zypp-plugin</package>
     </remove-packages>
   </software>
   <timezone>

--- a/sles/http/sles-12-sp2-x86_64-autoinst.xml
+++ b/sles/http/sles-12-sp2-x86_64-autoinst.xml
@@ -137,7 +137,7 @@
           <partition_nr config:type="integer">2</partition_nr>
           <raid_options/>
           <resize config:type="boolean">false</resize>
-          <size>19895844352</size>
+          <size>max</size>
           <subvolumes config:type="list">
             <listentry>boot/grub2/i386-pc</listentry>
             <listentry>boot/grub2/x86_64-efi</listentry>

--- a/sles/http/sles-12-sp3-x86_64-autoinst.xml
+++ b/sles/http/sles-12-sp3-x86_64-autoinst.xml
@@ -101,12 +101,13 @@
   <partitioning config:type="list">
     <drive>
       <!--
-        definition of device not needed (starting with SLES 11 SP2 
+        definition of device not needed (starting with SLES 11 SP2
         YaST will pickup the first harddisk.
         This is useful if someone wants to deploy using VirtualBox and/or KVM/virtio
       -->
       <!-- <device>/dev/sda</device> -->
       <!-- This section may be removed entirely if we want to simply reuse YaST defaults -->
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
       <initialize config:type="boolean">true</initialize>
       <partitions config:type="list">
         <partition>
@@ -223,6 +224,8 @@
       <package>postfix</package>
       <package>samba-libs</package>
       <package>ucode-intel</package>
+      <package>snapper</package>
+      <package>snapper-zypp-plugin</package>
     </remove-packages>
   </software>
   <timezone>

--- a/sles/http/sles-12-sp3-x86_64-autoinst.xml
+++ b/sles/http/sles-12-sp3-x86_64-autoinst.xml
@@ -137,7 +137,7 @@
           <partition_nr config:type="integer">2</partition_nr>
           <raid_options/>
           <resize config:type="boolean">false</resize>
-          <size>19895844352</size>
+          <size>max</size>
           <subvolumes config:type="list">
             <listentry>boot/grub2/i386-pc</listentry>
             <listentry>boot/grub2/x86_64-efi</listentry>

--- a/sles/sles-11-sp4-x86_64.json
+++ b/sles/sles-11-sp4-x86_64.json
@@ -1,0 +1,196 @@
+{
+  "builders": [
+    {
+      "boot_command": [
+        "<esc><enter><wait>",
+        "linux netdevice=eth0 netsetup=dhcp install=cd:/<wait>",
+        " lang=en_US autoyast=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `autoinst_cfg`}}<wait>",
+        " textmode=1<wait>",
+        "<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": "{{user `disk_size`}}",
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_os_type": "OpenSUSE_64",
+      "hard_drive_interface": "sata",
+      "headless": "{{ user `headless` }}",
+      "http_directory": "http",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-virtualbox",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "virtualbox-iso",
+      "vboxmanage": [
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "{{ user `memory` }}"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "{{ user `cpus` }}"
+        ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "{{ user `template` }}"
+    },
+    {
+      "boot_command": [
+        "<esc><enter><wait>",
+        "linux netdevice=eth0 netsetup=dhcp install=cd:/<wait>",
+        " lang=en_US autoyast=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `autoinst_cfg`}}",
+        " textmode=1<wait>",
+        "<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": "{{user `disk_size`}}",
+      "guest_os_type": "sles11-64",
+      "headless": "{{ user `headless` }}",
+      "http_directory": "http",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-vmware",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
+      "vm_name": "{{ user `template` }}",
+      "vmx_data": {
+        "cpuid.coresPerSocket": "1",
+        "memsize": "{{ user `memory` }}",
+        "numvcpus": "{{ user `cpus` }}"
+      }
+    },
+    {
+      "boot_command": [
+        "<esc><enter><wait>",
+        "linux netdevice=eth0 netsetup=dhcp install=cd:/<wait>",
+        " lang=en_US autoyast=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `autoinst_cfg`}}<wait>",
+        " textmode=1<wait>",
+        "<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": "{{user `disk_size`}}",
+      "guest_os_type": "suse",
+      "http_directory": "http",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-parallels",
+      "parallels_tools_flavor": "lin",
+      "prlctl": [
+        [
+          "set",
+          "{{.Name}}",
+          "--memsize",
+          "{{ user `memory` }}"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--cpus",
+          "{{ user `cpus` }}"
+        ]
+      ],
+      "prlctl_version_file": ".prlctl_version",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "parallels-iso",
+      "vm_name": "{{ user `template` }}"
+    },
+    {
+      "boot_command": [
+        "<esc><enter><wait>",
+        "linux netdevice=eth0 netsetup=dhcp install=cd:/<wait>",
+        " lang=en_US autoyast=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `autoinst_cfg`}}<wait>",
+        " textmode=1<wait>",
+        "<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": "{{user `disk_size`}}",
+      "headless": "{{ user `headless` }}",
+      "http_directory": "http",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
+      "output_directory": "packer-{{user `template`}}-qemu",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "type": "qemu",
+      "vm_name": "{{ user `template` }}"
+    }
+  ],
+  "post-processors": [
+    {
+      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "type": "vagrant"
+    }
+  ],
+  "provisioners": [
+    {
+      "destination": "/tmp/bento-metadata.json",
+      "source": "{{user `metadata`}}",
+      "type": "file"
+    },
+    {
+      "environment_vars": [
+        "HOME_DIR=/home/vagrant",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh '{{.Path}}'",
+      "scripts": [
+        "scripts/common/metadata.sh",
+        "scripts/common/sshd.sh",
+        "scripts/common/vagrant.sh",
+        "scripts/common/vmtools.sh",
+        "scripts/sles/sudoers.sh",
+        "scripts/sles/zypper-locks.sh",
+        "scripts/sles/remove-dvd-source.sh",
+        "scripts/common/minimize.sh"
+      ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "_DOWNLOAD_SITE": "https://www.suse.com/products/server/download",
+    "_README": "You must download the automated installer iso from the following page, and then place it in the packer_cache dir",
+    "arch": "64",
+    "autoinst_cfg": "sles-11-sp4-x86_64-autoinst.xml",
+    "box_basename": "sles-11-sp4",
+    "build_timestamp": "{{isotime \"20060102150405\"}}",
+    "cpus": "1",
+    "disk_size": "65536",
+    "git_revision": "__unknown_git_revision__",
+    "headless": "",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "iso_checksum": "4fbf22201876d571c719328f385d87d6d690fb3ceb5e093108cdf0373c43e855",
+    "iso_checksum_type": "sha256",
+    "iso_name": "SLES-11-SP4-DVD-x86_64-GM-DVD1.iso",
+    "memory": "1024",
+    "mirror": "./packer_cache",
+    "name": "sles-11-sp4",
+    "template": "sles-11-sp4-x86_64",
+    "version": "TIMESTAMP"
+  }
+}

--- a/sles/sles-11-sp4-x86_64.json
+++ b/sles/sles-11-sp4-x86_64.json
@@ -18,7 +18,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "packer-{{user `template`}}-virtualbox",
+      "output_directory": "../builds/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -58,7 +58,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "packer-{{user `template`}}-vmware",
+      "output_directory": "../builds/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -71,7 +71,8 @@
         "cpuid.coresPerSocket": "1",
         "memsize": "{{ user `memory` }}",
         "numvcpus": "{{ user `cpus` }}"
-      }
+      },
+      "vmx_remove_ethernet_interfaces": true
     },
     {
       "boot_command": [
@@ -88,7 +89,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "packer-{{user `template`}}-parallels",
+      "output_directory": "../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "prlctl": [
         [
@@ -128,7 +129,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "packer-{{user `template`}}-qemu",
+      "output_directory": "../builds/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -140,16 +141,11 @@
   ],
   "post-processors": [
     {
-      "output": "builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "../builds/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
   "provisioners": [
-    {
-      "destination": "/tmp/bento-metadata.json",
-      "source": "{{user `metadata`}}",
-      "type": "file"
-    },
     {
       "environment_vars": [
         "HOME_DIR=/home/vagrant",
@@ -158,15 +154,19 @@
         "no_proxy={{user `no_proxy`}}"
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh '{{.Path}}'",
+      "expect_disconnect": true,
       "scripts": [
-        "scripts/common/metadata.sh",
-        "scripts/common/sshd.sh",
-        "scripts/common/vagrant.sh",
-        "scripts/common/vmtools.sh",
-        "scripts/sles/sudoers.sh",
-        "scripts/sles/zypper-locks.sh",
-        "scripts/sles/remove-dvd-source.sh",
-        "scripts/common/minimize.sh"
+        "../_common/sshd.sh",
+        "../_common/vagrant.sh",
+        "scripts/unsupported-modules.sh",
+        "../_common/virtualbox.sh",
+        "../_common/vmware.sh",
+        "../_common/parallels.sh",
+        "scripts/sudoers.sh",
+        "scripts/zypper-locks.sh",
+        "scripts/remove-dvd-source.sh",
+        "scripts/cleanup.sh",
+        "../_common/minimize.sh"
       ],
       "type": "shell"
     }

--- a/sles/sles-11-sp4-x86_64.json
+++ b/sles/sles-11-sp4-x86_64.json
@@ -158,7 +158,6 @@
       "scripts": [
         "../_common/sshd.sh",
         "../_common/vagrant.sh",
-        "scripts/unsupported-modules.sh",
         "../_common/virtualbox.sh",
         "../_common/vmware.sh",
         "../_common/parallels.sh",

--- a/sles/sles-12-sp2-x86_64.json
+++ b/sles/sles-12-sp2-x86_64.json
@@ -179,7 +179,7 @@
     "box_basename": "sles-12-sp2",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
-    "disk_size": "20480",
+    "disk_size": "65536",
     "git_revision": "__unknown_git_revision__",
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
@@ -194,4 +194,3 @@
     "version": "TIMESTAMP"
   }
 }
-

--- a/sles/sles-12-sp3-x86_64.json
+++ b/sles/sles-12-sp3-x86_64.json
@@ -179,7 +179,7 @@
     "box_basename": "sles-12-sp3",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
-    "disk_size": "20480",
+    "disk_size": "65536",
     "git_revision": "__unknown_git_revision__",
     "headless": "",
     "http_proxy": "{{env `http_proxy`}}",
@@ -194,4 +194,3 @@
     "version": "TIMESTAMP"
   }
 }
-


### PR DESCRIPTION
* Implements the same disk space fixes that opensuse has
* Bring back SLES 11 SP4 because it is not EOL. General support ends in 2019, long term in 2022 (see [here](https://www.suse.com/lifecycle/))