### PR TITLE
Windows 2016: Point to the correct Autounattend.xml

### DIFF
--- a/windows/2016.json
+++ b/windows/2016.json
@@ -21,7 +21,7 @@
 		"shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
 		"shutdown_timeout": "15m",
 		"floppy_files": [
-			"answer_files/2012_r2/Autounattend.xml"
+			"answer_files/2016/Autounattend.xml"
 		]
 	}],
 	"provisioners": [{


### PR DESCRIPTION
This fixes an issue where an unattended install was failing.

Signed-off-by: John Jelinek <jjelinek@containerstore.com>