### PR TITLE
Disable apt-daily earlier.

### DIFF
--- a/debian/scripts/update.sh
+++ b/debian/scripts/update.sh
@@ -4,8 +4,6 @@ arch="`uname -r | sed 's/^.*[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\(-[0-9]\{1,2\}
 debian_version="`lsb_release -r | awk '{print $2}'`";
 major_version="`echo $debian_version | awk -F. '{print $1}'`";
 
-apt-get update;
-
 # Disable systemd apt timers/services
 if [ "$major_version" -ge "9" ]; then
   systemctl stop apt-daily.timer;
@@ -25,6 +23,8 @@ APT::Periodic::Download-Upgradeable-Packages "0";
 APT::Periodic::AutocleanInterval "0";
 APT::Periodic::Unattended-Upgrade "0";
 EOF
+
+apt-get update;
 
 apt-get -y upgrade linux-image-$arch;
 apt-get -y install linux-headers-`uname -r`;

--- a/ubuntu/scripts/update.sh
+++ b/ubuntu/scripts/update.sh
@@ -7,9 +7,6 @@ major_version="`echo $ubuntu_version | awk -F. '{print $1}'`";
 # Disable release-upgrades
 sed -i.bak 's/^Prompt=.*$/Prompt=never/' /etc/update-manager/release-upgrades;
 
-# Update the package list
-apt-get -y update;
-
 # Disable systemd apt timers/services
 if [ "$major_version" -ge "16" ]; then
   systemctl stop apt-daily.timer;
@@ -33,6 +30,9 @@ EOF
 # Clean and nuke the package from orbit
 rm -rf /var/log/unattended-upgrades;
 apt-get -y purge unattended-upgrades;
+
+# Update the package list
+apt-get -y update;
 
 # Upgrade all installed packages incl. kernel and kernel headers
 apt-get -y dist-upgrade -o Dpkg::Options::="--force-confnew";


### PR DESCRIPTION
There is a race to disable apt-daily before it can trigger its own apt
process that grabs the apt lock.

Running apt-get update first adds more time for apt-daily to trigger
before it gets disabled. Then a subsequent apt command after the
disablement of apt-daily can fail grabbing the apt lock.

Move the apt-get update later and disable apt-daily earlier to give us a
better chance of winning the race.

Signed-off-by: Vinson Lee <vlee@freedesktop.org>

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]
