### PR TITLE
fix: adding additional device for package iso and disk size as a string

### DIFF
--- a/packer_templates/sles/sles-15-sp1.json
+++ b/packer_templates/sles/sles-15-sp1.json
@@ -118,7 +118,7 @@
       "boot_wait": "10s",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
-      "disk_size": "{{user `disk_size`}}",
+      "disk_size": "{{user `disk_size`}}M",
       "headless": "{{ user `headless` }}",
       "http_directory": "{{template_dir}}/http",
       "iso_checksum": "{{user `iso_checksum`}}",
@@ -131,7 +131,12 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        ["-drive", "file={{user `mirror`}}/{{user `packages_iso`}},format=raw,if=none,id=cdrom0,readonly=on"],
+        ["-device", "virtio-scsi-pci,id=scsi0"],
+        ["-device", "scsi-cd,bus=scsi0.0,scsi-id=0,lun=1,drive=cdrom0"]
+      ]
     }
   ],
   "post-processors": [

--- a/packer_templates/sles/sles-15.json
+++ b/packer_templates/sles/sles-15.json
@@ -118,7 +118,7 @@
       "boot_wait": "10s",
       "memory": "{{ user `memory` }}",
       "cpus": "{{ user `cpus` }}",
-      "disk_size": "{{user `disk_size`}}",
+      "disk_size": "{{user `disk_size`}}M",
       "headless": "{{ user `headless` }}",
       "http_directory": "{{template_dir}}/http",
       "iso_checksum": "{{user `iso_checksum`}}",
@@ -131,7 +131,12 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        ["-drive", "file={{user `mirror`}}/{{user `packages_iso`}},format=raw,if=none,id=cdrom0,readonly=on"],
+        ["-device", "virtio-scsi-pci,id=scsi0"],
+        ["-device", "scsi-cd,bus=scsi0.0,scsi-id=0,lun=1,drive=cdrom0"]
+      ]
     }
   ],
   "post-processors": [


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
sles-15.json and sles-15-sp1.json builders needs an additional package iso to accomplish a new images, today its not possible with qemu builder because this iso its not attached. 

***hold this PR until packer 1.5 be released***

## Related Issue
closes #1252

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
