### PR TITLE
Install rsync on popular boxes

### DIFF
--- a/packer_templates/centos/http/6/ks.cfg
+++ b/packer_templates/centos/http/6/ks.cfg
@@ -32,6 +32,7 @@ perl
 wget
 nfs-utils
 virt-what
+rsync
 -fprintd-pam
 -intltool
 

--- a/packer_templates/centos/http/7/ks.cfg
+++ b/packer_templates/centos/http/7/ks.cfg
@@ -34,6 +34,7 @@ nfs-utils
 net-tools
 bzip2
 deltarpm
+rsync
 -fprintd-pam
 -intltool
 

--- a/packer_templates/debian/http/debian-8/preseed.cfg
+++ b/packer_templates/debian/http/debian-8/preseed.cfg
@@ -30,7 +30,7 @@ d-i passwd/user-uid string 1000
 d-i passwd/user-password password vagrant
 d-i passwd/user-password-again password vagrant
 d-i passwd/username string vagrant
-d-i pkgsel/include string sudo bzip2 acpid cryptsetup zlib1g-dev wget curl dkms fuse make nfs-common net-tools cifs-utils
+d-i pkgsel/include string sudo bzip2 acpid cryptsetup zlib1g-dev wget curl dkms fuse make nfs-common net-tools cifs-utils rsync
 d-i pkgsel/install-language-support boolean false
 d-i pkgsel/update-policy select none
 d-i pkgsel/upgrade select full-upgrade

--- a/packer_templates/debian/http/debian-9/preseed.cfg
+++ b/packer_templates/debian/http/debian-9/preseed.cfg
@@ -30,7 +30,7 @@ d-i passwd/user-uid string 1000
 d-i passwd/user-password password vagrant
 d-i passwd/user-password-again password vagrant
 d-i passwd/username string vagrant
-d-i pkgsel/include string sudo bzip2 acpid cryptsetup zlib1g-dev wget curl dkms fuse make nfs-common net-tools cifs-utils
+d-i pkgsel/include string sudo bzip2 acpid cryptsetup zlib1g-dev wget curl dkms fuse make nfs-common net-tools cifs-utils rsync
 d-i pkgsel/install-language-support boolean false
 d-i pkgsel/update-policy select none
 d-i pkgsel/upgrade select full-upgrade

--- a/packer_templates/fedora/http/ks-fedora29.cfg
+++ b/packer_templates/fedora/http/ks-fedora29.cfg
@@ -28,6 +28,7 @@ tar
 wget
 nfs-utils
 net-tools
+rsync
 -plymouth
 -plymouth-core-libs
 -fedora-release-notes

--- a/packer_templates/ubuntu/http/preseed.cfg
+++ b/packer_templates/ubuntu/http/preseed.cfg
@@ -25,7 +25,7 @@ d-i passwd/user-uid string 1000
 d-i passwd/user-password password vagrant
 d-i passwd/user-password-again password vagrant
 d-i passwd/username string vagrant
-d-i pkgsel/include string openssh-server cryptsetup build-essential libssl-dev libreadline-dev zlib1g-dev linux-source dkms nfs-common linux-headers-$(uname -r) perl cifs-utils software-properties-common
+d-i pkgsel/include string openssh-server cryptsetup build-essential libssl-dev libreadline-dev zlib1g-dev linux-source dkms nfs-common linux-headers-$(uname -r) perl cifs-utils software-properties-common rsync
 d-i pkgsel/install-language-support boolean false
 d-i pkgsel/update-policy select none
 d-i pkgsel/upgrade select full-upgrade


### PR DESCRIPTION
Installing rsync allows users to utilize kitchen-sync [1] to speed up
test-kitchen sync tasks. Unfortunately, none of the bento boxes include rsync so
this adds it. It should had a minimal amount of disk space (less than a few MBs)

[1] https://github.com/coderanger/kitchen-sync

Signed-off-by: Lance Albertson <lance@osuosl.org>

### Description

Install rsync package on most bento boxes.

### Issues Resolved

n/a
