### PR TITLE
Fix startup mount error on Parallels 14 guest tools

### DIFF
--- a/_common/parallels.sh
+++ b/_common/parallels.sh
@@ -20,5 +20,16 @@ parallels-iso|parallels-pvm)
     umount /tmp/parallels;
     rm -rf /tmp/parallels;
     rm -f $HOME_DIR/*.iso;
+
+    # Parallels Tools for Linux includes native auto-mount script,
+    # which causes losing some of Vagrant-relative shared folders.
+    # So, we should disable this behavior.
+    # https://github.com/Parallels/vagrant-parallels/issues/325#issuecomment-418727113
+    auto_mount_script='/usr/bin/prlfsmountd'
+    if [ -f "${auto_mount_script}" ]; then
+        echo -e '#!/bin/sh\n'\
+        '# Shared folders auto-mount is disabled by Vagrant ' \
+        > "${auto_mount_script}"
+    fi
     ;;
 esac


### PR DESCRIPTION
### Description

This is a workaround for the following error (happens on first startup with the latest Parallels Tools):

```
Failed to mount folders in Linux guest. This is usually because
the "prl_fs" file system is not available. Please verify that
Parallels Tools are properly installed in the guest and
can work properly. If so, the VM reboot can solve a problem.
The command attempted was:

mount -t prl_fs -o uid=`id -u vagrant`,gid=`getent group vagrant | cut -d: -f3` media_DockerData /media/DockerData
mount -t prl_fs -o uid=`id -u vagrant`,gid=`id -g vagrant` media_DockerData /media/DockerData
```

### Issues Resolved

#1115 
