### PR TITLE
remove sed -ie option command that leaves /etc/default/grube

### DIFF
--- a/debian/scripts/networking.sh
+++ b/debian/scripts/networking.sh
@@ -17,7 +17,7 @@ fi
 if [ "$major_version" -ge "9" ]; then
   # Disable Predictable Network Interface names and use eth0
   sed -i 's/en[[:alnum:]]*/eth0/g' /etc/network/interfaces;
-  sed -ie 's/GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0 \1"/g' /etc/default/grub;
+  sed -i 's/GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0 \1"/g' /etc/default/grub;
   update-grub;
 fi
 

--- a/ubuntu/scripts/networking.sh
+++ b/ubuntu/scripts/networking.sh
@@ -20,6 +20,6 @@ fi
 if [ "$major_version" -ge "16" ]; then
   # Disable Predictable Network Interface names and use eth0
   sed -i 's/en[[:alnum:]]*/eth0/g' /etc/network/interfaces;
-  sed -ie 's/GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0 \1"/g' /etc/default/grub;
+  sed -i 's/GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0 \1"/g' /etc/default/grub;
   update-grub;
 fi


### PR DESCRIPTION
For justification, see

https://github.com/sipwise/netscript/commit/4844134152e5195e3162c4df28d6fc3175866787

### Description

This change removes an option that leaves behind a file called /etc/default/grube

It was probably intended to be `sed -i -e` but only `sed -i` is required

### Issues Resolved

As above
