### PR TITLE
Fix the Fedora 30 box for Chef

### DIFF
--- a/packer_templates/fedora/fedora-30-x86_64.json
+++ b/packer_templates/fedora/fedora-30-x86_64.json
@@ -182,6 +182,7 @@
         "scripts/swap.sh",
         "scripts/fix-slow-dns.sh",
         "scripts/build-tools.sh",
+        "scripts/install-supporting-packages.sh",
         "../_common/motd.sh",
         "../_common/sshd.sh",
         "../_common/virtualbox.sh",

--- a/packer_templates/fedora/scripts/install-supporting-packages.sh
+++ b/packer_templates/fedora/scripts/install-supporting-packages.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -eux
+# Chef with Fedora >= 30 requires libxcrypt-compat to be installed
+dnf -y install libxcrypt-compat


### PR DESCRIPTION
Fedora >= 30 requires libxcrypt-compat to be installed to provide libcrypt.so.1 for Chef.

## Description

The the libxcrypt-compat package needs to be installed for Chef to work with Fedora 30 so add a script to do it and add it to the packer build.

## Related Issue

n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
