### PR TITLE
Updated the macos templates to use the "usb" option to enable usb instead of "vmx_data" for the vmware-iso builders.

### DIFF
--- a/packer_templates/macos/macos-10.12.json
+++ b/packer_templates/macos/macos-10.12.json
@@ -5,6 +5,7 @@
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
+      "usb": true,
       "guest_os_type": "darwin12-64",
       "headless": "{{ user `headless` }}",
       "iso_checksum": "{{user `iso_checksum`}}",
@@ -28,8 +29,7 @@
         "hpet0.present": "TRUE",
         "ich7m.present": "TRUE",
         "keyboardAndMouseProfile": "macProfile",
-        "smc.present": "TRUE",
-        "usb.present": "TRUE"
+        "smc.present": "TRUE"
       },
       "vmx_remove_ethernet_interfaces": true
     },

--- a/packer_templates/macos/macosx-10.11.json
+++ b/packer_templates/macos/macosx-10.11.json
@@ -5,6 +5,7 @@
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
       "disk_size": "{{user `disk_size`}}",
+      "usb": true,
       "guest_os_type": "darwin12-64",
       "headless": "{{ user `headless` }}",
       "iso_checksum": "{{user `iso_checksum`}}",
@@ -28,8 +29,7 @@
         "hpet0.present": "TRUE",
         "ich7m.present": "TRUE",
         "keyboardAndMouseProfile": "macProfile",
-        "smc.present": "TRUE",
-        "usb.present": "TRUE"
+        "smc.present": "TRUE"
       },
       "vmx_remove_ethernet_interfaces": true
     },


### PR DESCRIPTION
## Description
Sorry. I should've included this in my other PR, but didn't think of it until you mentioned "cleaning up the warnings". This replaces the "usb.present" option that's explicitly specified in the "vmx_data" for the macos templates with the "usb" option. I'm familiar with these options because I'm the author of their related PRs in packer, so...might as well spread the syntax everywhere.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
