### PR TITLE
Add homestead script to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ packer.log
 Gemfile.lock
 bootstrap.sh
 Berksfile.lock
+ubuntu/scripts/homestead.sh


### PR DESCRIPTION
### Description

I'm the maintainer of https://github.com/laravel/homestead and https://github.com/laravel/settler projects and would like to hard link my provisioning scripts without interfering with this repository.

Currently we just copy and delete our script as needed. This pull request would allow us to accept https://github.com/laravel/settler/pull/192 which creates a hard link. Both pull requests would allow us to continue our respective workflows with a lesser chance of me doing something goofy on my end. :D

Thanks for all the work that goes into this project. <3