### PR TITLE
Remove unsupported arg from CentOS 5 kickstart

### DIFF
--- a/centos/http/5/ks.cfg
+++ b/centos/http/5/ks.cfg
@@ -19,7 +19,7 @@ reboot
 user --name=vagrant --password vagrant
 key --skip
 
-%packages --nobase --ignoremissing --excludedocs --instLangs=en_US.utf8
+%packages --nobase --ignoremissing --excludedocs
 # vagrant needs this to copy initial files via scp
 openssh-clients
 openssh-server


### PR DESCRIPTION
### Description

Remove `--instLangs` argument to packages kickstart directive as it's not supported for CentOS 5.

### Issues Resolved

Fix #1160 

Signed-off-by: Seth Thomas <seth.g.thomas@gmail.com>
