### PR TITLE
Add curl to CentOS 5 install

### DIFF
--- a/centos/http/5/ks.cfg
+++ b/centos/http/5/ks.cfg
@@ -24,6 +24,7 @@ key --skip
 openssh-clients
 openssh-server
 bzip2
+curl
 dhclient
 gcc
 kernel-devel


### PR DESCRIPTION
It is already installed in 6 and 7 by default. Adding it to the
CentOS 5 kickstart so it will be installed there too.

### Description

Adds curl to the default package list in the CentOS 5 kickstart

### Issues Resolved

Lack of curl
