### PR TITLE
upgrading debian 10.1 -> 10.2 and use a separate preseed cfg

### DIFF
--- a/packer_templates/debian/debian-10.2-amd64.json
+++ b/packer_templates/debian/debian-10.2-amd64.json
@@ -197,7 +197,7 @@
     }
   ],
   "variables": {
-    "box_basename": "debian-10.1",
+    "box_basename": "debian-10.2",
     "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
@@ -207,16 +207,16 @@
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
     "guest_additions_url": "",
-    "iso_checksum": "7915fdb77a0c2623b4481fc5f0a8052330defe1cde1e0834ff233818dc6f301e",
+    "iso_checksum": "e43fef979352df15056ac512ad96a07b515cb8789bf0bfd86f99ed0404f885f5",
     "iso_checksum_type": "sha256",
-    "iso_name": "debian-10.1.0-amd64-netinst.iso",
+    "iso_name": "debian-10.2.0-amd64-netinst.iso",
     "memory": "1024",
     "mirror": "http://cdimage.debian.org/cdimage/release",
-    "mirror_directory": "10.1.0/amd64/iso-cd",
-    "name": "debian-10.1",
+    "mirror_directory": "10.2.0/amd64/iso-cd",
+    "name": "debian-10.2",
     "no_proxy": "{{env `no_proxy`}}",
     "preseed_path": "debian-9/preseed.cfg",
-    "template": "debian-10.1-amd64",
+    "template": "debian-10.2-amd64",
     "version": "TIMESTAMP"
   }
 }

--- a/packer_templates/debian/debian-10.2-i386.json
+++ b/packer_templates/debian/debian-10.2-i386.json
@@ -197,7 +197,7 @@
     }
   ],
   "variables": {
-    "box_basename": "debian-10.1-i386",
+    "box_basename": "debian-10.2-i386",
     "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "1",
@@ -207,16 +207,16 @@
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
     "guest_additions_url": "",
-    "iso_checksum": "78ea01feb0f0d8a8c274333a3b2e6261c93b33135c26aa5b7c791d0f57524eb5",
+    "iso_checksum": "883d0ca91d2f21ce0a0e0e481f97bf73d50a0232f467e5200aaea79849fc74fd",
     "iso_checksum_type": "sha256",
-    "iso_name": "debian-10.1.0-i386-netinst.iso",
+    "iso_name": "debian-10.2.0-i386-netinst.iso",
     "memory": "1024",
     "mirror": "http://cdimage.debian.org/cdimage/release",
-    "mirror_directory": "10.1.0/i386/iso-cd",
-    "name": "debian-10.1-i386",
+    "mirror_directory": "10.2.0/i386/iso-cd",
+    "name": "debian-10.2-i386",
     "no_proxy": "{{env `no_proxy`}}",
     "preseed_path": "debian-9/preseed.cfg",
-    "template": "debian-10.1-i386",
+    "template": "debian-10.2-i386",
     "version": "TIMESTAMP"
   }
 }


### PR DESCRIPTION
## Description
A quick update to the Debian 10.2 release. Additionally split the preseed configuration to have one configuration per major-release (currently 8, 9, 10).

## Related Issue
-

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
