### PR TITLE
Add network-scripts package for CentOS 8

### DIFF
--- a/packer_templates/centos/http/8/ks.cfg
+++ b/packer_templates/centos/http/8/ks.cfg
@@ -37,6 +37,7 @@ rsync
 dnf-utils
 redhat-lsb-core
 elfutils-libelf-devel
+network-scripts
 -fprintd-pam
 -intltool
 


### PR DESCRIPTION
This installs the legacy network scripts which [Vagrant still requires it](https://github.com/hashicorp/vagrant/blob/master/plugins/guests/pld/cap/change_host_name.rb#L22) seems for the ``network`` systemd service. The ``network-scripts`` package provides the ``network.service`` systemd unit which resolve the issue. That probably should be fixed upstream at some point to use ``nmcli`` or something else.

Signed-off-by: Lance Albertson <lance@osuosl.org>

<!--- Provide a short summary of your changes in the Title above -->

## Description

When starting a new VM with the latest CentOS 8 image I have the following issue:
``` console
-----> Starting Kitchen (v2.3.3)
-----> Creating <all-centos-8>...
       Bringing machine 'default' up with 'virtualbox' provider...
       ==> default: Importing base box 'bento/centos-8'...
==> default: Matching MAC address for NAT networking...
       ==> default: Checking if box 'bento/centos-8' is up to date...
       ==> default: Setting the name of the VM: kitchen-yum-centos-all-centos-8-c024b78e-067d-441f-9d54-b82aad365da8
       ==> default: Fixed port collision for 22 => 2222. Now on port 2200.
       ==> default: Clearing any previously set network interfaces...
       ==> default: Preparing network interfaces based on configuration...
           default: Adapter 1: nat
       ==> default: Forwarding ports...
           default: 22 (guest) => 2200 (host) (adapter 1)
       ==> default: Running 'pre-boot' VM customizations...
       ==> default: Booting VM...
       ==> default: Waiting for machine to boot. This may take a few minutes...
           default: SSH address: 127.0.0.1:2200
           default: SSH username: vagrant
           default: SSH auth method: private key
           default: 
           default: Vagrant insecure key detected. Vagrant will automatically replace
           default: this with a newly generated keypair for better security.
           default: 
           default: Inserting generated public key within guest...
           default: Removing insecure key from the guest if it's present...
           default: Key inserted! Disconnecting and reconnecting using new SSH key...
       ==> default: Machine booted and ready!
       ==> default: Checking for guest additions in VM...
           default: The guest additions on this VM do not match the installed version of
           default: VirtualBox! In most cases this is fine, but in rare cases it can
           default: prevent things such as shared folders from working properly. If you see
           default: shared folder errors, please make sure the guest additions within the
           default: virtual machine match the version of VirtualBox you have installed on
           default: your host and reload your VM.
           default: 
           default: Guest Additions Version: 6.0.12
           default: VirtualBox Version: 5.2
       ==> default: Setting hostname...
       The following SSH command responded with a non-zero exit status.
       Vagrant assumes that this means the command failed!
       
       # Update sysconfig
       sed -i 's/\(HOSTNAME=\).*/\1all-centos-8.vagrantup.com/' /etc/sysconfig/network
       
       # Update DNS
       sed -i 's/\(DHCP_HOSTNAME=\).*/\1"all-centos-8"/' /etc/sysconfig/network-scripts/ifcfg-*
       
       # Set the hostname - use hostnamectl if available
       echo 'all-centos-8.vagrantup.com' > /etc/hostname
       if command -v hostnamectl; then
         hostnamectl set-hostname --static 'all-centos-8.vagrantup.com'
         hostnamectl set-hostname --transient 'all-centos-8.vagrantup.com'
       else
         hostname -F /etc/hostname
       fi
       
       # Prepend ourselves to /etc/hosts
       grep -w 'all-centos-8.vagrantup.com' /etc/hosts || {
         sed -i'' '1i 127.0.0.1\tall-centos-8.vagrantup.com\tall-centos-8' /etc/hosts
       }
       
       # Restart network
       service network restart
       
       
       Stdout from the command:
       
       /bin/hostnamectl
       
       
       Stderr from the command:
       
       Redirecting to /bin/systemctl restart network.service
       Failed to restart network.service: Unit network.service not found.
```
If you then run the kitchen command again, everything seems to be ok:
``` console
-----> Starting Kitchen (v2.3.3)
-----> Creating <all-centos-8>...
       Bringing machine 'default' up with 'virtualbox' provider...
       ==> default: Checking if box 'bento/centos-8' is up to date...
       ==> default: Machine not provisioned because `--no-provision` is specified.
       [SSH] Established
       Vagrant instance <all-centos-8> created.
       Finished creating <all-centos-8> (0m3.23s).
-----> Kitchen is finished. (0m4.08s)
```
I'm assuming if we add the package which includes the network service, this should resolve the issue.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
