### PR TITLE
Support for fedora29 in libvirt and public release

### DIFF
--- a/builds.yml
+++ b/builds.yml
@@ -10,6 +10,7 @@ public:
 - 'debian-8.11'
 - 'oracle-7.5'
 - 'oracle-6.10'
+- 'fedora-29'
 - 'fedora-28'
 - 'fedora-27'
 - 'opensuse-leap-42.3'

--- a/fedora/fedora-29-x86_64.json
+++ b/fedora/fedora-29-x86_64.json
@@ -1,6 +1,44 @@
 {
   "builders": [
     {
+      "type": "qemu",
+      "vm_name": "{{ user `template` }}",
+      "name": "{{ user `template` }}",
+      "output_directory": "../builds/packer-{{user `template`}}-libvirt",
+      "accelerator": "kvm",
+      "boot_wait": "10s",
+      "boot_command": [
+          "<tab> linux ks=http://{{.HTTPIP}}:{{.HTTPPort}}/{{user `ks_path`}}<enter><wait>"
+      ],
+      "format": "qcow2",
+      "disk_size": "{{user `disk_size`}}",
+      "disk_discard": "unmap",
+      "disk_cache": "unsafe",
+      "disk_compression": true,
+      "disk_interface": "virtio-scsi",
+      "net_device": "virtio-net",
+      "qemuargs": [
+          [
+              "-m",
+              "{{ user `memory` }}"
+          ],
+          [
+              "-smp",
+              "cpus={{ user `cpus` }}"
+          ]
+      ],
+      "http_directory": "http",
+      "headless": "{{ user `headless` }}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "3600s",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now"
+    },
+    {
       "boot_command": [
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
       ],

--- a/fedora/http/ks-fedora29.cfg
+++ b/fedora/http/ks-fedora29.cfg
@@ -2,8 +2,8 @@ install
 cdrom
 lang en_US.UTF-8
 keyboard us
-network --bootproto=dhcp
-rootpw vagrant
+network --bootproto=dhcp --noipv6
+rootpw --plaintext vagrant
 firewall --disabled
 authconfig --enableshadow --passalgo=sha512
 selinux --permissive
@@ -13,9 +13,9 @@ text
 skipx
 zerombr
 clearpart --all --initlabel
-part / --fstype=ext4 --ondisk=sda --grow --label=root
+autopart --nohome --nolvm --noboot --fstype=ext4
 firstboot --disabled
-reboot
+reboot --eject
 user --name=vagrant --plaintext --password vagrant
 
 %packages --ignoremissing --excludedocs


### PR DESCRIPTION
### Description

This changes include support for creating fedora-29 boxes with libvirt. It also includes fedora-29 in builds.yml so the fedora-29 boxes are publicly available in vagrant cloud.
