### PR TITLE
Updated windows templates to replace scsi settings applied by "vmx_data" with the "disk_adapter_type" option in order to clean up validation warnings

### DIFF
--- a/packer_templates/windows/windows-10.json
+++ b/packer_templates/windows/windows-10.json
@@ -1,117 +1,117 @@
 {
-	"builders": [{
-			"type": "virtualbox-iso",
-			"vboxmanage": [
-				["modifyvm", "{{.Name}}", "--vram", "48"],
-				["modifyvm", "{{.Name}}", "--audio", "none"]
-			],
-			"memory": "{{ user `memory` }}",
-			"cpus": "{{ user `cpus` }}",
-			"guest_additions_mode": "{{ user `guest_additions_mode` }}",
-			"guest_additions_path": "C:/users/vagrant/VBoxGuestAdditions.iso",
-			"guest_os_type": "Windows10_64",
-			"hard_drive_interface": "sata",
-			"headless": "{{ user `headless` }}",
-			"iso_url": "{{ user `iso_url` }}",
-			"iso_checksum": "{{ user `iso_checksum` }}",
-			"iso_checksum_type": "sha1",
-			"output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
-			"communicator": "winrm",
-			"winrm_username": "vagrant",
-			"winrm_password": "vagrant",
-			"winrm_timeout": "12h",
-			"shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
-			"shutdown_timeout": "15m",
-			"floppy_files": [
-				"answer_files/10/Autounattend.xml",
-				"scripts/base_setup.ps1"
-			]
-		},
-		{
-			"type": "vmware-iso",
-			"memory": "{{ user `memory` }}",
-			"cpus": "{{ user `cpus` }}",
-			"disk_adapter_type": "lsisas1068",
-			"guest_os_type": "windows9srv-64",
-			"headless": "{{ user `headless` }}",
-			"iso_url": "{{ user `iso_url` }}",
-			"iso_checksum": "{{ user `iso_checksum` }}",
-			"iso_checksum_type": "sha1",
-			"output_directory": "../../builds/packer-{{user `template`}}-vmware",
-			"communicator": "winrm",
-			"winrm_username": "vagrant",
-			"winrm_password": "vagrant",
-			"winrm_timeout": "12h",
-			"shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
-			"shutdown_timeout": "15m",
-			"floppy_files": [
-				"answer_files/10/Autounattend.xml"
-			]
-		}
-	],
-	"provisioners": [{
-			"type": "chef-solo",
-			"cookbook_paths": ["cookbooks"],
-			"guest_os_type": "windows",
-			"run_list": [
-				"packer::disable_uac",
-				"packer::disable_onedrive",
-				"packer::disable_restore",
-				"packer::disable_hibernation",
-				"packer::disable_windows_update",
-				"packer::remove_defender"
-			]
-		},
-		{
-			"type": "windows-restart"
-		},
-		{
-			"type": "chef-solo",
-			"cookbook_paths": ["cookbooks"],
-			"guest_os_type": "windows",
-			"run_list": [
-				"packer::vm_tools",
-				"packer::features",
-				"packer::enable_file_sharing",
-				"packer::enable_remote_desktop",
-				"packer::ui_tweaks",
-				"packer::power"
-			]
-		},
-		{
-			"type": "windows-restart"
-		},
-		{
-			"type": "chef-solo",
-			"cookbook_paths": ["cookbooks"],
-			"guest_os_type": "windows",
-			"run_list": [
-				"packer::cleanup",
-				"packer::defrag"
-			]
-		},
-		{
-			"type": "powershell",
-			"script": "scripts/cleanup.ps1",
-			"elevated_user": "vagrant",
-			"elevated_password": "vagrant"
-		}
-	],
-	"post-processors": [
-		[{
-			"type": "vagrant",
-			"keep_input_artifact": true,
-			"output": "{{ user `template` }}-{{.Provider}}.box",
-			"vagrantfile_template": "vagrantfile-windows.template"
-		}]
-	],
-	"variables": {
-		"memory": "4096",
-		"cpus": "2",
-		"guest_additions_mode": "attach",
-		"headless": "true",
-		"iso_checksum": "743fc483bb8bf1901c0534a0ae15208a5a72a3c5",
-		"iso_url": "https://software-download.microsoft.com/download/pr/18362.30.190401-1528.19h1_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
-		"template": "windows-10"
-	}
+  "builders": [{
+      "type": "virtualbox-iso",
+      "vboxmanage": [
+        ["modifyvm", "{{.Name}}", "--vram", "48"],
+        ["modifyvm", "{{.Name}}", "--audio", "none"]
+      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
+      "guest_additions_mode": "{{ user `guest_additions_mode` }}",
+      "guest_additions_path": "C:/users/vagrant/VBoxGuestAdditions.iso",
+      "guest_os_type": "Windows10_64",
+      "hard_drive_interface": "sata",
+      "headless": "{{ user `headless` }}",
+      "iso_url": "{{ user `iso_url` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "communicator": "winrm",
+      "winrm_username": "vagrant",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "12h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "shutdown_timeout": "15m",
+      "floppy_files": [
+        "answer_files/10/Autounattend.xml",
+        "scripts/base_setup.ps1"
+      ]
+    },
+    {
+      "type": "vmware-iso",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
+      "disk_adapter_type": "lsisas1068",
+      "guest_os_type": "windows9srv-64",
+      "headless": "{{ user `headless` }}",
+      "iso_url": "{{ user `iso_url` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "communicator": "winrm",
+      "winrm_username": "vagrant",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "12h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "shutdown_timeout": "15m",
+      "floppy_files": [
+        "answer_files/10/Autounattend.xml"
+      ]
+    }
+  ],
+  "provisioners": [{
+      "type": "chef-solo",
+      "cookbook_paths": ["cookbooks"],
+      "guest_os_type": "windows",
+      "run_list": [
+        "packer::disable_uac",
+        "packer::disable_onedrive",
+        "packer::disable_restore",
+        "packer::disable_hibernation",
+        "packer::disable_windows_update",
+        "packer::remove_defender"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "chef-solo",
+      "cookbook_paths": ["cookbooks"],
+      "guest_os_type": "windows",
+      "run_list": [
+        "packer::vm_tools",
+        "packer::features",
+        "packer::enable_file_sharing",
+        "packer::enable_remote_desktop",
+        "packer::ui_tweaks",
+        "packer::power"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "chef-solo",
+      "cookbook_paths": ["cookbooks"],
+      "guest_os_type": "windows",
+      "run_list": [
+        "packer::cleanup",
+        "packer::defrag"
+      ]
+    },
+    {
+      "type": "powershell",
+      "script": "scripts/cleanup.ps1",
+      "elevated_user": "vagrant",
+      "elevated_password": "vagrant"
+    }
+  ],
+  "post-processors": [
+    [{
+      "type": "vagrant",
+      "keep_input_artifact": true,
+      "output": "{{ user `template` }}-{{.Provider}}.box",
+      "vagrantfile_template": "vagrantfile-windows.template"
+    }]
+  ],
+  "variables": {
+    "memory": "4096",
+    "cpus": "2",
+    "guest_additions_mode": "attach",
+    "headless": "true",
+    "iso_checksum": "743fc483bb8bf1901c0534a0ae15208a5a72a3c5",
+    "iso_url": "https://software-download.microsoft.com/download/pr/18362.30.190401-1528.19h1_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
+    "template": "windows-10"
+  }
 }

--- a/packer_templates/windows/windows-10.json
+++ b/packer_templates/windows/windows-10.json
@@ -29,12 +29,9 @@
 		},
 		{
 			"type": "vmware-iso",
-			"vmx_data": {
-				"scsi0.virtualDev": "lsisas1068",
-				"scsi0.present": "TRUE"
-			},
 			"memory": "{{ user `memory` }}",
 			"cpus": "{{ user `cpus` }}",
+			"disk_adapter_type": "lsisas1068",
 			"guest_os_type": "windows9srv-64",
 			"headless": "{{ user `headless` }}",
 			"iso_url": "{{ user `iso_url` }}",

--- a/packer_templates/windows/windows-2008r2.json
+++ b/packer_templates/windows/windows-2008r2.json
@@ -1,83 +1,83 @@
 {
-	"builders": [{
-		"type": "virtualbox-iso",
-		"vboxmanage": [
-			["modifyvm", "{{.Name}}", "--vram", "48"]
-		],
-		"memory": "{{ user `memory` }}",
-		"cpus": "{{ user `cpus` }}",
-		"guest_additions_mode": "{{ user `guest_additions_mode` }}",
-		"guest_additions_path": "C:/users/vagrant/VBoxGuestAdditions.iso",
-		"guest_os_type": "Windows2008_64",
-		"headless": "{{ user `headless` }}",
-		"iso_url": "{{ user `iso_url` }}",
-		"iso_checksum": "{{ user `iso_checksum` }}",
-		"iso_checksum_type": "sha1",
-		"output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
-		"communicator": "winrm",
-		"winrm_username": "vagrant",
-		"winrm_password": "vagrant",
-		"winrm_timeout": "12h",
-		"shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
-		"shutdown_timeout": "15m",
-		"floppy_files": [
-			"answer_files/2008_r2/Autounattend.xml"
-		]
-	}],
-	"provisioners": [{
-			"type": "chef-solo",
-			"cookbook_paths": ["cookbooks"],
-			"guest_os_type": "windows",
-			"install_command": "powershell.exe -Command \"(new-object Net.WebClient).DownloadString('https://omnitruck.chef.io/install.ps1') | iex; install\"",
-			"run_list": [
-				"packer::disable_uac",
-				"packer::disable_restore",
-				"packer::disable_windows_update",
-				"packer::vm_tools",
-				"packer::features",
-				"packer::enable_file_sharing",
-				"packer::enable_remote_desktop",
-				"packer::ui_tweaks",
-				"packer::power",
-				"packer::updates"
-			]
-		},
-		{
-			"type": "windows-restart"
-		},
-		{
-			"type": "chef-solo",
-			"cookbook_paths": ["cookbooks"],
-			"guest_os_type": "windows",
-			"install_command": "powershell.exe -Command \"(new-object Net.WebClient).DownloadString('https://omnitruck.chef.io/install.ps1') | iex; install\"",
-			"run_list": [
-				"packer::disable_uac",
-				"packer::cleanup",
-				"packer::defrag"
-			]
-		},
-		{
-			"type": "powershell",
-			"script": "scripts/cleanup.ps1",
-			"elevated_user": "vagrant",
-			"elevated_password": "vagrant"
-		}
-	],
-	"post-processors": [
-		[{
-			"type": "vagrant",
-			"keep_input_artifact": true,
-			"output": "{{ user `template` }}-{{.Provider}}.box",
-			"vagrantfile_template": "vagrantfile-windows.template"
-		}]
-	],
-	"variables": {
-		"memory": "4096",
-		"cpus": "2",
-		"guest_additions_mode": "attach",
-		"headless": "false",
-		"iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
-		"iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
-		"template": "windows-2008r2-standard"
-	}
+  "builders": [{
+    "type": "virtualbox-iso",
+    "vboxmanage": [
+      ["modifyvm", "{{.Name}}", "--vram", "48"]
+    ],
+    "memory": "{{ user `memory` }}",
+    "cpus": "{{ user `cpus` }}",
+    "guest_additions_mode": "{{ user `guest_additions_mode` }}",
+    "guest_additions_path": "C:/users/vagrant/VBoxGuestAdditions.iso",
+    "guest_os_type": "Windows2008_64",
+    "headless": "{{ user `headless` }}",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+    "communicator": "winrm",
+    "winrm_username": "vagrant",
+    "winrm_password": "vagrant",
+    "winrm_timeout": "12h",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_timeout": "15m",
+    "floppy_files": [
+      "answer_files/2008_r2/Autounattend.xml"
+    ]
+  }],
+  "provisioners": [{
+      "type": "chef-solo",
+      "cookbook_paths": ["cookbooks"],
+      "guest_os_type": "windows",
+      "install_command": "powershell.exe -Command \"(new-object Net.WebClient).DownloadString('https://omnitruck.chef.io/install.ps1') | iex; install\"",
+      "run_list": [
+        "packer::disable_uac",
+        "packer::disable_restore",
+        "packer::disable_windows_update",
+        "packer::vm_tools",
+        "packer::features",
+        "packer::enable_file_sharing",
+        "packer::enable_remote_desktop",
+        "packer::ui_tweaks",
+        "packer::power",
+        "packer::updates"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "chef-solo",
+      "cookbook_paths": ["cookbooks"],
+      "guest_os_type": "windows",
+      "install_command": "powershell.exe -Command \"(new-object Net.WebClient).DownloadString('https://omnitruck.chef.io/install.ps1') | iex; install\"",
+      "run_list": [
+        "packer::disable_uac",
+        "packer::cleanup",
+        "packer::defrag"
+      ]
+    },
+    {
+      "type": "powershell",
+      "script": "scripts/cleanup.ps1",
+      "elevated_user": "vagrant",
+      "elevated_password": "vagrant"
+    }
+  ],
+  "post-processors": [
+    [{
+      "type": "vagrant",
+      "keep_input_artifact": true,
+      "output": "{{ user `template` }}-{{.Provider}}.box",
+      "vagrantfile_template": "vagrantfile-windows.template"
+    }]
+  ],
+  "variables": {
+    "memory": "4096",
+    "cpus": "2",
+    "guest_additions_mode": "attach",
+    "headless": "false",
+    "iso_checksum": "beed231a34e90e1dd9a04b3afabec31d62ce3889",
+    "iso_url": "http://download.microsoft.com/download/7/5/E/75EC4E54-5B02-42D6-8879-D8D3A25FBEF7/7601.17514.101119-1850_x64fre_server_eval_en-us-GRMSXEVAL_EN_DVD.iso",
+    "template": "windows-2008r2-standard"
+  }
 }

--- a/packer_templates/windows/windows-2012r2.json
+++ b/packer_templates/windows/windows-2012r2.json
@@ -26,12 +26,9 @@
 		},
 		{
 			"type": "vmware-iso",
-			"vmx_data": {
-				"scsi0.virtualDev": "lsisas1068",
-				"scsi0.present": "TRUE"
-			},
 			"memory": "{{ user `memory` }}",
 			"cpus": "{{ user `cpus` }}",
+			"disk_adapter_type": "lsisas1068",
 			"guest_os_type": "windows9srv-64",
 			"headless": "{{ user `headless` }}",
 			"iso_url": "{{ user `iso_url` }}",

--- a/packer_templates/windows/windows-2012r2.json
+++ b/packer_templates/windows/windows-2012r2.json
@@ -1,112 +1,112 @@
 {
-	"builders": [{
-			"type": "virtualbox-iso",
-			"vboxmanage": [
-				["modifyvm", "{{.Name}}", "--vram", "48"]
-			],
-			"memory": "{{ user `memory` }}",
-			"cpus": "{{ user `cpus` }}",
-			"guest_additions_mode": "{{ user `guest_additions_mode` }}",
-			"guest_additions_path": "C:/users/vagrant/VBoxGuestAdditions.iso",
-			"guest_os_type": "Windows2012_64",
-			"headless": "{{ user `headless` }}",
-			"iso_url": "{{ user `iso_url` }}",
-			"iso_checksum": "{{ user `iso_checksum` }}",
-			"iso_checksum_type": "sha1",
-			"output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
-			"communicator": "winrm",
-			"winrm_username": "vagrant",
-			"winrm_password": "vagrant",
-			"winrm_timeout": "12h",
-			"shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
-			"shutdown_timeout": "15m",
-			"floppy_files": [
-				"answer_files/2012_r2/Autounattend.xml"
-			]
-		},
-		{
-			"type": "vmware-iso",
-			"memory": "{{ user `memory` }}",
-			"cpus": "{{ user `cpus` }}",
-			"disk_adapter_type": "lsisas1068",
-			"guest_os_type": "windows9srv-64",
-			"headless": "{{ user `headless` }}",
-			"iso_url": "{{ user `iso_url` }}",
-			"iso_checksum": "{{ user `iso_checksum` }}",
-			"iso_checksum_type": "sha1",
-			"output_directory": "../../builds/packer-{{user `template`}}-vmware",
-			"communicator": "winrm",
-			"winrm_username": "vagrant",
-			"winrm_password": "vagrant",
-			"winrm_timeout": "12h",
-			"shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
-			"shutdown_timeout": "15m",
-			"floppy_files": [
-				"answer_files/2012_r2/Autounattend.xml"
-			]
-		}
-	],
-	"provisioners": [{
-			"type": "chef-solo",
-			"cookbook_paths": ["cookbooks"],
-			"guest_os_type": "windows",
-			"run_list": [
-				"packer::disable_uac",
-				"packer::disable_restore",
-				"packer::disable_windows_update",
-				"packer::remove_defender"
-			]
-		},
-		{
-			"type": "windows-restart"
-		},
-		{
-			"type": "chef-solo",
-			"cookbook_paths": ["cookbooks"],
-			"guest_os_type": "windows",
-			"run_list": [
-				"packer::vm_tools",
-				"packer::features",
-				"packer::enable_file_sharing",
-				"packer::enable_remote_desktop",
-				"packer::ui_tweaks",
-				"packer::power"
-			]
-		},
-		{
-			"type": "windows-restart"
-		},
-		{
-			"type": "chef-solo",
-			"cookbook_paths": ["cookbooks"],
-			"guest_os_type": "windows",
-			"run_list": [
-				"packer::cleanup",
-				"packer::defrag"
-			]
-		},
-		{
-			"type": "powershell",
-			"script": "scripts/cleanup.ps1",
-			"elevated_user": "vagrant",
-			"elevated_password": "vagrant"
-		}
-	],
-	"post-processors": [
-		[{
-			"type": "vagrant",
-			"keep_input_artifact": true,
-			"output": "{{ user `template` }}-{{.Provider}}.box",
-			"vagrantfile_template": "vagrantfile-windows.template"
-		}]
-	],
-	"variables": {
-		"cpus": "2",
-		"memory": "4096",
-		"guest_additions_mode": "attach",
-		"headless": "true",
-		"iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
-		"iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
-		"template": "windows-2012r2-standard"
-	}
+  "builders": [{
+      "type": "virtualbox-iso",
+      "vboxmanage": [
+        ["modifyvm", "{{.Name}}", "--vram", "48"]
+      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
+      "guest_additions_mode": "{{ user `guest_additions_mode` }}",
+      "guest_additions_path": "C:/users/vagrant/VBoxGuestAdditions.iso",
+      "guest_os_type": "Windows2012_64",
+      "headless": "{{ user `headless` }}",
+      "iso_url": "{{ user `iso_url` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "communicator": "winrm",
+      "winrm_username": "vagrant",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "12h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "shutdown_timeout": "15m",
+      "floppy_files": [
+        "answer_files/2012_r2/Autounattend.xml"
+      ]
+    },
+    {
+      "type": "vmware-iso",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
+      "disk_adapter_type": "lsisas1068",
+      "guest_os_type": "windows9srv-64",
+      "headless": "{{ user `headless` }}",
+      "iso_url": "{{ user `iso_url` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "communicator": "winrm",
+      "winrm_username": "vagrant",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "12h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "shutdown_timeout": "15m",
+      "floppy_files": [
+        "answer_files/2012_r2/Autounattend.xml"
+      ]
+    }
+  ],
+  "provisioners": [{
+      "type": "chef-solo",
+      "cookbook_paths": ["cookbooks"],
+      "guest_os_type": "windows",
+      "run_list": [
+        "packer::disable_uac",
+        "packer::disable_restore",
+        "packer::disable_windows_update",
+        "packer::remove_defender"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "chef-solo",
+      "cookbook_paths": ["cookbooks"],
+      "guest_os_type": "windows",
+      "run_list": [
+        "packer::vm_tools",
+        "packer::features",
+        "packer::enable_file_sharing",
+        "packer::enable_remote_desktop",
+        "packer::ui_tweaks",
+        "packer::power"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "chef-solo",
+      "cookbook_paths": ["cookbooks"],
+      "guest_os_type": "windows",
+      "run_list": [
+        "packer::cleanup",
+        "packer::defrag"
+      ]
+    },
+    {
+      "type": "powershell",
+      "script": "scripts/cleanup.ps1",
+      "elevated_user": "vagrant",
+      "elevated_password": "vagrant"
+    }
+  ],
+  "post-processors": [
+    [{
+      "type": "vagrant",
+      "keep_input_artifact": true,
+      "output": "{{ user `template` }}-{{.Provider}}.box",
+      "vagrantfile_template": "vagrantfile-windows.template"
+    }]
+  ],
+  "variables": {
+    "cpus": "2",
+    "memory": "4096",
+    "guest_additions_mode": "attach",
+    "headless": "true",
+    "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
+    "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
+    "template": "windows-2012r2-standard"
+  }
 }

--- a/packer_templates/windows/windows-2016.json
+++ b/packer_templates/windows/windows-2016.json
@@ -1,112 +1,112 @@
 {
-	"builders": [{
-			"type": "virtualbox-iso",
-			"vboxmanage": [
-				["modifyvm", "{{.Name}}", "--vram", "48"]
-			],
-			"memory": "{{ user `memory` }}",
-			"cpus": "{{ user `cpus` }}",
-			"guest_additions_mode": "{{ user `guest_additions_mode` }}",
-			"guest_additions_path": "C:/users/vagrant/VBoxGuestAdditions.iso",
-			"guest_os_type": "Windows2016_64",
-			"headless": "{{ user `headless` }}",
-			"iso_url": "{{ user `iso_url` }}",
-			"iso_checksum": "{{ user `iso_checksum` }}",
-			"iso_checksum_type": "sha1",
-			"output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
-			"communicator": "winrm",
-			"winrm_username": "vagrant",
-			"winrm_password": "vagrant",
-			"winrm_timeout": "12h",
-			"shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
-			"shutdown_timeout": "15m",
-			"floppy_files": [
-				"answer_files/2016/Autounattend.xml"
-			]
-		},
-		{
-			"type": "vmware-iso",
-			"memory": "{{ user `memory` }}",
-			"cpus": "{{ user `cpus` }}",
-			"disk_adapter_type": "lsisas1068",
-			"guest_os_type": "windows9srv-64",
-			"headless": "{{ user `headless` }}",
-			"iso_url": "{{ user `iso_url` }}",
-			"iso_checksum": "{{ user `iso_checksum` }}",
-			"iso_checksum_type": "sha1",
-			"output_directory": "../../builds/packer-{{user `template`}}-vmware",
-			"communicator": "winrm",
-			"winrm_username": "vagrant",
-			"winrm_password": "vagrant",
-			"winrm_timeout": "12h",
-			"shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
-			"shutdown_timeout": "15m",
-			"floppy_files": [
-				"answer_files/2016/Autounattend.xml"
-			]
-		}
-	],
-	"provisioners": [{
-			"type": "chef-solo",
-			"cookbook_paths": ["cookbooks"],
-			"guest_os_type": "windows",
-			"run_list": [
-				"packer::disable_uac",
-				"packer::disable_restore",
-				"packer::disable_windows_update",
-				"packer::remove_defender"
-			]
-		},
-		{
-			"type": "windows-restart"
-		},
-		{
-			"type": "chef-solo",
-			"cookbook_paths": ["cookbooks"],
-			"guest_os_type": "windows",
-			"run_list": [
-				"packer::vm_tools",
-				"packer::features",
-				"packer::enable_file_sharing",
-				"packer::enable_remote_desktop",
-				"packer::ui_tweaks",
-				"packer::power"
-			]
-		},
-		{
-			"type": "windows-restart"
-		},
-		{
-			"type": "chef-solo",
-			"cookbook_paths": ["cookbooks"],
-			"guest_os_type": "windows",
-			"run_list": [
-				"packer::cleanup",
-				"packer::defrag"
-			]
-		},
-		{
-			"type": "powershell",
-			"script": "scripts/cleanup.ps1",
-			"elevated_user": "vagrant",
-			"elevated_password": "vagrant"
-		}
-	],
-	"post-processors": [
-		[{
-			"type": "vagrant",
-			"keep_input_artifact": true,
-			"output": "{{ user `template` }}-{{.Provider}}.box",
-			"vagrantfile_template": "vagrantfile-windows.template"
-		}]
-	],
-	"variables": {
-		"memory": "4096",
-		"cpus": "2",
-		"guest_additions_mode": "attach",
-		"headless": "true",
-		"iso_checksum": "772700802951b36c8cb26a61c040b9a8dc3816a3",
-		"iso_url": "https://software-download.microsoft.com/download/pr/Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO",
-		"template": "windows-2016-standard"
-	}
+  "builders": [{
+      "type": "virtualbox-iso",
+      "vboxmanage": [
+        ["modifyvm", "{{.Name}}", "--vram", "48"]
+      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
+      "guest_additions_mode": "{{ user `guest_additions_mode` }}",
+      "guest_additions_path": "C:/users/vagrant/VBoxGuestAdditions.iso",
+      "guest_os_type": "Windows2016_64",
+      "headless": "{{ user `headless` }}",
+      "iso_url": "{{ user `iso_url` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "communicator": "winrm",
+      "winrm_username": "vagrant",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "12h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "shutdown_timeout": "15m",
+      "floppy_files": [
+        "answer_files/2016/Autounattend.xml"
+      ]
+    },
+    {
+      "type": "vmware-iso",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
+      "disk_adapter_type": "lsisas1068",
+      "guest_os_type": "windows9srv-64",
+      "headless": "{{ user `headless` }}",
+      "iso_url": "{{ user `iso_url` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "communicator": "winrm",
+      "winrm_username": "vagrant",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "12h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "shutdown_timeout": "15m",
+      "floppy_files": [
+        "answer_files/2016/Autounattend.xml"
+      ]
+    }
+  ],
+  "provisioners": [{
+      "type": "chef-solo",
+      "cookbook_paths": ["cookbooks"],
+      "guest_os_type": "windows",
+      "run_list": [
+        "packer::disable_uac",
+        "packer::disable_restore",
+        "packer::disable_windows_update",
+        "packer::remove_defender"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "chef-solo",
+      "cookbook_paths": ["cookbooks"],
+      "guest_os_type": "windows",
+      "run_list": [
+        "packer::vm_tools",
+        "packer::features",
+        "packer::enable_file_sharing",
+        "packer::enable_remote_desktop",
+        "packer::ui_tweaks",
+        "packer::power"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "chef-solo",
+      "cookbook_paths": ["cookbooks"],
+      "guest_os_type": "windows",
+      "run_list": [
+        "packer::cleanup",
+        "packer::defrag"
+      ]
+    },
+    {
+      "type": "powershell",
+      "script": "scripts/cleanup.ps1",
+      "elevated_user": "vagrant",
+      "elevated_password": "vagrant"
+    }
+  ],
+  "post-processors": [
+    [{
+      "type": "vagrant",
+      "keep_input_artifact": true,
+      "output": "{{ user `template` }}-{{.Provider}}.box",
+      "vagrantfile_template": "vagrantfile-windows.template"
+    }]
+  ],
+  "variables": {
+    "memory": "4096",
+    "cpus": "2",
+    "guest_additions_mode": "attach",
+    "headless": "true",
+    "iso_checksum": "772700802951b36c8cb26a61c040b9a8dc3816a3",
+    "iso_url": "https://software-download.microsoft.com/download/pr/Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO",
+    "template": "windows-2016-standard"
+  }
 }

--- a/packer_templates/windows/windows-2016.json
+++ b/packer_templates/windows/windows-2016.json
@@ -26,12 +26,9 @@
 		},
 		{
 			"type": "vmware-iso",
-			"vmx_data": {
-				"scsi0.virtualDev": "lsisas1068",
-				"scsi0.present": "TRUE"
-			},
 			"memory": "{{ user `memory` }}",
 			"cpus": "{{ user `cpus` }}",
+			"disk_adapter_type": "lsisas1068",
 			"guest_os_type": "windows9srv-64",
 			"headless": "{{ user `headless` }}",
 			"iso_url": "{{ user `iso_url` }}",

--- a/packer_templates/windows/windows-2019.json
+++ b/packer_templates/windows/windows-2019.json
@@ -26,12 +26,9 @@
 		},
 		{
 			"type": "vmware-iso",
-			"vmx_data": {
-				"scsi0.virtualDev": "lsisas1068",
-				"scsi0.present": "TRUE"
-			},
 			"memory": "{{ user `memory` }}",
 			"cpus": "{{ user `cpus` }}",
+			"disk_adapter_type": "lsisas1068",
 			"guest_os_type": "windows9srv-64",
 			"headless": "{{ user `headless` }}",
 			"iso_url": "{{ user `iso_url` }}",

--- a/packer_templates/windows/windows-2019.json
+++ b/packer_templates/windows/windows-2019.json
@@ -1,112 +1,112 @@
 {
-	"builders": [{
-			"type": "virtualbox-iso",
-			"vboxmanage": [
-				["modifyvm", "{{.Name}}", "--vram", "48"]
-			],
-			"memory": "{{ user `memory` }}",
-			"cpus": "{{ user `cpus` }}",
-			"guest_additions_mode": "{{ user `guest_additions_mode` }}",
-			"guest_additions_path": "C:/users/vagrant/VBoxGuestAdditions.iso",
-			"guest_os_type": "Windows2016_64",
-			"headless": "{{ user `headless` }}",
-			"iso_url": "{{ user `iso_url` }}",
-			"iso_checksum": "{{ user `iso_checksum` }}",
-			"iso_checksum_type": "sha1",
-			"output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
-			"communicator": "winrm",
-			"winrm_username": "vagrant",
-			"winrm_password": "vagrant",
-			"winrm_timeout": "12h",
-			"shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
-			"shutdown_timeout": "15m",
-			"floppy_files": [
-				"answer_files/2019/Autounattend.xml"
-			]
-		},
-		{
-			"type": "vmware-iso",
-			"memory": "{{ user `memory` }}",
-			"cpus": "{{ user `cpus` }}",
-			"disk_adapter_type": "lsisas1068",
-			"guest_os_type": "windows9srv-64",
-			"headless": "{{ user `headless` }}",
-			"iso_url": "{{ user `iso_url` }}",
-			"iso_checksum": "{{ user `iso_checksum` }}",
-			"iso_checksum_type": "sha1",
-			"output_directory": "../../builds/packer-{{user `template`}}-vmware",
-			"communicator": "winrm",
-			"winrm_username": "vagrant",
-			"winrm_password": "vagrant",
-			"winrm_timeout": "12h",
-			"shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
-			"shutdown_timeout": "15m",
-			"floppy_files": [
-				"answer_files/2019/Autounattend.xml"
-			]
-		}
-	],
-	"provisioners": [{
-			"type": "chef-solo",
-			"cookbook_paths": ["cookbooks"],
-			"guest_os_type": "windows",
-			"run_list": [
-				"packer::disable_uac",
-				"packer::disable_restore",
-				"packer::disable_windows_update",
-				"packer::remove_defender"
-			]
-		},
-		{
-			"type": "windows-restart"
-		},
-		{
-			"type": "chef-solo",
-			"cookbook_paths": ["cookbooks"],
-			"guest_os_type": "windows",
-			"run_list": [
-				"packer::vm_tools",
-				"packer::features",
-				"packer::enable_file_sharing",
-				"packer::enable_remote_desktop",
-				"packer::ui_tweaks",
-				"packer::power"
-			]
-		},
-		{
-			"type": "windows-restart"
-		},
-		{
-			"type": "chef-solo",
-			"cookbook_paths": ["cookbooks"],
-			"guest_os_type": "windows",
-			"run_list": [
-				"packer::cleanup",
-				"packer::defrag"
-			]
-		},
-		{
-			"type": "powershell",
-			"script": "scripts/cleanup.ps1",
-			"elevated_user": "vagrant",
-			"elevated_password": "vagrant"
-		}
-	],
-	"post-processors": [
-		[{
-			"type": "vagrant",
-			"keep_input_artifact": true,
-			"output": "{{ user `template` }}-{{.Provider}}.box",
-			"vagrantfile_template": "vagrantfile-windows.template"
-		}]
-	],
-	"variables": {
-		"memory": "4096",
-		"cpus": "2",
-		"guest_additions_mode": "attach",
-		"headless": "true",
-		"iso_checksum": "91e3a2f1acc39af21353c7cc105c799494d7539f",
-		"iso_url": "https://software-download.microsoft.com/download/sg/17763.253.190108-0006.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",
-		"template": "windows-2019-standard"
-	}
+  "builders": [{
+      "type": "virtualbox-iso",
+      "vboxmanage": [
+        ["modifyvm", "{{.Name}}", "--vram", "48"]
+      ],
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
+      "guest_additions_mode": "{{ user `guest_additions_mode` }}",
+      "guest_additions_path": "C:/users/vagrant/VBoxGuestAdditions.iso",
+      "guest_os_type": "Windows2016_64",
+      "headless": "{{ user `headless` }}",
+      "iso_url": "{{ user `iso_url` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+      "communicator": "winrm",
+      "winrm_username": "vagrant",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "12h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "shutdown_timeout": "15m",
+      "floppy_files": [
+        "answer_files/2019/Autounattend.xml"
+      ]
+    },
+    {
+      "type": "vmware-iso",
+      "memory": "{{ user `memory` }}",
+      "cpus": "{{ user `cpus` }}",
+      "disk_adapter_type": "lsisas1068",
+      "guest_os_type": "windows9srv-64",
+      "headless": "{{ user `headless` }}",
+      "iso_url": "{{ user `iso_url` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_checksum_type": "sha1",
+      "output_directory": "../../builds/packer-{{user `template`}}-vmware",
+      "communicator": "winrm",
+      "winrm_username": "vagrant",
+      "winrm_password": "vagrant",
+      "winrm_timeout": "12h",
+      "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+      "shutdown_timeout": "15m",
+      "floppy_files": [
+        "answer_files/2019/Autounattend.xml"
+      ]
+    }
+  ],
+  "provisioners": [{
+      "type": "chef-solo",
+      "cookbook_paths": ["cookbooks"],
+      "guest_os_type": "windows",
+      "run_list": [
+        "packer::disable_uac",
+        "packer::disable_restore",
+        "packer::disable_windows_update",
+        "packer::remove_defender"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "chef-solo",
+      "cookbook_paths": ["cookbooks"],
+      "guest_os_type": "windows",
+      "run_list": [
+        "packer::vm_tools",
+        "packer::features",
+        "packer::enable_file_sharing",
+        "packer::enable_remote_desktop",
+        "packer::ui_tweaks",
+        "packer::power"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "chef-solo",
+      "cookbook_paths": ["cookbooks"],
+      "guest_os_type": "windows",
+      "run_list": [
+        "packer::cleanup",
+        "packer::defrag"
+      ]
+    },
+    {
+      "type": "powershell",
+      "script": "scripts/cleanup.ps1",
+      "elevated_user": "vagrant",
+      "elevated_password": "vagrant"
+    }
+  ],
+  "post-processors": [
+    [{
+      "type": "vagrant",
+      "keep_input_artifact": true,
+      "output": "{{ user `template` }}-{{.Provider}}.box",
+      "vagrantfile_template": "vagrantfile-windows.template"
+    }]
+  ],
+  "variables": {
+    "memory": "4096",
+    "cpus": "2",
+    "guest_additions_mode": "attach",
+    "headless": "true",
+    "iso_checksum": "91e3a2f1acc39af21353c7cc105c799494d7539f",
+    "iso_url": "https://software-download.microsoft.com/download/sg/17763.253.190108-0006.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us.iso",
+    "template": "windows-2019-standard"
+  }
 }

--- a/packer_templates/windows/windows-7.json
+++ b/packer_templates/windows/windows-7.json
@@ -1,90 +1,90 @@
 {
-	"builders": [{
-		"type": "virtualbox-iso",
-		"vboxmanage": [
-			["modifyvm", "{{.Name}}", "--vram", "36"]
-		],
-		"memory": "{{ user `memory` }}",
-		"cpus": "{{ user `cpus` }}",
-		"guest_additions_mode": "{{ user `guest_additions_mode` }}",
-		"guest_additions_path": "C:/users/vagrant/VBoxGuestAdditions.iso",
-		"guest_os_type": "Windows7_64",
-		"headless": "{{ user `headless` }}",
-		"iso_url": "{{ user `iso_url` }}",
-		"iso_checksum": "{{ user `iso_checksum` }}",
-		"iso_checksum_type": "sha1",
-		"output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
-		"communicator": "winrm",
-		"winrm_username": "vagrant",
-		"winrm_password": "vagrant",
-		"winrm_timeout": "12h",
-		"shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
-		"shutdown_timeout": "15m",
-		"floppy_files": [
-			"answer_files/7/Autounattend.xml"
-		]
-	}],
-	"provisioners": [{
-			"type": "chef-solo",
-			"cookbook_paths": ["cookbooks"],
-			"guest_os_type": "windows",
-			"run_list": [
-				"packer::disable_uac",
-				"packer::disable_restore",
-				"packer::disable_windows_update",
-				"packer::remove_defender"
-			]
-		},
-		{
-			"type": "windows-restart"
-		},
-		{
-			"type": "chef-solo",
-			"cookbook_paths": ["cookbooks"],
-			"guest_os_type": "windows",
-			"run_list": [
-				"packer::vm_tools",
-				"packer::features",
-				"packer::enable_file_sharing",
-				"packer::enable_remote_desktop",
-				"packer::ui_tweaks",
-				"packer::power"
-			]
-		},
-		{
-			"type": "windows-restart"
-		},
-		{
-			"type": "chef-solo",
-			"cookbook_paths": ["cookbooks"],
-			"guest_os_type": "windows",
-			"run_list": [
-				"packer::cleanup",
-				"packer::defrag"
-			]
-		},
-		{
-			"type": "powershell",
-			"script": "scripts/cleanup.ps1",
-			"elevated_user": "vagrant",
-			"elevated_password": "vagrant"
-		}
-	],
-	"post-processors": [
-		[{
-			"type": "vagrant",
-			"keep_input_artifact": true,
-			"output": "{{ user `template` }}-{{.Provider}}.box",
-			"vagrantfile_template": "vagrantfile-windows.template"
-		}]
-	],
-	"variables": {
-		"memory": "4096",
-		"cpus": "2",
-		"guest_additions_mode": "attach",
-		"headless": "false",
-		"iso_checksum": "971fc00183a52c152fe924a6b99fdec011a871c2",
-		"iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x86/EN/7600.16385.090713-1255_x86fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENEVAL_EN_DVD.iso",
-		"template": "windows-7"
-	}
+  "builders": [{
+    "type": "virtualbox-iso",
+    "vboxmanage": [
+      ["modifyvm", "{{.Name}}", "--vram", "36"]
+    ],
+    "memory": "{{ user `memory` }}",
+    "cpus": "{{ user `cpus` }}",
+    "guest_additions_mode": "{{ user `guest_additions_mode` }}",
+    "guest_additions_path": "C:/users/vagrant/VBoxGuestAdditions.iso",
+    "guest_os_type": "Windows7_64",
+    "headless": "{{ user `headless` }}",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "output_directory": "../../builds/packer-{{user `template`}}-virtualbox",
+    "communicator": "winrm",
+    "winrm_username": "vagrant",
+    "winrm_password": "vagrant",
+    "winrm_timeout": "12h",
+    "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
+    "shutdown_timeout": "15m",
+    "floppy_files": [
+      "answer_files/7/Autounattend.xml"
+    ]
+  }],
+  "provisioners": [{
+      "type": "chef-solo",
+      "cookbook_paths": ["cookbooks"],
+      "guest_os_type": "windows",
+      "run_list": [
+        "packer::disable_uac",
+        "packer::disable_restore",
+        "packer::disable_windows_update",
+        "packer::remove_defender"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "chef-solo",
+      "cookbook_paths": ["cookbooks"],
+      "guest_os_type": "windows",
+      "run_list": [
+        "packer::vm_tools",
+        "packer::features",
+        "packer::enable_file_sharing",
+        "packer::enable_remote_desktop",
+        "packer::ui_tweaks",
+        "packer::power"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "chef-solo",
+      "cookbook_paths": ["cookbooks"],
+      "guest_os_type": "windows",
+      "run_list": [
+        "packer::cleanup",
+        "packer::defrag"
+      ]
+    },
+    {
+      "type": "powershell",
+      "script": "scripts/cleanup.ps1",
+      "elevated_user": "vagrant",
+      "elevated_password": "vagrant"
+    }
+  ],
+  "post-processors": [
+    [{
+      "type": "vagrant",
+      "keep_input_artifact": true,
+      "output": "{{ user `template` }}-{{.Provider}}.box",
+      "vagrantfile_template": "vagrantfile-windows.template"
+    }]
+  ],
+  "variables": {
+    "memory": "4096",
+    "cpus": "2",
+    "guest_additions_mode": "attach",
+    "headless": "false",
+    "iso_checksum": "971fc00183a52c152fe924a6b99fdec011a871c2",
+    "iso_url": "http://care.dlservice.microsoft.com/dl/download/evalx/win7/x86/EN/7600.16385.090713-1255_x86fre_enterprise_en-us_EVAL_Eval_Enterprise-GRMCENEVAL_EN_DVD.iso",
+    "template": "windows-7"
+  }
 }


### PR DESCRIPTION
## Description
This updates the windows templates to change the setting of scsi options using "vmx_data" with the "disk_adapter_type" option in order to clean up warnings during template validation. The default setting of "lsisas1068" was retained in order to not actually change the semantics of anything. This commit is 1eb7739ebffa61f9dde2050f07b7f0e1a676d663 in case that's easier to see the specific changes.

The second commit changes the tabs in the windows templates to 2-space indents so that it follows the same style of the linux templates and is consistent. I made it a second commit in case you guys don't care for this type of change to these window templates. Let me know if you want me to restore the tabs or split it into a different PR if that's the case. This commit is 1eb7739ebffa61f9dde2050f07b7f0e1a676d663.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
