### PR TITLE
update debian provision: purge installation-report in cleanup.sh

### DIFF
--- a/debian/scripts/cleanup.sh
+++ b/debian/scripts/cleanup.sh
@@ -35,6 +35,7 @@ apt-get -y purge ppp pppconfig pppoeconf;
 
 # Delete oddities
 apt-get -y purge popularity-contest;
+apt-get -y purge installation-report;
 
 apt-get -y autoremove;
 apt-get -y clean;


### PR DESCRIPTION
### Description

The `installation-report` package generates installation report, installer related choices and debug infos into `/var/log/installer/`.

It takes about 15M disk space for debian 9.5 builds.

### Issues Resolved

Fixes #1129 
