### PR TITLE
Turn off ProtectYourPC and set the org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ packer.log
 .kitchen.yml
 Gemfile.lock
 bootstrap.sh
+Berksfile.lock

--- a/windows/answer_files/2008_r2/Autounattend.xml
+++ b/windows/answer_files/2008_r2/Autounattend.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
-    <servicing/>
     <settings pass="windowsPE">
 	<component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 		<DriverPaths>
@@ -37,7 +36,7 @@
             <UserData>
                 <AcceptEula>true</AcceptEula>
                 <FullName>Vagrant Administrator</FullName>
-                <Organization>Vagrant Inc.</Organization>
+                <Organization>Bento by Chef</Organization>
                 <!-- Product Key from http://technet.microsoft.com/en-us/library/jj612867.aspx -->
                 <ProductKey>
                     <!-- Do not uncomment the Key element if you are using trial ISOs -->

--- a/windows/answer_files/2012_r2/Autounattend.xml
+++ b/windows/answer_files/2012_r2/Autounattend.xml
@@ -75,7 +75,7 @@
                 </ProductKey>
                 <AcceptEula>true</AcceptEula>
                 <FullName>Vagrant</FullName>
-                <Organization>Vagrant</Organization>
+                <Organization>Bento by Chef</Organization>
             </UserData>
         </component>
     </settings>
@@ -103,7 +103,9 @@
                 <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
                 <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
                 <NetworkLocation>Home</NetworkLocation>
-                <ProtectYourPC>1</ProtectYourPC>
+                <ProtectYourPC>3</ProtectYourPC>
+                <SkipUserOOBE>true</SkipUserOOBE>
+                <SkipMachineOOBE>true</SkipMachineOOBE>
             </OOBE>
       <TimeZone>UTC</TimeZone>
       <UserAccounts>

--- a/windows/answer_files/2016/Autounattend.xml
+++ b/windows/answer_files/2016/Autounattend.xml
@@ -75,7 +75,7 @@
                 </ProductKey>
                 <AcceptEula>true</AcceptEula>
                 <FullName>Vagrant</FullName>
-                <Organization>Vagrant</Organization>
+                <Organization>Bento by Chef</Organization>
             </UserData>
         </component>
     </settings>
@@ -103,7 +103,9 @@
                 <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
                 <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
                 <NetworkLocation>Home</NetworkLocation>
-                <ProtectYourPC>1</ProtectYourPC>
+                <ProtectYourPC>3</ProtectYourPC>
+                <SkipMachineOOBE>true</SkipMachineOOBE>
+                <SkipUserOOBE>true</SkipUserOOBE>
             </OOBE>
       <TimeZone>UTC</TimeZone>
       <UserAccounts>


### PR DESCRIPTION
Turn off all the out of the box setup, disable all the protection junk, and set the org to Bento not Vagrant.

Signed-off-by: Tim Smith <tsmith@chef.io>