### PR TITLE
Install ifup/ifdown utilities needed for private networks

### DIFF
--- a/ubuntu/scripts/update.sh
+++ b/ubuntu/scripts/update.sh
@@ -10,6 +10,9 @@ sed -i.bak 's/^Prompt=.*$/Prompt=never/' /etc/update-manager/release-upgrades;
 # Update the package list
 apt-get -y update;
 
+# Install ifup/ifdown utilities needed for Vagrant private networks
+apt-get -y install ifupdown;
+
 # Disable systemd apt timers/services
 if [ "$major_version" -ge "16" ]; then
   systemctl stop apt-daily.timer;


### PR DESCRIPTION
### Description

Vagrant network configuration scripts need ifup and ifdown utilities to configure private networks. Those utilities were removed from Ubuntu 17.04 - added with installation of *ifupdown* package.
