### PR TITLE
Disable consistent naming in RHEL/CentOS 7

### DIFF
--- a/centos/http/7/ks.cfg
+++ b/centos/http/7/ks.cfg
@@ -8,7 +8,7 @@ firewall --disabled
 selinux --permissive
 timezone UTC
 unsupported_hardware
-bootloader --location=mbr
+bootloader --location=mbr --append="net.ifnames=0 biosdevname=0"
 text
 skipx
 zerombr
@@ -73,4 +73,26 @@ if [ $(virt-what) == "hyperv" ]; then
     systemctl enable hypervkvpd
 fi
 
+# Since we disable consistent network naming, we need to make sure the eth0
+# configuration file is in place so it will come up.
+# Delete other network configuration first because RHEL/C7 networking will not
+# restart successfully if there are configuration files for devices that do not
+# exist.
+rm -f /etc/sysconfig/network-scripts/ifcfg-e*
+cat > /etc/sysconfig/network-scripts/ifcfg-eth0 << _EOF_
+TYPE=Ethernet
+PROXY_METHOD=none
+BROWSER_ONLY=no
+BOOTPROTO=dhcp
+DEFROUTE=yes
+IPV4_FAILURE_FATAL=no
+IPV6INIT=yes
+IPV6_AUTOCONF=yes
+IPV6_DEFROUTE=yes
+IPV6_FAILURE_FATAL=no
+IPV6_ADDR_GEN_MODE=stable-privacy
+NAME=eth0
+DEVICE=eth0
+ONBOOT=yes
+_EOF_
 %end


### PR DESCRIPTION
Disable consistent naming in RHEL/CentOS 7 so we always have an eth0 interface.