### PR TITLE
Modify Debian 9 URL to point to archive

### DIFF
--- a/packer_templates/debian/debian-9.9-amd64.json
+++ b/packer_templates/debian/debian-9.9-amd64.json
@@ -229,7 +229,7 @@
     "iso_checksum_type": "sha256",
     "iso_name": "debian-9.9.0-amd64-netinst.iso",
     "memory": "1024",
-    "mirror": "http://cdimage.debian.org/cdimage/release",
+    "mirror": "http://cdimage.debian.org/cdimage/archive",
     "mirror_directory": "9.9.0/amd64/iso-cd",
     "name": "debian-9.9",
     "no_proxy": "{{env `no_proxy`}}",

--- a/packer_templates/debian/debian-9.9-i386.json
+++ b/packer_templates/debian/debian-9.9-i386.json
@@ -229,7 +229,7 @@
     "iso_checksum_type": "sha256",
     "iso_name": "debian-9.9.0-i386-netinst.iso",
     "memory": "1024",
-    "mirror": "http://cdimage.debian.org/cdimage/release",
+    "mirror": "http://cdimage.debian.org/cdimage/archive",
     "mirror_directory": "9.9.0/i386/iso-cd",
     "name": "debian-9.9-i386",
     "no_proxy": "{{env `no_proxy`}}",

--- a/packer_templates/debian/debian-9.9-ppc64el.json
+++ b/packer_templates/debian/debian-9.9-ppc64el.json
@@ -90,7 +90,7 @@
     "iso_checksum_type": "sha256",
     "iso_name": "debian-9.9.0-ppc64el-netinst.iso",
     "memory": "1024",
-    "mirror": "http://cdimage.debian.org/cdimage/release",
+    "mirror": "http://cdimage.debian.org/cdimage/archive",
     "mirror_directory": "9.9.0/ppc64el/iso-cd",
     "name": "debian-9.9",
     "no_proxy": "{{env `no_proxy`}}",


### PR DESCRIPTION
Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

### Description

Debian 9 is no longer available via the release tree and needs to be pulled from archive.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]
