### PR TITLE
Add the name key for FreeBSD 11.2, fix build/upload

### DIFF
--- a/freebsd/freebsd-11.2-amd64.json
+++ b/freebsd/freebsd-11.2-amd64.json
@@ -220,6 +220,7 @@
     "memory": "1024",
     "mirror": "https://download.freebsd.org/ftp",
     "mirror_directory": "releases/amd64/amd64/ISO-IMAGES/11.2",
+    "name": "freebsd-11.2",
     "no_proxy": "{{env `no_proxy`}}",
     "pkg_branch": "quarterly",
     "template": "freebsd-11.2-amd64",


### PR DESCRIPTION
We weren't setting `name` and so boxes were using the `template_name` instead which broke the build/test/upload pipeline.

Signed-off-by: Seth Thomas <sthomas@chef.io>
