### PR TITLE
Updated template to use a "build_directory" user-variable defaulted to "../../builds"

### DIFF
--- a/packer_templates/amazonlinux/amazon-2-x86_64.json
+++ b/packer_templates/amazonlinux/amazon-2-x86_64.json
@@ -4,7 +4,7 @@
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_wait_timeout": "10000s",
       "ssh_port": 22,
@@ -32,7 +32,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -61,7 +61,7 @@
   ],
   "variables": {
     "box_basename": "amazon-2",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/amazonlinux/amazon-2-x86_64.json
+++ b/packer_templates/amazonlinux/amazon-2-x86_64.json
@@ -4,7 +4,7 @@
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "headless": "{{ user `headless` }}",
       "http_directory": "http",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_wait_timeout": "10000s",
       "ssh_port": 22,
@@ -32,7 +32,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -61,6 +61,7 @@
   ],
   "variables": {
     "box_basename": "amazon-2",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/centos/centos-5.11-i386.json
+++ b/packer_templates/centos/centos-5.11-i386.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -95,7 +95,7 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "memory": "{{ user `memory` }}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-hyperv",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-hyperv",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -118,7 +118,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -130,7 +130,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -162,7 +162,7 @@
   ],
   "variables": {
     "box_basename": "centos-5.11-i386",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/centos/centos-5.11-i386.json
+++ b/packer_templates/centos/centos-5.11-i386.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -95,7 +95,7 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "memory": "{{ user `memory` }}",
-      "output_directory": "../../builds/packer-{{user `template`}}-hyperv",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-hyperv",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -118,7 +118,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -130,7 +130,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -162,6 +162,7 @@
   ],
   "variables": {
     "box_basename": "centos-5.11-i386",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/centos/centos-5.11-x86_64.json
+++ b/packer_templates/centos/centos-5.11-x86_64.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -95,7 +95,7 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "memory": "{{ user `memory` }}",
-      "output_directory": "../../builds/packer-{{user `template`}}-hyperv",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-hyperv",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -118,7 +118,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -130,7 +130,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -162,6 +162,7 @@
   ],
   "variables": {
     "box_basename": "centos-5.11",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/centos/centos-5.11-x86_64.json
+++ b/packer_templates/centos/centos-5.11-x86_64.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -95,7 +95,7 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "memory": "{{ user `memory` }}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-hyperv",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-hyperv",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -118,7 +118,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -130,7 +130,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -162,7 +162,7 @@
   ],
   "variables": {
     "box_basename": "centos-5.11",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/centos/centos-6.10-i386.json
+++ b/packer_templates/centos/centos-6.10-i386.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -95,7 +95,7 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "memory": "{{ user `memory` }}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-hyperv",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-hyperv",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -118,7 +118,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -130,7 +130,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -161,7 +161,7 @@
   ],
   "variables": {
     "box_basename": "centos-6.10-i386",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/centos/centos-6.10-i386.json
+++ b/packer_templates/centos/centos-6.10-i386.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -95,7 +95,7 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "memory": "{{ user `memory` }}",
-      "output_directory": "../../builds/packer-{{user `template`}}-hyperv",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-hyperv",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -118,7 +118,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -130,7 +130,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -161,6 +161,7 @@
   ],
   "variables": {
     "box_basename": "centos-6.10-i386",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/centos/centos-6.10-x86_64.json
+++ b/packer_templates/centos/centos-6.10-x86_64.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -95,7 +95,7 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "memory": "{{ user `memory` }}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-hyperv",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-hyperv",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -118,7 +118,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -130,7 +130,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -161,7 +161,7 @@
   ],
   "variables": {
     "box_basename": "centos-6.10",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/centos/centos-6.10-x86_64.json
+++ b/packer_templates/centos/centos-6.10-x86_64.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -95,7 +95,7 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "memory": "{{ user `memory` }}",
-      "output_directory": "../../builds/packer-{{user `template`}}-hyperv",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-hyperv",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -118,7 +118,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -130,7 +130,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -161,6 +161,7 @@
   ],
   "variables": {
     "box_basename": "centos-6.10",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/centos/centos-7.7-x86_64.json
+++ b/packer_templates/centos/centos-7.7-x86_64.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -95,7 +95,7 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "memory": "{{ user `memory` }}",
-      "output_directory": "../../builds/packer-{{user `template`}}-hyperv",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-hyperv",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -118,7 +118,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -130,7 +130,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -161,6 +161,7 @@
   ],
   "variables": {
     "box_basename": "centos-7.7",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/centos/centos-7.7-x86_64.json
+++ b/packer_templates/centos/centos-7.7-x86_64.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -95,7 +95,7 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "memory": "{{ user `memory` }}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-hyperv",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-hyperv",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -118,7 +118,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -130,7 +130,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -161,7 +161,7 @@
   ],
   "variables": {
     "box_basename": "centos-7.7",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/centos/centos-8.0-x86_64.json
+++ b/packer_templates/centos/centos-8.0-x86_64.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -95,7 +95,7 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "memory": "{{ user `memory` }}",
-      "output_directory": "../../builds/packer-{{user `template`}}-hyperv",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-hyperv",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -118,7 +118,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -130,7 +130,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -161,6 +161,7 @@
   ],
   "variables": {
     "box_basename": "centos-8.0",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"2019102650405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/centos/centos-8.0-x86_64.json
+++ b/packer_templates/centos/centos-8.0-x86_64.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -95,7 +95,7 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "memory": "{{ user `memory` }}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-hyperv",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-hyperv",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -118,7 +118,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -130,7 +130,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -161,7 +161,7 @@
   ],
   "variables": {
     "box_basename": "centos-8.0",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"2019102650405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/debian/debian-10.1-amd64.json
+++ b/packer_templates/debian/debian-10.1-amd64.json
@@ -29,7 +29,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -68,7 +68,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -111,7 +111,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -152,7 +152,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -164,7 +164,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -197,7 +197,7 @@
   ],
   "variables": {
     "box_basename": "debian-10.1",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/debian/debian-10.1-amd64.json
+++ b/packer_templates/debian/debian-10.1-amd64.json
@@ -29,7 +29,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -68,7 +68,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -111,7 +111,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -152,7 +152,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -164,7 +164,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -197,6 +197,7 @@
   ],
   "variables": {
     "box_basename": "debian-10.1",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/debian/debian-10.1-i386.json
+++ b/packer_templates/debian/debian-10.1-i386.json
@@ -29,7 +29,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -68,7 +68,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -111,7 +111,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -152,7 +152,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -164,7 +164,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -197,7 +197,7 @@
   ],
   "variables": {
     "box_basename": "debian-10.1-i386",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/debian/debian-10.1-i386.json
+++ b/packer_templates/debian/debian-10.1-i386.json
@@ -29,7 +29,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -68,7 +68,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -111,7 +111,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -152,7 +152,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -164,7 +164,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -197,6 +197,7 @@
   ],
   "variables": {
     "box_basename": "debian-10.1-i386",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/debian/debian-8.11-amd64.json
+++ b/packer_templates/debian/debian-8.11-amd64.json
@@ -29,7 +29,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -68,7 +68,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -111,7 +111,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -152,7 +152,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -164,7 +164,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -197,7 +197,7 @@
   ],
   "variables": {
     "box_basename": "debian-8.11",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/debian/debian-8.11-amd64.json
+++ b/packer_templates/debian/debian-8.11-amd64.json
@@ -29,7 +29,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -68,7 +68,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -111,7 +111,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -152,7 +152,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -164,7 +164,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -197,6 +197,7 @@
   ],
   "variables": {
     "box_basename": "debian-8.11",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/debian/debian-8.11-i386.json
+++ b/packer_templates/debian/debian-8.11-i386.json
@@ -29,7 +29,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -68,7 +68,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -111,7 +111,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -152,7 +152,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -164,7 +164,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -197,6 +197,7 @@
   ],
   "variables": {
     "box_basename": "debian-8.11-i386",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/debian/debian-8.11-i386.json
+++ b/packer_templates/debian/debian-8.11-i386.json
@@ -29,7 +29,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -68,7 +68,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -111,7 +111,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -152,7 +152,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -164,7 +164,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -197,7 +197,7 @@
   ],
   "variables": {
     "box_basename": "debian-8.11-i386",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/debian/debian-9.11-amd64.json
+++ b/packer_templates/debian/debian-9.11-amd64.json
@@ -29,7 +29,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -68,7 +68,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -111,7 +111,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -152,7 +152,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -164,7 +164,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -197,6 +197,7 @@
   ],
   "variables": {
     "box_basename": "debian-9.11",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/debian/debian-9.11-amd64.json
+++ b/packer_templates/debian/debian-9.11-amd64.json
@@ -29,7 +29,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -68,7 +68,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -111,7 +111,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -152,7 +152,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -164,7 +164,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -197,7 +197,7 @@
   ],
   "variables": {
     "box_basename": "debian-9.11",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/debian/debian-9.11-i386.json
+++ b/packer_templates/debian/debian-9.11-i386.json
@@ -29,7 +29,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -68,7 +68,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -111,7 +111,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -152,7 +152,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -164,7 +164,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -197,6 +197,7 @@
   ],
   "variables": {
     "box_basename": "debian-9.11-i386",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/debian/debian-9.11-i386.json
+++ b/packer_templates/debian/debian-9.11-i386.json
@@ -29,7 +29,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -68,7 +68,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -111,7 +111,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -152,7 +152,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -164,7 +164,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -197,7 +197,7 @@
   ],
   "variables": {
     "box_basename": "debian-9.11-i386",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/debian/debian-9.11-ppc64el.json
+++ b/packer_templates/debian/debian-9.11-ppc64el.json
@@ -33,7 +33,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -49,7 +49,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -82,6 +82,7 @@
   ],
   "variables": {
     "box_basename": "debian-9.11",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/debian/debian-9.11-ppc64el.json
+++ b/packer_templates/debian/debian-9.11-ppc64el.json
@@ -33,7 +33,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -49,7 +49,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -82,7 +82,7 @@
   ],
   "variables": {
     "box_basename": "debian-9.11",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/fedora/fedora-29-x86_64.json
+++ b/packer_templates/fedora/fedora-29-x86_64.json
@@ -4,7 +4,7 @@
       "type": "qemu",
       "vm_name": "{{ user `template` }}",
       "name": "{{ user `template` }}",
-      "output_directory": "../../builds/packer-{{user `template`}}-libvirt",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-libvirt",
       "accelerator": "kvm",
       "boot_wait": "10s",
       "boot_command": [
@@ -44,7 +44,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -68,7 +68,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -96,7 +96,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -122,7 +122,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -134,7 +134,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -167,6 +167,7 @@
   "variables": {
     "arch": "64",
     "box_basename": "fedora-29",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/fedora/fedora-29-x86_64.json
+++ b/packer_templates/fedora/fedora-29-x86_64.json
@@ -4,7 +4,7 @@
       "type": "qemu",
       "vm_name": "{{ user `template` }}",
       "name": "{{ user `template` }}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-libvirt",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-libvirt",
       "accelerator": "kvm",
       "boot_wait": "10s",
       "boot_command": [
@@ -44,7 +44,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -68,7 +68,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -96,7 +96,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -122,7 +122,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -134,7 +134,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -167,7 +167,7 @@
   "variables": {
     "arch": "64",
     "box_basename": "fedora-29",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/fedora/fedora-30-x86_64.json
+++ b/packer_templates/fedora/fedora-30-x86_64.json
@@ -4,7 +4,7 @@
       "type": "qemu",
       "vm_name": "{{ user `template` }}",
       "name": "{{ user `template` }}",
-      "output_directory": "../../builds/packer-{{user `template`}}-libvirt",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-libvirt",
       "accelerator": "kvm",
       "boot_wait": "10s",
       "boot_command": [
@@ -44,7 +44,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -68,7 +68,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -96,7 +96,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -122,7 +122,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -134,7 +134,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -168,6 +168,7 @@
   "variables": {
     "arch": "64",
     "box_basename": "fedora-30",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/fedora/fedora-30-x86_64.json
+++ b/packer_templates/fedora/fedora-30-x86_64.json
@@ -4,7 +4,7 @@
       "type": "qemu",
       "vm_name": "{{ user `template` }}",
       "name": "{{ user `template` }}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-libvirt",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-libvirt",
       "accelerator": "kvm",
       "boot_wait": "10s",
       "boot_command": [
@@ -44,7 +44,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -68,7 +68,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -96,7 +96,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -122,7 +122,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -134,7 +134,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -168,7 +168,7 @@
   "variables": {
     "arch": "64",
     "box_basename": "fedora-30",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/fedora/fedora-31-x86_64.json
+++ b/packer_templates/fedora/fedora-31-x86_64.json
@@ -4,7 +4,7 @@
       "type": "qemu",
       "vm_name": "{{ user `template` }}",
       "name": "{{ user `template` }}",
-      "output_directory": "../../builds/packer-{{user `template`}}-libvirt",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-libvirt",
       "accelerator": "kvm",
       "boot_wait": "10s",
       "boot_command": [
@@ -44,7 +44,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -68,7 +68,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -96,7 +96,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -122,7 +122,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -134,7 +134,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -168,6 +168,7 @@
   "variables": {
     "arch": "64",
     "box_basename": "fedora-31",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/fedora/fedora-31-x86_64.json
+++ b/packer_templates/fedora/fedora-31-x86_64.json
@@ -4,7 +4,7 @@
       "type": "qemu",
       "vm_name": "{{ user `template` }}",
       "name": "{{ user `template` }}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-libvirt",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-libvirt",
       "accelerator": "kvm",
       "boot_wait": "10s",
       "boot_command": [
@@ -44,7 +44,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -68,7 +68,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -96,7 +96,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -122,7 +122,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -134,7 +134,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -168,7 +168,7 @@
   "variables": {
     "arch": "64",
     "box_basename": "fedora-31",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/freebsd/freebsd-11.3-amd64.json
+++ b/packer_templates/freebsd/freebsd-11.3-amd64.json
@@ -23,7 +23,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -56,7 +56,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -90,7 +90,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_mode": "disable",
       "prlctl": [
         [
@@ -144,7 +144,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -156,7 +156,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant",
       "vagrantfile_template": "vagrantfile_templates/freebsd.rb"
     }
@@ -186,7 +186,7 @@
   ],
   "variables": {
     "box_basename": "freebsd-11.3",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/freebsd/freebsd-11.3-amd64.json
+++ b/packer_templates/freebsd/freebsd-11.3-amd64.json
@@ -23,7 +23,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -56,7 +56,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -90,7 +90,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_mode": "disable",
       "prlctl": [
         [
@@ -144,7 +144,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -156,7 +156,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant",
       "vagrantfile_template": "vagrantfile_templates/freebsd.rb"
     }
@@ -186,6 +186,7 @@
   ],
   "variables": {
     "box_basename": "freebsd-11.3",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/freebsd/freebsd-11.3-i386.json
+++ b/packer_templates/freebsd/freebsd-11.3-i386.json
@@ -23,7 +23,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -56,7 +56,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -90,7 +90,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_mode": "disable",
       "prlctl": [
         [
@@ -144,7 +144,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -156,7 +156,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant",
       "vagrantfile_template": "vagrantfile_templates/freebsd.rb"
     }
@@ -186,6 +186,7 @@
   ],
   "variables": {
     "box_basename": "freebsd-11.3-i386",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "40960",

--- a/packer_templates/freebsd/freebsd-11.3-i386.json
+++ b/packer_templates/freebsd/freebsd-11.3-i386.json
@@ -23,7 +23,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -56,7 +56,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -90,7 +90,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_mode": "disable",
       "prlctl": [
         [
@@ -144,7 +144,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -156,7 +156,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant",
       "vagrantfile_template": "vagrantfile_templates/freebsd.rb"
     }
@@ -186,7 +186,7 @@
   ],
   "variables": {
     "box_basename": "freebsd-11.3-i386",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "40960",

--- a/packer_templates/freebsd/freebsd-12.0-amd64.json
+++ b/packer_templates/freebsd/freebsd-12.0-amd64.json
@@ -23,7 +23,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -56,7 +56,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -90,7 +90,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_mode": "disable",
       "prlctl": [
         [
@@ -144,7 +144,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -156,7 +156,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant",
       "vagrantfile_template": "vagrantfile_templates/freebsd.rb"
     }
@@ -186,6 +186,7 @@
   ],
   "variables": {
     "box_basename": "freebsd-12.0",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/freebsd/freebsd-12.0-amd64.json
+++ b/packer_templates/freebsd/freebsd-12.0-amd64.json
@@ -23,7 +23,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -56,7 +56,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -90,7 +90,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_mode": "disable",
       "prlctl": [
         [
@@ -144,7 +144,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -156,7 +156,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant",
       "vagrantfile_template": "vagrantfile_templates/freebsd.rb"
     }
@@ -186,7 +186,7 @@
   ],
   "variables": {
     "box_basename": "freebsd-12.0",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/freebsd/freebsd-12.0-i386.json
+++ b/packer_templates/freebsd/freebsd-12.0-i386.json
@@ -23,7 +23,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -56,7 +56,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -90,7 +90,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_mode": "disable",
       "prlctl": [
         [
@@ -144,7 +144,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -156,7 +156,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant",
       "vagrantfile_template": "vagrantfile_templates/freebsd.rb"
     }
@@ -186,7 +186,7 @@
   ],
   "variables": {
     "box_basename": "freebsd-12.0-i386",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "40960",

--- a/packer_templates/freebsd/freebsd-12.0-i386.json
+++ b/packer_templates/freebsd/freebsd-12.0-i386.json
@@ -23,7 +23,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -56,7 +56,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -90,7 +90,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_mode": "disable",
       "prlctl": [
         [
@@ -144,7 +144,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -156,7 +156,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant",
       "vagrantfile_template": "vagrantfile_templates/freebsd.rb"
     }
@@ -186,6 +186,7 @@
   ],
   "variables": {
     "box_basename": "freebsd-12.0-i386",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "40960",

--- a/packer_templates/hardenedbsd/hardenedbsd-11-amd64.json
+++ b/packer_templates/hardenedbsd/hardenedbsd-11-amd64.json
@@ -21,7 +21,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -56,7 +56,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -91,7 +91,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_mode": "disable",
       "prlctl": [
         [
@@ -145,7 +145,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -157,7 +157,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant",
       "vagrantfile_template": "vagrantfile_templates/hardenedbsd.rb"
     }
@@ -185,7 +185,7 @@
   ],
   "variables": {
     "box_basename": "hardenedbsd-11",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/hardenedbsd/hardenedbsd-11-amd64.json
+++ b/packer_templates/hardenedbsd/hardenedbsd-11-amd64.json
@@ -21,7 +21,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -56,7 +56,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -91,7 +91,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_mode": "disable",
       "prlctl": [
         [
@@ -145,7 +145,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | su -m root -c 'shutdown -p now'",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -157,7 +157,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant",
       "vagrantfile_template": "vagrantfile_templates/hardenedbsd.rb"
     }
@@ -185,6 +185,7 @@
   ],
   "variables": {
     "box_basename": "hardenedbsd-11",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/macos/macos-10.12.json
+++ b/packer_templates/macos/macos-10.12.json
@@ -11,7 +11,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant'| sudo -S shutdown -h now",
       "skip_compaction": true,
       "ssh_password": "vagrant",
@@ -45,7 +45,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant'| sudo -S shutdown -h now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -153,7 +153,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "mac",
       "prlctl": [
         [
@@ -174,7 +174,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant",
       "vagrantfile_template": "vagrantfile_templates/macosx.rb"
     }
@@ -213,6 +213,7 @@
     "_README": "You must provide a prepared Mac disk image (from https://github.com/timsutton/osx-vm-templates) and checksum value for this template to work. For more details, consult this project's README.md",
     "autologin": "true",
     "box_basename": "macos-10.12",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/macos/macos-10.12.json
+++ b/packer_templates/macos/macos-10.12.json
@@ -11,7 +11,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant'| sudo -S shutdown -h now",
       "skip_compaction": true,
       "ssh_password": "vagrant",
@@ -45,7 +45,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant'| sudo -S shutdown -h now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -153,7 +153,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "mac",
       "prlctl": [
         [
@@ -174,7 +174,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant",
       "vagrantfile_template": "vagrantfile_templates/macosx.rb"
     }
@@ -213,7 +213,7 @@
     "_README": "You must provide a prepared Mac disk image (from https://github.com/timsutton/osx-vm-templates) and checksum value for this template to work. For more details, consult this project's README.md",
     "autologin": "true",
     "box_basename": "macos-10.12",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/macos/macosx-10.11.json
+++ b/packer_templates/macos/macosx-10.11.json
@@ -11,7 +11,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant'| sudo -S shutdown -h now",
       "skip_compaction": true,
       "ssh_password": "vagrant",
@@ -45,7 +45,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant'| sudo -S shutdown -h now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -153,7 +153,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "mac",
       "prlctl": [
         [
@@ -174,7 +174,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant",
       "vagrantfile_template": "vagrantfile_templates/macosx.rb"
     }
@@ -213,6 +213,7 @@
     "_README": "You must provide a prepared Mac disk image (from https://github.com/timsutton/osx-vm-templates) and checksum value for this template to work. For more details, consult this project's README.md",
     "autologin": "true",
     "box_basename": "macosx-10.11",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/macos/macosx-10.11.json
+++ b/packer_templates/macos/macosx-10.11.json
@@ -11,7 +11,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant'| sudo -S shutdown -h now",
       "skip_compaction": true,
       "ssh_password": "vagrant",
@@ -45,7 +45,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant'| sudo -S shutdown -h now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -153,7 +153,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `iso_url`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "mac",
       "prlctl": [
         [
@@ -174,7 +174,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant",
       "vagrantfile_template": "vagrantfile_templates/macosx.rb"
     }
@@ -213,7 +213,7 @@
     "_README": "You must provide a prepared Mac disk image (from https://github.com/timsutton/osx-vm-templates) and checksum value for this template to work. For more details, consult this project's README.md",
     "autologin": "true",
     "box_basename": "macosx-10.11",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/opensuse/opensuse-leap-15.1-x86_64.json
+++ b/packer_templates/opensuse/opensuse-leap-15.1-x86_64.json
@@ -23,7 +23,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -56,7 +56,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -h 1",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -92,7 +92,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -122,7 +122,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -134,7 +134,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -171,7 +171,7 @@
     "arch": "64",
     "autoinst_cfg": "15/autoinst.xml",
     "box_basename": "opensuse-leap-15.1",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/opensuse/opensuse-leap-15.1-x86_64.json
+++ b/packer_templates/opensuse/opensuse-leap-15.1-x86_64.json
@@ -23,7 +23,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -56,7 +56,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/shutdown -h 1",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -92,7 +92,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -122,7 +122,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -134,7 +134,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -171,6 +171,7 @@
     "arch": "64",
     "autoinst_cfg": "15/autoinst.xml",
     "box_basename": "opensuse-leap-15.1",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/oraclelinux/oracle-5.11-i386.json
+++ b/packer_templates/oraclelinux/oracle-5.11-i386.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -91,7 +91,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -103,7 +103,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -134,6 +134,7 @@
   "variables": {
     "arch": "32",
     "box_basename": "oracle-5.11-i386",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/oraclelinux/oracle-5.11-i386.json
+++ b/packer_templates/oraclelinux/oracle-5.11-i386.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -91,7 +91,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -103,7 +103,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -134,7 +134,7 @@
   "variables": {
     "arch": "32",
     "box_basename": "oracle-5.11-i386",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/oraclelinux/oracle-5.11-x86_64.json
+++ b/packer_templates/oraclelinux/oracle-5.11-x86_64.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -46,7 +46,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -73,7 +73,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -99,7 +99,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -111,7 +111,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -142,7 +142,7 @@
   "variables": {
     "arch": "64",
     "box_basename": "oracle-5.11",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/oraclelinux/oracle-5.11-x86_64.json
+++ b/packer_templates/oraclelinux/oracle-5.11-x86_64.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -46,7 +46,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -73,7 +73,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -99,7 +99,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -111,7 +111,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -142,6 +142,7 @@
   "variables": {
     "arch": "64",
     "box_basename": "oracle-5.11",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/oraclelinux/oracle-6.10-i386.json
+++ b/packer_templates/oraclelinux/oracle-6.10-i386.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -91,7 +91,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -103,7 +103,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -135,6 +135,7 @@
   "variables": {
     "arch": "32",
     "box_basename": "oracle-6.10-i386",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/oraclelinux/oracle-6.10-i386.json
+++ b/packer_templates/oraclelinux/oracle-6.10-i386.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -91,7 +91,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -103,7 +103,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -135,7 +135,7 @@
   "variables": {
     "arch": "32",
     "box_basename": "oracle-6.10-i386",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/oraclelinux/oracle-6.10-x86_64.json
+++ b/packer_templates/oraclelinux/oracle-6.10-x86_64.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -91,7 +91,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -103,7 +103,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -135,7 +135,7 @@
   "variables": {
     "arch": "64",
     "box_basename": "oracle-6.10",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/oraclelinux/oracle-6.10-x86_64.json
+++ b/packer_templates/oraclelinux/oracle-6.10-x86_64.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -91,7 +91,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -103,7 +103,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -135,6 +135,7 @@
   "variables": {
     "arch": "64",
     "box_basename": "oracle-6.10",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/oraclelinux/oracle-7.7-x86_64.json
+++ b/packer_templates/oraclelinux/oracle-7.7-x86_64.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -91,7 +91,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -103,7 +103,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -135,6 +135,7 @@
   "variables": {
     "arch": "64",
     "box_basename": "oracle-7.7",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/oraclelinux/oracle-7.7-x86_64.json
+++ b/packer_templates/oraclelinux/oracle-7.7-x86_64.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -91,7 +91,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -103,7 +103,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -135,7 +135,7 @@
   "variables": {
     "arch": "64",
     "box_basename": "oracle-7.7",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/rhel/rhel-5.11-i386.json
+++ b/packer_templates/rhel/rhel-5.11-i386.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -91,7 +91,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -103,7 +103,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -133,6 +133,7 @@
   "variables": {
     "arch": "32",
     "box_basename": "rhel-5.11-i386",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/rhel/rhel-5.11-i386.json
+++ b/packer_templates/rhel/rhel-5.11-i386.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -91,7 +91,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -103,7 +103,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -133,7 +133,7 @@
   "variables": {
     "arch": "32",
     "box_basename": "rhel-5.11-i386",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/rhel/rhel-5.11-x86_64.json
+++ b/packer_templates/rhel/rhel-5.11-x86_64.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -46,7 +46,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -73,7 +73,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -99,7 +99,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -111,7 +111,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -141,6 +141,7 @@
   "variables": {
     "arch": "64",
     "box_basename": "rhel-5.11",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/rhel/rhel-5.11-x86_64.json
+++ b/packer_templates/rhel/rhel-5.11-x86_64.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -46,7 +46,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -73,7 +73,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -99,7 +99,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -111,7 +111,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -141,7 +141,7 @@
   "variables": {
     "arch": "64",
     "box_basename": "rhel-5.11",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/rhel/rhel-6.10-i386.json
+++ b/packer_templates/rhel/rhel-6.10-i386.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -91,7 +91,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -103,7 +103,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -134,6 +134,7 @@
   "variables": {
     "arch": "32",
     "box_basename": "rhel-6.10-i386",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/rhel/rhel-6.10-i386.json
+++ b/packer_templates/rhel/rhel-6.10-i386.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -91,7 +91,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -103,7 +103,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -134,7 +134,7 @@
   "variables": {
     "arch": "32",
     "box_basename": "rhel-6.10-i386",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/rhel/rhel-6.10-x86_64.json
+++ b/packer_templates/rhel/rhel-6.10-x86_64.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -91,7 +91,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -103,7 +103,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -134,7 +134,7 @@
   "variables": {
     "arch": "64",
     "box_basename": "rhel-6.10",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/rhel/rhel-6.10-x86_64.json
+++ b/packer_templates/rhel/rhel-6.10-x86_64.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -91,7 +91,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -103,7 +103,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -134,6 +134,7 @@
   "variables": {
     "arch": "64",
     "box_basename": "rhel-6.10",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/rhel/rhel-7.6-x86_64.json
+++ b/packer_templates/rhel/rhel-7.6-x86_64.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -91,7 +91,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -103,7 +103,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -134,7 +134,7 @@
   "variables": {
     "arch": "64",
     "box_basename": "rhel-7.6",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/rhel/rhel-7.6-x86_64.json
+++ b/packer_templates/rhel/rhel-7.6-x86_64.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -91,7 +91,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -103,7 +103,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -134,6 +134,7 @@
   "variables": {
     "arch": "64",
     "box_basename": "rhel-7.6",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/rhel/rhel-8.0-x86_64.json
+++ b/packer_templates/rhel/rhel-8.0-x86_64.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -91,7 +91,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -103,7 +103,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -134,7 +134,7 @@
   "variables": {
     "arch": "64",
     "box_basename": "rhel-8.0",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/rhel/rhel-8.0-x86_64.json
+++ b/packer_templates/rhel/rhel-8.0-x86_64.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -38,7 +38,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -65,7 +65,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -91,7 +91,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -103,7 +103,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -134,6 +134,7 @@
   "variables": {
     "arch": "64",
     "box_basename": "rhel-8.0",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/scientificlinux/scientific-7.7-x86_64.json
+++ b/packer_templates/scientificlinux/scientific-7.7-x86_64.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -41,7 +41,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -70,7 +70,7 @@
   ],
   "variables": {
     "box_basename": "scientific-7.7",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20080506150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/scientificlinux/scientific-7.7-x86_64.json
+++ b/packer_templates/scientificlinux/scientific-7.7-x86_64.json
@@ -14,7 +14,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -41,7 +41,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -70,6 +70,7 @@
   ],
   "variables": {
     "box_basename": "scientific-7.7",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20080506150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/sles/sles-11-sp4-x86_64.json
+++ b/packer_templates/sles/sles-11-sp4-x86_64.json
@@ -18,7 +18,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -46,7 +46,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -77,7 +77,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -107,7 +107,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -119,7 +119,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -155,7 +155,7 @@
     "arch": "64",
     "autoinst_cfg": "sles-11-sp4-x86_64-autoinst.xml",
     "box_basename": "sles-11-sp4",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/sles/sles-11-sp4-x86_64.json
+++ b/packer_templates/sles/sles-11-sp4-x86_64.json
@@ -18,7 +18,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -46,7 +46,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -77,7 +77,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -107,7 +107,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -119,7 +119,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -155,6 +155,7 @@
     "arch": "64",
     "autoinst_cfg": "sles-11-sp4-x86_64-autoinst.xml",
     "box_basename": "sles-11-sp4",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/sles/sles-12-sp2-x86_64.json
+++ b/packer_templates/sles/sles-12-sp2-x86_64.json
@@ -18,7 +18,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -46,7 +46,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -77,7 +77,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -107,7 +107,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -119,7 +119,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -156,7 +156,7 @@
     "arch": "64",
     "autoinst_cfg": "sles-12-sp2-x86_64-autoinst.xml",
     "box_basename": "sles-12-sp2",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/sles/sles-12-sp2-x86_64.json
+++ b/packer_templates/sles/sles-12-sp2-x86_64.json
@@ -18,7 +18,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -46,7 +46,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -77,7 +77,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -107,7 +107,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -119,7 +119,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -156,6 +156,7 @@
     "arch": "64",
     "autoinst_cfg": "sles-12-sp2-x86_64-autoinst.xml",
     "box_basename": "sles-12-sp2",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/sles/sles-12-sp3-x86_64.json
+++ b/packer_templates/sles/sles-12-sp3-x86_64.json
@@ -18,7 +18,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -46,7 +46,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -77,7 +77,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -107,7 +107,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -119,7 +119,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -156,7 +156,7 @@
     "arch": "64",
     "autoinst_cfg": "sles-12-sp3-x86_64-autoinst.xml",
     "box_basename": "sles-12-sp3",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/sles/sles-12-sp3-x86_64.json
+++ b/packer_templates/sles/sles-12-sp3-x86_64.json
@@ -18,7 +18,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -46,7 +46,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -77,7 +77,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -107,7 +107,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -119,7 +119,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -156,6 +156,7 @@
     "arch": "64",
     "autoinst_cfg": "sles-12-sp3-x86_64-autoinst.xml",
     "box_basename": "sles-12-sp3",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/sles/sles-15-sp1.json
+++ b/packer_templates/sles/sles-15-sp1.json
@@ -18,7 +18,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -62,7 +62,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -93,7 +93,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -123,7 +123,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -135,7 +135,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -172,7 +172,7 @@
     "arch": "64",
     "autoinst_cfg": "sles-15-sp1-x86_64-autoinst.xml",
     "box_basename": "sles-15-sp1",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/sles/sles-15-sp1.json
+++ b/packer_templates/sles/sles-15-sp1.json
@@ -18,7 +18,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -62,7 +62,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -93,7 +93,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -123,7 +123,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -135,7 +135,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -172,6 +172,7 @@
     "arch": "64",
     "autoinst_cfg": "sles-15-sp1-x86_64-autoinst.xml",
     "box_basename": "sles-15-sp1",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/sles/sles-15.json
+++ b/packer_templates/sles/sles-15.json
@@ -18,7 +18,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -62,7 +62,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -93,7 +93,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -123,7 +123,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -135,7 +135,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -172,6 +172,7 @@
     "arch": "64",
     "autoinst_cfg": "sles-15-x86_64-autoinst.xml",
     "box_basename": "sles-15",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/sles/sles-15.json
+++ b/packer_templates/sles/sles-15.json
@@ -18,7 +18,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -62,7 +62,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -93,7 +93,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -123,7 +123,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -135,7 +135,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -172,7 +172,7 @@
     "arch": "64",
     "autoinst_cfg": "sles-15-x86_64-autoinst.xml",
     "box_basename": "sles-15",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/solaris/solaris-10.11-x86.json
+++ b/packer_templates/solaris/solaris-10.11-x86.json
@@ -85,7 +85,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -106,6 +106,7 @@
     "_README": "You must download the automated installer iso from the following page, and then place it somewhere that packer can fetch it",
     "arch": "64",
     "box_basename": "solaris-10.11",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/solaris/solaris-10.11-x86.json
+++ b/packer_templates/solaris/solaris-10.11-x86.json
@@ -85,7 +85,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -106,7 +106,7 @@
     "_README": "You must download the automated installer iso from the following page, and then place it somewhere that packer can fetch it",
     "arch": "64",
     "box_basename": "solaris-10.11",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/solaris/solaris-11-x86.json
+++ b/packer_templates/solaris/solaris-11-x86.json
@@ -105,7 +105,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -128,6 +128,7 @@
     "_README": "You must download the automated installer iso from the following page, and then place it in the packer_cache dir",
     "arch": "64",
     "box_basename": "solaris-11.3",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/solaris/solaris-11-x86.json
+++ b/packer_templates/solaris/solaris-11-x86.json
@@ -105,7 +105,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -128,7 +128,7 @@
     "_README": "You must download the automated installer iso from the following page, and then place it in the packer_cache dir",
     "arch": "64",
     "box_basename": "solaris-11.3",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/ubuntu/ubuntu-16.04-amd64.json
+++ b/packer_templates/ubuntu/ubuntu-16.04-amd64.json
@@ -37,7 +37,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -84,7 +84,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -135,7 +135,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -182,7 +182,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
@@ -218,7 +218,7 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "memory": "{{user `memory`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-hyperv",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-hyperv",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -231,7 +231,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -264,7 +264,7 @@
   ],
   "variables": {
     "box_basename": "ubuntu-16.04",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/ubuntu/ubuntu-16.04-amd64.json
+++ b/packer_templates/ubuntu/ubuntu-16.04-amd64.json
@@ -37,7 +37,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -84,7 +84,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -135,7 +135,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -182,7 +182,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
       "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
@@ -218,7 +218,7 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "memory": "{{user `memory`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-hyperv",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-hyperv",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -231,7 +231,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -264,6 +264,7 @@
   ],
   "variables": {
     "box_basename": "ubuntu-16.04",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/ubuntu/ubuntu-16.04-i386.json
+++ b/packer_templates/ubuntu/ubuntu-16.04-i386.json
@@ -37,7 +37,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -84,7 +84,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -134,7 +134,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -181,7 +181,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
@@ -195,7 +195,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -227,6 +227,7 @@
   ],
   "variables": {
     "box_basename": "ubuntu-16.04-i386",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/ubuntu/ubuntu-16.04-i386.json
+++ b/packer_templates/ubuntu/ubuntu-16.04-i386.json
@@ -37,7 +37,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -84,7 +84,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -134,7 +134,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -181,7 +181,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
@@ -195,7 +195,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -227,7 +227,7 @@
   ],
   "variables": {
     "box_basename": "ubuntu-16.04-i386",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/ubuntu/ubuntu-18.04-amd64.json
+++ b/packer_templates/ubuntu/ubuntu-18.04-amd64.json
@@ -36,7 +36,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -82,7 +82,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -132,7 +132,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -178,7 +178,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
@@ -214,7 +214,7 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "memory": "{{user `memory`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-hyperv",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-hyperv",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -227,7 +227,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -260,6 +260,7 @@
   ],
   "variables": {
     "box_basename": "ubuntu-18.04",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/ubuntu/ubuntu-18.04-amd64.json
+++ b/packer_templates/ubuntu/ubuntu-18.04-amd64.json
@@ -36,7 +36,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -82,7 +82,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -132,7 +132,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -178,7 +178,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
@@ -214,7 +214,7 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "memory": "{{user `memory`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-hyperv",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-hyperv",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -227,7 +227,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -260,7 +260,7 @@
   ],
   "variables": {
     "box_basename": "ubuntu-18.04",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/ubuntu/ubuntu-18.10-amd64.json
+++ b/packer_templates/ubuntu/ubuntu-18.10-amd64.json
@@ -36,7 +36,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -82,7 +82,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -132,7 +132,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -178,7 +178,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
@@ -214,7 +214,7 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "memory": "{{user `memory`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-hyperv",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-hyperv",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -227,7 +227,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -260,6 +260,7 @@
   ],
   "variables": {
     "box_basename": "ubuntu-18.10",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/ubuntu/ubuntu-18.10-amd64.json
+++ b/packer_templates/ubuntu/ubuntu-18.10-amd64.json
@@ -36,7 +36,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -82,7 +82,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -132,7 +132,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -178,7 +178,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
@@ -214,7 +214,7 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "memory": "{{user `memory`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-hyperv",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-hyperv",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -227,7 +227,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -260,7 +260,7 @@
   ],
   "variables": {
     "box_basename": "ubuntu-18.10",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/ubuntu/ubuntu-19.04-amd64.json
+++ b/packer_templates/ubuntu/ubuntu-19.04-amd64.json
@@ -36,7 +36,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -82,7 +82,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -132,7 +132,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -178,7 +178,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
@@ -214,7 +214,7 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "memory": "{{user `memory`}}",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-hyperv",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-hyperv",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -227,7 +227,7 @@
   ],
   "post-processors": [
     {
-      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -260,7 +260,7 @@
   ],
   "variables": {
     "box_basename": "ubuntu-19.04",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/ubuntu/ubuntu-19.04-amd64.json
+++ b/packer_templates/ubuntu/ubuntu-19.04-amd64.json
@@ -36,7 +36,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -82,7 +82,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -132,7 +132,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-parallels",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-parallels",
       "parallels_tools_flavor": "lin",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
@@ -178,7 +178,7 @@
       "iso_checksum": "{{user `iso_checksum`}}",
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-qemu",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-qemu",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
@@ -214,7 +214,7 @@
       "iso_checksum_type": "{{user `iso_checksum_type`}}",
       "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
       "memory": "{{user `memory`}}",
-      "output_directory": "../../builds/packer-{{user `template`}}-hyperv",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-hyperv",
       "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -227,7 +227,7 @@
   ],
   "post-processors": [
     {
-      "output": "../../builds/{{user `box_basename`}}.{{.Provider}}.box",
+      "output": "{{ user `builddir` }}/{{user `box_basename`}}.{{.Provider}}.box",
       "type": "vagrant"
     }
   ],
@@ -260,6 +260,7 @@
   ],
   "variables": {
     "box_basename": "ubuntu-19.04",
+    "builddir": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
     "disk_size": "65536",

--- a/packer_templates/windows/windows-10.json
+++ b/packer_templates/windows/windows-10.json
@@ -15,7 +15,7 @@
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_checksum_type": "sha1",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "communicator": "winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -37,7 +37,7 @@
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_checksum_type": "sha1",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "communicator": "winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -112,7 +112,7 @@
     "headless": "true",
     "iso_checksum": "743fc483bb8bf1901c0534a0ae15208a5a72a3c5",
     "iso_url": "https://software-download.microsoft.com/download/pr/18362.30.190401-1528.19h1_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "template": "windows-10"
   }
 }

--- a/packer_templates/windows/windows-10.json
+++ b/packer_templates/windows/windows-10.json
@@ -15,7 +15,7 @@
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_checksum_type": "sha1",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "communicator": "winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -37,7 +37,7 @@
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_checksum_type": "sha1",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "communicator": "winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -112,6 +112,7 @@
     "headless": "true",
     "iso_checksum": "743fc483bb8bf1901c0534a0ae15208a5a72a3c5",
     "iso_url": "https://software-download.microsoft.com/download/pr/18362.30.190401-1528.19h1_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
+    "builddir": "../../builds",
     "template": "windows-10"
   }
 }

--- a/packer_templates/windows/windows-2008r2.json
+++ b/packer_templates/windows/windows-2008r2.json
@@ -13,7 +13,7 @@
     "iso_url": "{{ user `iso_url` }}",
     "iso_checksum": "{{ user `iso_checksum` }}",
     "iso_checksum_type": "sha1",
-    "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+    "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
     "communicator": "winrm",
     "winrm_username": "vagrant",
     "winrm_password": "vagrant",
@@ -78,7 +78,7 @@
     "headless": "false",
     "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
     "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "template": "windows-2008r2-standard"
   }
 }

--- a/packer_templates/windows/windows-2008r2.json
+++ b/packer_templates/windows/windows-2008r2.json
@@ -13,7 +13,7 @@
     "iso_url": "{{ user `iso_url` }}",
     "iso_checksum": "{{ user `iso_checksum` }}",
     "iso_checksum_type": "sha1",
-    "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+    "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
     "communicator": "winrm",
     "winrm_username": "vagrant",
     "winrm_password": "vagrant",
@@ -78,6 +78,7 @@
     "headless": "false",
     "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
     "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
+    "builddir": "../../builds",
     "template": "windows-2008r2-standard"
   }
 }

--- a/packer_templates/windows/windows-2012r2.json
+++ b/packer_templates/windows/windows-2012r2.json
@@ -13,7 +13,7 @@
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_checksum_type": "sha1",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "communicator": "winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -34,7 +34,7 @@
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_checksum_type": "sha1",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "communicator": "winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -107,7 +107,7 @@
     "headless": "true",
     "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
     "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "template": "windows-2012r2-standard"
   }
 }

--- a/packer_templates/windows/windows-2012r2.json
+++ b/packer_templates/windows/windows-2012r2.json
@@ -13,7 +13,7 @@
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_checksum_type": "sha1",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "communicator": "winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -34,7 +34,7 @@
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_checksum_type": "sha1",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "communicator": "winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -107,6 +107,7 @@
     "headless": "true",
     "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
     "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+    "builddir": "../../builds",
     "template": "windows-2012r2-standard"
   }
 }

--- a/packer_templates/windows/windows-2016.json
+++ b/packer_templates/windows/windows-2016.json
@@ -13,7 +13,7 @@
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_checksum_type": "sha1",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "communicator": "winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -34,7 +34,7 @@
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_checksum_type": "sha1",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "communicator": "winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -107,7 +107,7 @@
     "headless": "true",
     "iso_checksum": "772700802951b36c8cb26a61c040b9a8dc3816a3",
     "iso_url": "https://software-download.microsoft.com/download/pr/Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "template": "windows-2016-standard"
   }
 }

--- a/packer_templates/windows/windows-2016.json
+++ b/packer_templates/windows/windows-2016.json
@@ -13,7 +13,7 @@
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_checksum_type": "sha1",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "communicator": "winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -34,7 +34,7 @@
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_checksum_type": "sha1",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "communicator": "winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -107,6 +107,7 @@
     "headless": "true",
     "iso_checksum": "772700802951b36c8cb26a61c040b9a8dc3816a3",
     "iso_url": "https://software-download.microsoft.com/download/pr/Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO",
+    "builddir": "../../builds",
     "template": "windows-2016-standard"
   }
 }

--- a/packer_templates/windows/windows-2019.json
+++ b/packer_templates/windows/windows-2019.json
@@ -13,7 +13,7 @@
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_checksum_type": "sha1",
-      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
       "communicator": "winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -34,7 +34,7 @@
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_checksum_type": "sha1",
-      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
       "communicator": "winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -107,6 +107,7 @@
     "headless": "true",
     "iso_checksum": "91e3a2f1acc39af21353c7cc105c799494d7539f",
     "iso_url": "https://software-download.microsoft.com/download/sg/17763.253.190108-0006.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",
+    "builddir": "../../builds",
     "template": "windows-2019-standard"
   }
 }

--- a/packer_templates/windows/windows-2019.json
+++ b/packer_templates/windows/windows-2019.json
@@ -13,7 +13,7 @@
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_checksum_type": "sha1",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
       "communicator": "winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -34,7 +34,7 @@
       "iso_url": "{{ user `iso_url` }}",
       "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_checksum_type": "sha1",
-      "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-vmware",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
       "communicator": "winrm",
       "winrm_username": "vagrant",
       "winrm_password": "vagrant",
@@ -107,7 +107,7 @@
     "headless": "true",
     "iso_checksum": "91e3a2f1acc39af21353c7cc105c799494d7539f",
     "iso_url": "https://software-download.microsoft.com/download/sg/17763.253.190108-0006.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "template": "windows-2019-standard"
   }
 }

--- a/packer_templates/windows/windows-7.json
+++ b/packer_templates/windows/windows-7.json
@@ -13,7 +13,7 @@
     "iso_url": "{{ user `iso_url` }}",
     "iso_checksum": "{{ user `iso_checksum` }}",
     "iso_checksum_type": "sha1",
-    "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+    "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
     "communicator": "winrm",
     "winrm_username": "vagrant",
     "winrm_password": "vagrant",
@@ -85,6 +85,7 @@
     "headless": "false",
     "iso_checksum": "971fc00183a52c152fe924a6b99fdec011a871c2",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x86/EN/7600.16385.090713-1255_x86fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENEVAL_EN_DVD.iso",
+    "builddir": "../../builds",
     "template": "windows-7"
   }
 }

--- a/packer_templates/windows/windows-7.json
+++ b/packer_templates/windows/windows-7.json
@@ -13,7 +13,7 @@
     "iso_url": "{{ user `iso_url` }}",
     "iso_checksum": "{{ user `iso_checksum` }}",
     "iso_checksum_type": "sha1",
-    "output_directory": "{{ user `builddir` }}/packer-{{user `template`}}-virtualbox",
+    "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
     "communicator": "winrm",
     "winrm_username": "vagrant",
     "winrm_password": "vagrant",
@@ -85,7 +85,7 @@
     "headless": "false",
     "iso_checksum": "971fc00183a52c152fe924a6b99fdec011a871c2",
     "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x86/EN/7600.16385.090713-1255_x86fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENEVAL_EN_DVD.iso",
-    "builddir": "../../builds",
+    "build_directory": "../../builds",
     "template": "windows-7"
   }
 }


### PR DESCRIPTION
## Description
This updates the "output_directory" option for the builders and the "output" option in the post-processor to use a user-variable named "build_directory" when determining the path. This allows the person building to customize the directory that the vagrant box will be dropped into by specifying said user-variable. The default value for the "build_directory" user-variable is set to "../../builds" so that things should work the same way as before.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
