### PR TITLE
Change profile to Private to avoid infinite wait

### DIFF
--- a/packer_templates/windows/scripts/base_setup.ps1
+++ b/packer_templates/windows/scripts/base_setup.ps1
@@ -6,8 +6,13 @@ Write-Host "Performing the WinRM setup necessary to get the host ready for packe
 # Supress network location Prompt
 New-Item -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff" -Force
 
+# The above suppresses the prompt but defaults to "Public" which prevents WinRM from being enabled even with the SkipNetworkProfileCheck arg
+# This command sets any network connections detected to Private to allow WinRM to be configured and started
+Get-NetConnectionProfile | Set-NetConnectionProfile -NetworkCategory "Private"
+
 # Does a lot: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/enable-psremoting?view=powershell-6
 Enable-PSRemoting -SkipNetworkProfileCheck -Force
+# May not be necessary since we set the profile to Private above
 Set-NetFirewallRule -Name "WINRM-HTTP-In-TCP" -RemoteAddress Any # allow winrm over public profile interfaces
 
 winrm set "winrm/config" '@{MaxTimeoutms="1800000"}'


### PR DESCRIPTION
I've run into an infinite wait scenario when trying to build without the additional line added. While debugging I ran this script from an Administrator Powershell window and the error was always the same, the WinRM -quickconfig command doesn't seem to be getting the profile override so isn't allowing WinRM to be enabled preventing the initial Packer wait for WinRM to succeed.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
