### PR TITLE
Updated all templates to use Packer's "memory" and "cpus" options in supported builders

### DIFF
--- a/packer_templates/amazonlinux/amazon-2-x86_64.json
+++ b/packer_templates/amazonlinux/amazon-2-x86_64.json
@@ -12,20 +12,8 @@
       "source_path": "amazon2.ovf",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     }

--- a/packer_templates/amazonlinux/amazon-2-x86_64.json
+++ b/packer_templates/amazonlinux/amazon-2-x86_64.json
@@ -12,8 +12,20 @@
       "source_path": "amazon2.ovf",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
-      "memory": "{{ user `memory` }}",
-      "cpus": "{{ user `cpus` }}",
+      "vboxmanage": [
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "{{ user `memory` }}"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "{{ user `cpus` }}"
+        ]
+      ],
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     }

--- a/packer_templates/centos/centos-5.11-i386.json
+++ b/packer_templates/centos/centos-5.11-i386.json
@@ -21,20 +21,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "1"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -59,10 +47,10 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -79,20 +67,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer_templates/centos/centos-5.11-i386.json
+++ b/packer_templates/centos/centos-5.11-i386.json
@@ -110,6 +110,8 @@
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/centos/centos-5.11-x86_64.json
+++ b/packer_templates/centos/centos-5.11-x86_64.json
@@ -21,20 +21,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "1"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -59,10 +47,10 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -79,20 +67,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer_templates/centos/centos-5.11-x86_64.json
+++ b/packer_templates/centos/centos-5.11-x86_64.json
@@ -110,6 +110,8 @@
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/centos/centos-6.10-i386.json
+++ b/packer_templates/centos/centos-6.10-i386.json
@@ -21,20 +21,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -59,10 +47,10 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -79,20 +67,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer_templates/centos/centos-6.10-i386.json
+++ b/packer_templates/centos/centos-6.10-i386.json
@@ -110,6 +110,8 @@
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/centos/centos-6.10-x86_64.json
+++ b/packer_templates/centos/centos-6.10-x86_64.json
@@ -21,20 +21,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -59,10 +47,10 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -79,20 +67,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer_templates/centos/centos-6.10-x86_64.json
+++ b/packer_templates/centos/centos-6.10-x86_64.json
@@ -110,6 +110,8 @@
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/centos/centos-7.7-x86_64.json
+++ b/packer_templates/centos/centos-7.7-x86_64.json
@@ -21,20 +21,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -59,10 +47,10 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -79,20 +67,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer_templates/centos/centos-7.7-x86_64.json
+++ b/packer_templates/centos/centos-7.7-x86_64.json
@@ -110,6 +110,8 @@
         "<up><wait><tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/centos/centos-8.0-x86_64.json
+++ b/packer_templates/centos/centos-8.0-x86_64.json
@@ -21,20 +21,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -59,10 +47,10 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -79,20 +67,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer_templates/centos/centos-8.0-x86_64.json
+++ b/packer_templates/centos/centos-8.0-x86_64.json
@@ -110,6 +110,8 @@
         "<up><wait><tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/debian/debian-10.1-amd64.json
+++ b/packer_templates/debian/debian-10.1-amd64.json
@@ -144,6 +144,8 @@
         "<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/debian/debian-10.1-amd64.json
+++ b/packer_templates/debian/debian-10.1-amd64.json
@@ -36,20 +36,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -89,11 +77,11 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
-        "ethernet0.pciSlotNumber": "32",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "ethernet0.pciSlotNumber": "32"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -125,20 +113,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",

--- a/packer_templates/debian/debian-10.1-i386.json
+++ b/packer_templates/debian/debian-10.1-i386.json
@@ -144,6 +144,8 @@
         "<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/debian/debian-10.1-i386.json
+++ b/packer_templates/debian/debian-10.1-i386.json
@@ -36,20 +36,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -89,11 +77,11 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
-        "ethernet0.pciSlotNumber": "32",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "ethernet0.pciSlotNumber": "32"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -125,20 +113,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",

--- a/packer_templates/debian/debian-8.11-amd64.json
+++ b/packer_templates/debian/debian-8.11-amd64.json
@@ -144,6 +144,8 @@
         "<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/debian/debian-8.11-amd64.json
+++ b/packer_templates/debian/debian-8.11-amd64.json
@@ -36,20 +36,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -89,11 +77,11 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
-        "ethernet0.pciSlotNumber": "32",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "ethernet0.pciSlotNumber": "32"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -125,20 +113,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",

--- a/packer_templates/debian/debian-8.11-i386.json
+++ b/packer_templates/debian/debian-8.11-i386.json
@@ -144,6 +144,8 @@
         "<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/debian/debian-8.11-i386.json
+++ b/packer_templates/debian/debian-8.11-i386.json
@@ -36,20 +36,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -89,11 +77,11 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
-        "ethernet0.pciSlotNumber": "32",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "ethernet0.pciSlotNumber": "32"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -125,20 +113,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",

--- a/packer_templates/debian/debian-9.11-amd64.json
+++ b/packer_templates/debian/debian-9.11-amd64.json
@@ -144,6 +144,8 @@
         "<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/debian/debian-9.11-amd64.json
+++ b/packer_templates/debian/debian-9.11-amd64.json
@@ -36,20 +36,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -89,11 +77,11 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
-        "ethernet0.pciSlotNumber": "32",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "ethernet0.pciSlotNumber": "32"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -125,20 +113,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",

--- a/packer_templates/debian/debian-9.11-i386.json
+++ b/packer_templates/debian/debian-9.11-i386.json
@@ -144,6 +144,8 @@
         "<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/debian/debian-9.11-i386.json
+++ b/packer_templates/debian/debian-9.11-i386.json
@@ -36,20 +36,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -89,11 +77,11 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
-        "ethernet0.pciSlotNumber": "32",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "ethernet0.pciSlotNumber": "32"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -125,20 +113,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",

--- a/packer_templates/debian/debian-9.11-ppc64el.json
+++ b/packer_templates/debian/debian-9.11-ppc64el.json
@@ -25,6 +25,8 @@
         "boot<enter>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/fedora/fedora-29-x86_64.json
+++ b/packer_templates/fedora/fedora-29-x86_64.json
@@ -17,16 +17,8 @@
       "disk_compression": true,
       "disk_interface": "virtio-scsi",
       "net_device": "virtio-net",
-      "qemuargs": [
-          [
-              "-m",
-              "{{ user `memory` }}"
-          ],
-          [
-              "-smp",
-              "cpus={{ user `cpus` }}"
-          ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "http_directory": "http",
       "headless": "{{ user `headless` }}",
       "iso_checksum": "{{user `iso_checksum`}}",
@@ -59,20 +51,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -97,11 +77,11 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
-        "ethernet0.pciSlotNumber": "32",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "ethernet0.pciSlotNumber": "32"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -118,20 +98,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",

--- a/packer_templates/fedora/fedora-29-x86_64.json
+++ b/packer_templates/fedora/fedora-29-x86_64.json
@@ -114,6 +114,8 @@
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/fedora/fedora-30-x86_64.json
+++ b/packer_templates/fedora/fedora-30-x86_64.json
@@ -17,16 +17,8 @@
       "disk_compression": true,
       "disk_interface": "virtio-scsi",
       "net_device": "virtio-net",
-      "qemuargs": [
-          [
-              "-m",
-              "{{ user `memory` }}"
-          ],
-          [
-              "-smp",
-              "cpus={{ user `cpus` }}"
-          ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "http_directory": "http",
       "headless": "{{ user `headless` }}",
       "iso_checksum": "{{user `iso_checksum`}}",
@@ -59,20 +51,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -97,11 +77,11 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
-        "ethernet0.pciSlotNumber": "32",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "ethernet0.pciSlotNumber": "32"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -118,20 +98,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",

--- a/packer_templates/fedora/fedora-30-x86_64.json
+++ b/packer_templates/fedora/fedora-30-x86_64.json
@@ -114,6 +114,8 @@
         "<tab> linux ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/freebsd/freebsd-11.3-amd64.json
+++ b/packer_templates/freebsd/freebsd-11.3-amd64.json
@@ -13,6 +13,8 @@
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_mode": "disable",
       "guest_os_type": "FreeBSD_64",
@@ -28,20 +30,6 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -59,6 +47,8 @@
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "guest_os_type": "freebsd-64",
       "headless": "{{ user `headless` }}",
@@ -75,9 +65,7 @@
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -94,6 +82,8 @@
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "8s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "guest_os_type": "freebsd",
       "http_directory": "http",
@@ -103,18 +93,6 @@
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_mode": "disable",
       "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ],
         [
           "set",
           "{{.Name}}",
@@ -158,6 +136,8 @@
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "7s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/freebsd/freebsd-11.3-i386.json
+++ b/packer_templates/freebsd/freebsd-11.3-i386.json
@@ -13,6 +13,8 @@
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_mode": "disable",
       "guest_os_type": "FreeBSD",
@@ -28,20 +30,6 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -59,6 +47,8 @@
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "guest_os_type": "freebsd",
       "headless": "{{ user `headless` }}",
@@ -75,9 +65,7 @@
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -94,6 +82,8 @@
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "8s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "guest_os_type": "freebsd",
       "http_directory": "http",
@@ -103,18 +93,6 @@
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_mode": "disable",
       "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ],
         [
           "set",
           "{{.Name}}",
@@ -158,6 +136,8 @@
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "7s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/freebsd/freebsd-12.0-amd64.json
+++ b/packer_templates/freebsd/freebsd-12.0-amd64.json
@@ -13,6 +13,8 @@
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_mode": "disable",
       "guest_os_type": "FreeBSD_64",
@@ -28,20 +30,6 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -59,6 +47,8 @@
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "guest_os_type": "freebsd-64",
       "headless": "{{ user `headless` }}",
@@ -75,9 +65,7 @@
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -94,6 +82,8 @@
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "8s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "guest_os_type": "freebsd",
       "http_directory": "http",
@@ -103,18 +93,6 @@
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_mode": "disable",
       "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ],
         [
           "set",
           "{{.Name}}",
@@ -158,6 +136,8 @@
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "7s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/freebsd/freebsd-12.0-i386.json
+++ b/packer_templates/freebsd/freebsd-12.0-i386.json
@@ -13,6 +13,8 @@
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_mode": "disable",
       "guest_os_type": "FreeBSD",
@@ -28,20 +30,6 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -59,6 +47,8 @@
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "guest_os_type": "freebsd",
       "headless": "{{ user `headless` }}",
@@ -75,9 +65,7 @@
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -94,6 +82,8 @@
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "8s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "guest_os_type": "freebsd",
       "http_directory": "http",
@@ -103,18 +93,6 @@
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_mode": "disable",
       "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ],
         [
           "set",
           "{{.Name}}",
@@ -158,6 +136,8 @@
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "7s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/hardenedbsd/hardenedbsd-11-amd64.json
+++ b/packer_templates/hardenedbsd/hardenedbsd-11-amd64.json
@@ -28,20 +28,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -59,6 +47,8 @@
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "guest_os_type": "freebsd-64",
       "headless": "{{ user `headless` }}",
@@ -76,9 +66,7 @@
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -95,6 +83,8 @@
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "8s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "guest_os_type": "freebsd",
       "http_directory": "http",
@@ -104,18 +94,6 @@
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_mode": "disable",
       "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ],
         [
           "set",
           "{{.Name}}",
@@ -159,6 +137,8 @@
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "7s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/macos/macos-10.12.json
+++ b/packer_templates/macos/macos-10.12.json
@@ -2,6 +2,8 @@
   "builders": [
     {
       "boot_wait": "2s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "guest_os_type": "darwin12-64",
       "headless": "{{ user `headless` }}",
@@ -26,8 +28,6 @@
         "hpet0.present": "TRUE",
         "ich7m.present": "TRUE",
         "keyboardAndMouseProfile": "macProfile",
-        "memsize": "{{ user `memsize` }}",
-        "numvcpus": "{{ user `cpus` }}",
         "smc.present": "TRUE",
         "usb.present": "TRUE"
       },
@@ -35,6 +35,8 @@
     },
     {
       "boot_wait": "2s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_mode": "disable",
       "guest_os_type": "MacOS1011_64",
@@ -78,12 +80,6 @@
         [
           "modifyvm",
           "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
           "--firmware",
           "efi"
         ],
@@ -98,12 +94,6 @@
           "{{.Name}}",
           "--keyboard",
           "usb"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memsize` }}"
         ],
         [
           "modifyvm",
@@ -156,6 +146,8 @@
     },
     {
       "boot_wait": "2s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "guest_os_type": "macosx",
       "iso_checksum": "{{user `iso_checksum`}}",
@@ -164,18 +156,6 @@
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "mac",
       "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memsize` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ],
         [
           "set",
           "{{.Name}}",
@@ -243,7 +223,7 @@
     "iso_checksum": "__unset_iso_checksum__",
     "iso_checksum_type": "md5",
     "iso_url": "http://YOU-MUST-PROVIDE-YOUR-OWN-DMG.sorry",
-    "memsize": "2048",
+    "memory": "2048",
     "name": "macos-10.12",
     "no_proxy": "{{env `no_proxy`}}",
     "template": "macos-10.12",

--- a/packer_templates/macos/macosx-10.11.json
+++ b/packer_templates/macos/macosx-10.11.json
@@ -2,6 +2,8 @@
   "builders": [
     {
       "boot_wait": "2s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "guest_os_type": "darwin12-64",
       "headless": "{{ user `headless` }}",
@@ -26,8 +28,6 @@
         "hpet0.present": "TRUE",
         "ich7m.present": "TRUE",
         "keyboardAndMouseProfile": "macProfile",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}",
         "smc.present": "TRUE",
         "usb.present": "TRUE"
       },
@@ -35,6 +35,8 @@
     },
     {
       "boot_wait": "2s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "guest_additions_mode": "disable",
       "guest_os_type": "MacOS1011_64",
@@ -78,12 +80,6 @@
         [
           "modifyvm",
           "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
           "--firmware",
           "efi"
         ],
@@ -98,12 +94,6 @@
           "{{.Name}}",
           "--keyboard",
           "usb"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
         ],
         [
           "modifyvm",
@@ -156,6 +146,8 @@
     },
     {
       "boot_wait": "2s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "guest_os_type": "macosx",
       "iso_checksum": "{{user `iso_checksum`}}",
@@ -164,18 +156,6 @@
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "mac",
       "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ],
         [
           "set",
           "{{.Name}}",

--- a/packer_templates/opensuse/opensuse-leap-15.1-x86_64.json
+++ b/packer_templates/opensuse/opensuse-leap-15.1-x86_64.json
@@ -114,6 +114,8 @@
         "<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/opensuse/opensuse-leap-15.1-x86_64.json
+++ b/packer_templates/opensuse/opensuse-leap-15.1-x86_64.json
@@ -30,20 +30,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -77,10 +65,10 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -106,20 +94,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer_templates/oraclelinux/oracle-5.11-i386.json
+++ b/packer_templates/oraclelinux/oracle-5.11-i386.json
@@ -21,20 +21,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -59,10 +47,10 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -79,20 +67,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer_templates/oraclelinux/oracle-5.11-i386.json
+++ b/packer_templates/oraclelinux/oracle-5.11-i386.json
@@ -83,6 +83,8 @@
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "../centos/http",

--- a/packer_templates/oraclelinux/oracle-5.11-x86_64.json
+++ b/packer_templates/oraclelinux/oracle-5.11-x86_64.json
@@ -21,19 +21,9 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ],
         [
           "modifyvm",
           "{{.Name}}",
@@ -65,10 +55,10 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -85,20 +75,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer_templates/oraclelinux/oracle-5.11-x86_64.json
+++ b/packer_templates/oraclelinux/oracle-5.11-x86_64.json
@@ -91,6 +91,8 @@
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "../centos/http",

--- a/packer_templates/oraclelinux/oracle-6.10-i386.json
+++ b/packer_templates/oraclelinux/oracle-6.10-i386.json
@@ -21,20 +21,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -59,10 +47,10 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -79,20 +67,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer_templates/oraclelinux/oracle-6.10-i386.json
+++ b/packer_templates/oraclelinux/oracle-6.10-i386.json
@@ -83,6 +83,8 @@
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "../centos/http",

--- a/packer_templates/oraclelinux/oracle-6.10-x86_64.json
+++ b/packer_templates/oraclelinux/oracle-6.10-x86_64.json
@@ -21,20 +21,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -59,10 +47,10 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -79,20 +67,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer_templates/oraclelinux/oracle-6.10-x86_64.json
+++ b/packer_templates/oraclelinux/oracle-6.10-x86_64.json
@@ -83,6 +83,8 @@
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "../centos/http",

--- a/packer_templates/oraclelinux/oracle-7.7-x86_64.json
+++ b/packer_templates/oraclelinux/oracle-7.7-x86_64.json
@@ -21,20 +21,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -59,10 +47,10 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -79,20 +67,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer_templates/oraclelinux/oracle-7.7-x86_64.json
+++ b/packer_templates/oraclelinux/oracle-7.7-x86_64.json
@@ -83,6 +83,8 @@
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "../centos/http",

--- a/packer_templates/rhel/rhel-5.11-i386.json
+++ b/packer_templates/rhel/rhel-5.11-i386.json
@@ -21,20 +21,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -59,10 +47,10 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -79,20 +67,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer_templates/rhel/rhel-5.11-i386.json
+++ b/packer_templates/rhel/rhel-5.11-i386.json
@@ -83,6 +83,8 @@
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "../centos/http",

--- a/packer_templates/rhel/rhel-5.11-x86_64.json
+++ b/packer_templates/rhel/rhel-5.11-x86_64.json
@@ -21,19 +21,9 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ],
         [
           "modifyvm",
           "{{.Name}}",
@@ -65,10 +55,10 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -85,20 +75,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer_templates/rhel/rhel-5.11-x86_64.json
+++ b/packer_templates/rhel/rhel-5.11-x86_64.json
@@ -91,6 +91,8 @@
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "../centos/http",

--- a/packer_templates/rhel/rhel-6.10-i386.json
+++ b/packer_templates/rhel/rhel-6.10-i386.json
@@ -21,20 +21,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -59,10 +47,10 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -79,20 +67,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer_templates/rhel/rhel-6.10-i386.json
+++ b/packer_templates/rhel/rhel-6.10-i386.json
@@ -83,6 +83,8 @@
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "../centos/http",

--- a/packer_templates/rhel/rhel-6.10-x86_64.json
+++ b/packer_templates/rhel/rhel-6.10-x86_64.json
@@ -21,20 +21,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -59,10 +47,10 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -79,20 +67,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer_templates/rhel/rhel-6.10-x86_64.json
+++ b/packer_templates/rhel/rhel-6.10-x86_64.json
@@ -83,6 +83,8 @@
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "../centos/http",

--- a/packer_templates/rhel/rhel-7.6-x86_64.json
+++ b/packer_templates/rhel/rhel-7.6-x86_64.json
@@ -21,20 +21,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -59,10 +47,10 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -79,20 +67,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer_templates/rhel/rhel-7.6-x86_64.json
+++ b/packer_templates/rhel/rhel-7.6-x86_64.json
@@ -83,6 +83,8 @@
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "../centos/http",

--- a/packer_templates/rhel/rhel-8.0-x86_64.json
+++ b/packer_templates/rhel/rhel-8.0-x86_64.json
@@ -21,20 +21,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -59,10 +47,10 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -79,20 +67,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer_templates/rhel/rhel-8.0-x86_64.json
+++ b/packer_templates/rhel/rhel-8.0-x86_64.json
@@ -83,6 +83,8 @@
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "../centos/http",

--- a/packer_templates/sles/sles-11-sp4-x86_64.json
+++ b/packer_templates/sles/sles-11-sp4-x86_64.json
@@ -99,6 +99,8 @@
         "<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/sles/sles-11-sp4-x86_64.json
+++ b/packer_templates/sles/sles-11-sp4-x86_64.json
@@ -25,20 +25,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -67,10 +55,10 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -91,20 +79,8 @@
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer_templates/sles/sles-12-sp2-x86_64.json
+++ b/packer_templates/sles/sles-12-sp2-x86_64.json
@@ -99,6 +99,8 @@
         "<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/sles/sles-12-sp2-x86_64.json
+++ b/packer_templates/sles/sles-12-sp2-x86_64.json
@@ -25,20 +25,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -67,10 +55,10 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -91,20 +79,8 @@
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer_templates/sles/sles-12-sp3-x86_64.json
+++ b/packer_templates/sles/sles-12-sp3-x86_64.json
@@ -99,6 +99,8 @@
         "<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/sles/sles-12-sp3-x86_64.json
+++ b/packer_templates/sles/sles-12-sp3-x86_64.json
@@ -25,20 +25,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -67,10 +55,10 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -91,20 +79,8 @@
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer_templates/sles/sles-15-sp1.json
+++ b/packer_templates/sles/sles-15-sp1.json
@@ -25,19 +25,9 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
+      "manager": [
         [
           "storageattach",
           "{{.Name}}",
@@ -81,10 +71,10 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -105,20 +95,8 @@
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer_templates/sles/sles-15-sp1.json
+++ b/packer_templates/sles/sles-15-sp1.json
@@ -115,6 +115,8 @@
         "<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/sles/sles-15-sp1.json
+++ b/packer_templates/sles/sles-15-sp1.json
@@ -27,7 +27,7 @@
       "type": "virtualbox-iso",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
-      "manager": [
+      "vboxmanage": [
         [
           "storageattach",
           "{{.Name}}",

--- a/packer_templates/sles/sles-15.json
+++ b/packer_templates/sles/sles-15.json
@@ -25,19 +25,9 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
+      "manager": [
         [
           "storageattach",
           "{{.Name}}",
@@ -81,10 +71,10 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -105,20 +95,8 @@
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",

--- a/packer_templates/sles/sles-15.json
+++ b/packer_templates/sles/sles-15.json
@@ -115,6 +115,8 @@
         "<enter><wait>"
       ],
       "boot_wait": "10s",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",

--- a/packer_templates/sles/sles-15.json
+++ b/packer_templates/sles/sles-15.json
@@ -27,7 +27,7 @@
       "type": "virtualbox-iso",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
-      "manager": [
+      "vboxmanage": [
         [
           "storageattach",
           "{{.Name}}",

--- a/packer_templates/solaris/solaris-10.11-x86.json
+++ b/packer_templates/solaris/solaris-10.11-x86.json
@@ -34,20 +34,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "50000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -87,10 +75,10 @@
       "tools_upload_path": "/home/vagrant/solaris.iso",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     }

--- a/packer_templates/solaris/solaris-11-x86.json
+++ b/packer_templates/solaris/solaris-11-x86.json
@@ -45,20 +45,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -107,10 +95,10 @@
       "ssh_wait_timeout": "10000s",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     }

--- a/packer_templates/ubuntu/ubuntu-16.04-amd64.json
+++ b/packer_templates/ubuntu/ubuntu-16.04-amd64.json
@@ -44,20 +44,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -105,11 +93,11 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
-        "ethernet0.pciSlotNumber": "32",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "ethernet0.pciSlotNumber": "32"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -149,20 +137,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
@@ -207,16 +183,8 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-qemu",
-      "qemuargs": [
-        [
-          "-m",
-          "{{ user `memory` }}M"
-        ],
-        [
-          "-smp",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,

--- a/packer_templates/ubuntu/ubuntu-16.04-i386.json
+++ b/packer_templates/ubuntu/ubuntu-16.04-i386.json
@@ -44,20 +44,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -105,10 +93,10 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
-        "cpuid.coresPerSocket": "1",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "cpuid.coresPerSocket": "1"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -148,20 +136,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
@@ -206,23 +182,15 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}",
-      "qemuargs": [
-        [
-          "-m",
-          "{{ user `memory` }}M"
-        ],
-        [
-          "-smp",
-          "{{ user `cpus` }}"
-        ]
-      ]
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/packer_templates/ubuntu/ubuntu-18.04-amd64.json
+++ b/packer_templates/ubuntu/ubuntu-18.04-amd64.json
@@ -43,20 +43,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -103,11 +91,11 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
-        "ethernet0.pciSlotNumber": "32",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "ethernet0.pciSlotNumber": "32"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -146,20 +134,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
@@ -203,16 +179,8 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-qemu",
-      "qemuargs": [
-        [
-          "-m",
-          "{{ user `memory` }}M"
-        ],
-        [
-          "-smp",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,

--- a/packer_templates/ubuntu/ubuntu-18.10-amd64.json
+++ b/packer_templates/ubuntu/ubuntu-18.10-amd64.json
@@ -43,20 +43,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -103,11 +91,11 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
-        "ethernet0.pciSlotNumber": "32",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "ethernet0.pciSlotNumber": "32"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -146,20 +134,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
@@ -203,16 +179,8 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-qemu",
-      "qemuargs": [
-        [
-          "-m",
-          "{{ user `memory` }}M"
-        ],
-        [
-          "-smp",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,

--- a/packer_templates/ubuntu/ubuntu-19.04-amd64.json
+++ b/packer_templates/ubuntu/ubuntu-19.04-amd64.json
@@ -43,20 +43,8 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "virtualbox-iso",
-      "vboxmanage": [
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--memory",
-          "{{ user `memory` }}"
-        ],
-        [
-          "modifyvm",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "virtualbox_version_file": ".vbox_version",
       "vm_name": "{{ user `template` }}"
     },
@@ -103,11 +91,11 @@
       "tools_upload_flavor": "linux",
       "type": "vmware-iso",
       "vm_name": "{{ user `template` }}",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "vmx_data": {
         "cpuid.coresPerSocket": "1",
-        "ethernet0.pciSlotNumber": "32",
-        "memsize": "{{ user `memory` }}",
-        "numvcpus": "{{ user `cpus` }}"
+        "ethernet0.pciSlotNumber": "32"
       },
       "vmx_remove_ethernet_interfaces": true
     },
@@ -146,20 +134,8 @@
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
-      "prlctl": [
-        [
-          "set",
-          "{{.Name}}",
-          "--memsize",
-          "{{ user `memory` }}"
-        ],
-        [
-          "set",
-          "{{.Name}}",
-          "--cpus",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "prlctl_version_file": ".prlctl_version",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
@@ -203,16 +179,8 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "output_directory": "../../builds/packer-{{user `template`}}-qemu",
-      "qemuargs": [
-        [
-          "-m",
-          "{{ user `memory` }}M"
-        ],
-        [
-          "-smp",
-          "{{ user `cpus` }}"
-        ]
-      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,

--- a/packer_templates/windows/windows-10.json
+++ b/packer_templates/windows/windows-10.json
@@ -2,11 +2,11 @@
 	"builders": [{
 			"type": "virtualbox-iso",
 			"vboxmanage": [
-				["modifyvm", "{{.Name}}", "--memory", "4096"],
 				["modifyvm", "{{.Name}}", "--vram", "48"],
-				["modifyvm", "{{.Name}}", "--cpus", "2"],
 				["modifyvm", "{{.Name}}", "--audio", "none"]
 			],
+			"memory": "{{ user `memory` }}",
+			"cpus": "{{ user `cpus` }}",
 			"guest_additions_mode": "{{ user `guest_additions_mode` }}",
 			"guest_additions_path": "C:/users/vagrant/VBoxGuestAdditions.iso",
 			"guest_os_type": "Windows10_64",
@@ -30,11 +30,11 @@
 		{
 			"type": "vmware-iso",
 			"vmx_data": {
-				"memsize": "4096",
-				"numvcpus": "2",
 				"scsi0.virtualDev": "lsisas1068",
 				"scsi0.present": "TRUE"
 			},
+			"memory": "{{ user `memory` }}",
+			"cpus": "{{ user `cpus` }}",
 			"guest_os_type": "windows9srv-64",
 			"headless": "{{ user `headless` }}",
 			"iso_url": "{{ user `iso_url` }}",
@@ -109,6 +109,8 @@
 		}]
 	],
 	"variables": {
+		"memory": 4096,
+		"cpus": 2,
 		"guest_additions_mode": "attach",
 		"headless": "true",
 		"iso_checksum": "743fc483bb8bf1901c0534a0ae15208a5a72a3c5",

--- a/packer_templates/windows/windows-10.json
+++ b/packer_templates/windows/windows-10.json
@@ -109,8 +109,8 @@
 		}]
 	],
 	"variables": {
-		"memory": 4096,
-		"cpus": 2,
+		"memory": "4096",
+		"cpus": "2",
 		"guest_additions_mode": "attach",
 		"headless": "true",
 		"iso_checksum": "743fc483bb8bf1901c0534a0ae15208a5a72a3c5",

--- a/packer_templates/windows/windows-2008r2.json
+++ b/packer_templates/windows/windows-2008r2.json
@@ -2,10 +2,10 @@
 	"builders": [{
 		"type": "virtualbox-iso",
 		"vboxmanage": [
-			["modifyvm", "{{.Name}}", "--memory", "4096"],
-			["modifyvm", "{{.Name}}", "--vram", "48"],
-			["modifyvm", "{{.Name}}", "--cpus", "2"]
+			["modifyvm", "{{.Name}}", "--vram", "48"]
 		],
+		"memory": "{{ user `memory` }}",
+		"cpus": "{{ user `cpus` }}",
 		"guest_additions_mode": "{{ user `guest_additions_mode` }}",
 		"guest_additions_path": "C:/users/vagrant/VBoxGuestAdditions.iso",
 		"guest_os_type": "Windows2008_64",
@@ -72,6 +72,8 @@
 		}]
 	],
 	"variables": {
+		"memory": 4096,
+		"cpus": 2,
 		"guest_additions_mode": "attach",
 		"headless": "false",
 		"iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",

--- a/packer_templates/windows/windows-2008r2.json
+++ b/packer_templates/windows/windows-2008r2.json
@@ -72,8 +72,8 @@
 		}]
 	],
 	"variables": {
-		"memory": 4096,
-		"cpus": 2,
+		"memory": "4096",
+		"cpus": "2",
 		"guest_additions_mode": "attach",
 		"headless": "false",
 		"iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",

--- a/packer_templates/windows/windows-2012r2.json
+++ b/packer_templates/windows/windows-2012r2.json
@@ -2,10 +2,10 @@
 	"builders": [{
 			"type": "virtualbox-iso",
 			"vboxmanage": [
-				["modifyvm", "{{.Name}}", "--memory", "4096"],
-				["modifyvm", "{{.Name}}", "--vram", "48"],
-				["modifyvm", "{{.Name}}", "--cpus", "2"]
+				["modifyvm", "{{.Name}}", "--vram", "48"]
 			],
+			"memory": "{{ user `memory` }}",
+			"cpus": "{{ user `cpus` }}",
 			"guest_additions_mode": "{{ user `guest_additions_mode` }}",
 			"guest_additions_path": "C:/users/vagrant/VBoxGuestAdditions.iso",
 			"guest_os_type": "Windows2012_64",
@@ -27,11 +27,11 @@
 		{
 			"type": "vmware-iso",
 			"vmx_data": {
-				"memsize": "4096",
-				"numvcpus": "2",
 				"scsi0.virtualDev": "lsisas1068",
 				"scsi0.present": "TRUE"
 			},
+			"memory": "{{ user `memory` }}",
+			"cpus": "{{ user `cpus` }}",
 			"guest_os_type": "windows9srv-64",
 			"headless": "{{ user `headless` }}",
 			"iso_url": "{{ user `iso_url` }}",
@@ -104,6 +104,8 @@
 		}]
 	],
 	"variables": {
+		"cpus": 2,
+		"memory": 4096,
 		"guest_additions_mode": "attach",
 		"headless": "true",
 		"iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",

--- a/packer_templates/windows/windows-2012r2.json
+++ b/packer_templates/windows/windows-2012r2.json
@@ -104,8 +104,8 @@
 		}]
 	],
 	"variables": {
-		"cpus": 2,
-		"memory": 4096,
+		"cpus": "2",
+		"memory": "4096",
 		"guest_additions_mode": "attach",
 		"headless": "true",
 		"iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",

--- a/packer_templates/windows/windows-2016.json
+++ b/packer_templates/windows/windows-2016.json
@@ -2,10 +2,10 @@
 	"builders": [{
 			"type": "virtualbox-iso",
 			"vboxmanage": [
-				["modifyvm", "{{.Name}}", "--memory", "4096"],
-				["modifyvm", "{{.Name}}", "--vram", "48"],
-				["modifyvm", "{{.Name}}", "--cpus", "2"]
+				["modifyvm", "{{.Name}}", "--vram", "48"]
 			],
+			"memory": "{{ user `memory` }}",
+			"cpus": "{{ user `cpus` }}",
 			"guest_additions_mode": "{{ user `guest_additions_mode` }}",
 			"guest_additions_path": "C:/users/vagrant/VBoxGuestAdditions.iso",
 			"guest_os_type": "Windows2016_64",
@@ -27,11 +27,11 @@
 		{
 			"type": "vmware-iso",
 			"vmx_data": {
-				"memsize": "4096",
-				"numvcpus": "2",
 				"scsi0.virtualDev": "lsisas1068",
 				"scsi0.present": "TRUE"
 			},
+			"memory": "{{ user `memory` }}",
+			"cpus": "{{ user `cpus` }}",
 			"guest_os_type": "windows9srv-64",
 			"headless": "{{ user `headless` }}",
 			"iso_url": "{{ user `iso_url` }}",
@@ -104,6 +104,8 @@
 		}]
 	],
 	"variables": {
+		"memory": 4096,
+		"cpus": 2,
 		"guest_additions_mode": "attach",
 		"headless": "true",
 		"iso_checksum": "772700802951b36c8cb26a61c040b9a8dc3816a3",

--- a/packer_templates/windows/windows-2016.json
+++ b/packer_templates/windows/windows-2016.json
@@ -104,8 +104,8 @@
 		}]
 	],
 	"variables": {
-		"memory": 4096,
-		"cpus": 2,
+		"memory": "4096",
+		"cpus": "2",
 		"guest_additions_mode": "attach",
 		"headless": "true",
 		"iso_checksum": "772700802951b36c8cb26a61c040b9a8dc3816a3",

--- a/packer_templates/windows/windows-2019.json
+++ b/packer_templates/windows/windows-2019.json
@@ -104,8 +104,8 @@
 		}]
 	],
 	"variables": {
-		"memory": 4096,
-		"cpus": 2,
+		"memory": "4096",
+		"cpus": "2",
 		"guest_additions_mode": "attach",
 		"headless": "true",
 		"iso_checksum": "91e3a2f1acc39af21353c7cc105c799494d7539f",

--- a/packer_templates/windows/windows-2019.json
+++ b/packer_templates/windows/windows-2019.json
@@ -2,10 +2,10 @@
 	"builders": [{
 			"type": "virtualbox-iso",
 			"vboxmanage": [
-				["modifyvm", "{{.Name}}", "--memory", "4096"],
-				["modifyvm", "{{.Name}}", "--vram", "48"],
-				["modifyvm", "{{.Name}}", "--cpus", "2"]
+				["modifyvm", "{{.Name}}", "--vram", "48"]
 			],
+			"memory": "{{ user `memory` }}",
+			"cpus": "{{ user `cpus` }}",
 			"guest_additions_mode": "{{ user `guest_additions_mode` }}",
 			"guest_additions_path": "C:/users/vagrant/VBoxGuestAdditions.iso",
 			"guest_os_type": "Windows2016_64",
@@ -27,11 +27,11 @@
 		{
 			"type": "vmware-iso",
 			"vmx_data": {
-				"memsize": "4096",
-				"numvcpus": "2",
 				"scsi0.virtualDev": "lsisas1068",
 				"scsi0.present": "TRUE"
 			},
+			"memory": "{{ user `memory` }}",
+			"cpus": "{{ user `cpus` }}",
 			"guest_os_type": "windows9srv-64",
 			"headless": "{{ user `headless` }}",
 			"iso_url": "{{ user `iso_url` }}",
@@ -104,6 +104,8 @@
 		}]
 	],
 	"variables": {
+		"memory": 4096,
+		"cpus": 2,
 		"guest_additions_mode": "attach",
 		"headless": "true",
 		"iso_checksum": "91e3a2f1acc39af21353c7cc105c799494d7539f",

--- a/packer_templates/windows/windows-7.json
+++ b/packer_templates/windows/windows-7.json
@@ -79,8 +79,8 @@
 		}]
 	],
 	"variables": {
-		"memory": 4096,
-		"cpus": 2,
+		"memory": "4096",
+		"cpus": "2",
 		"guest_additions_mode": "attach",
 		"headless": "false",
 		"iso_checksum": "971fc00183a52c152fe924a6b99fdec011a871c2",

--- a/packer_templates/windows/windows-7.json
+++ b/packer_templates/windows/windows-7.json
@@ -2,10 +2,10 @@
 	"builders": [{
 		"type": "virtualbox-iso",
 		"vboxmanage": [
-			["modifyvm", "{{.Name}}", "--memory", "5120"],
-			["modifyvm", "{{.Name}}", "--vram", "36"],
-			["modifyvm", "{{.Name}}", "--cpus", "2"]
+			["modifyvm", "{{.Name}}", "--vram", "36"]
 		],
+		"memory": "{{ user `memory` }}",
+		"cpus": "{{ user `cpus` }}",
 		"guest_additions_mode": "{{ user `guest_additions_mode` }}",
 		"guest_additions_path": "C:/users/vagrant/VBoxGuestAdditions.iso",
 		"guest_os_type": "Windows7_64",
@@ -24,7 +24,7 @@
 			"answer_files/7/Autounattend.xml"
 		]
 	}],
-  "provisioners": [{
+	"provisioners": [{
 			"type": "chef-solo",
 			"cookbook_paths": ["cookbooks"],
 			"guest_os_type": "windows",
@@ -79,10 +79,12 @@
 		}]
 	],
 	"variables": {
+		"memory": 4096,
+		"cpus": 2,
 		"guest_additions_mode": "attach",
 		"headless": "false",
-    "iso_checksum": "971fc00183a52c152fe924a6b99fdec011a871c2",
-    "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x86/EN/7600.16385.090713-1255_x86fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENEVAL_EN_DVD.iso",
+		"iso_checksum": "971fc00183a52c152fe924a6b99fdec011a871c2",
+		"iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x86/EN/7600.16385.090713-1255_x86fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENEVAL_EN_DVD.iso",
 		"template": "windows-7"
 	}
 }


### PR DESCRIPTION
## Description
Packer has generalized the specification of the number of cpus and memory for each builder by exposing the options "memory" and "cpus". This supersedes the builder-specific method of using "vmx_data", "vboxmanage", "prlctl", "qemuargs", etc. and is supported by the "vmware-iso", "virtualbox-iso", "parallels-iso", and "qemu" builders. The replacement of the builder-specific options with the general options are done by the first commit in this PR.

Some of the "qemu" builders defined in the supported templates were also not using the former "qemuargs" option to customize the amount memory and cpus using their respective user-variables. These have been updated by the second commit in this PR.

Also, some of the windows templates were not using the "memory" and "cpus" user variables which are inconsistent with the rest of the linux templates. The windows-7 template also had mismatched tabs which were replaced with whitespace so the indentation is consistent. The macos-10.12 template was using "memsize" as the user variable which is different from the other templates, this was renamed to "memory" in order to be able to use the same user-variables when building this. This change was part of the first commit of this PR.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
