### PR TITLE
Fix CentOS 7.7 hang on start due to ambiguous "eth" network type

### DIFF
--- a/packer_templates/centos/scripts/cleanup.sh
+++ b/packer_templates/centos/scripts/cleanup.sh
@@ -48,7 +48,7 @@ done
 # add gateway interface connection.
 gwdev=\`nmcli dev | grep ethernet | egrep -v 'unmanaged' | head -n 1 | awk '{print \$1}'\`
 if [ "\$gwdev" != "" ]; then
-  nmcli c add type eth ifname \$gwdev con-name \$gwdev
+  nmcli connection add type ethernet ifname \$gwdev con-name \$gwdev
 fi
 sed -i "/^#BENTO-BEGIN/,/^#BENTO-END/d" /etc/rc.d/rc.local
 chmod -x /etc/rc.d/rc.local


### PR DESCRIPTION
## Description
This PR fixes the problem as described in issue #1230 (and using the same solution), whereas `vagrant up` hangs forever for CentOS 7.7 boxes due to the `cleanup.sh` script on build specifying an ambiguous `eth` parameter as network type for `nmcli`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
