### PR TITLE
Fix Debian 8 builds to not ask for confirmation, and use a separate preseed file for Debian 9.

### DIFF
--- a/debian/debian-9.8-amd64.json
+++ b/debian/debian-9.8-amd64.json
@@ -233,7 +233,7 @@
     "mirror_directory": "9.8.0/amd64/iso-cd",
     "name": "debian-9.8",
     "no_proxy": "{{env `no_proxy`}}",
-    "preseed_path": "debian-8/preseed.cfg",
+    "preseed_path": "debian-9/preseed.cfg",
     "template": "debian-9.8-amd64",
     "version": "TIMESTAMP"
   }

--- a/debian/debian-9.8-i386.json
+++ b/debian/debian-9.8-i386.json
@@ -233,7 +233,7 @@
     "mirror_directory": "9.8.0/i386/iso-cd",
     "name": "debian-9.8-i386",
     "no_proxy": "{{env `no_proxy`}}",
-    "preseed_path": "debian-8/preseed.cfg",
+    "preseed_path": "debian-9/preseed.cfg",
     "template": "debian-9.8-i386",
     "version": "TIMESTAMP"
   }

--- a/debian/debian-9.8-ppc64el.json
+++ b/debian/debian-9.8-ppc64el.json
@@ -94,7 +94,7 @@
     "mirror_directory": "9.8.0/ppc64el/iso-cd",
     "name": "debian-9.8",
     "no_proxy": "{{env `no_proxy`}}",
-    "preseed_path": "debian-8/preseed.cfg",
+    "preseed_path": "debian-9/preseed.cfg",
     "template": "debian-9.8-ppc64el",
     "version": "TIMESTAMP"
   }

--- a/debian/http/debian-9/preseed.cfg
+++ b/debian/http/debian-9/preseed.cfg
@@ -46,5 +46,3 @@ apt-cdrom-setup apt-setup/cdrom/set-first boolean false
 apt-mirror-setup apt-setup/use_mirror boolean true
 popularity-contest popularity-contest/participate boolean false
 tasksel tasksel/first multiselect standard, ssh-server
-# Fix "Debian 8 build is stuck, asking for user input" - https://github.com/chef/bento/issues/1190
-d-i apt-setup/services-select multiselect security


### PR DESCRIPTION
### Description

Fix Debian 8 build that is currently asking for user input, and have a separate preseed file for Debian 9 that does not have this workaround.

### Issues Resolved

https://github.com/chef/bento/issues/1190
