### PR TITLE
Remove customized kern.hz as it will be automatically adjusted

### DIFF
--- a/packer_templates/freebsd/scripts/postinstall.sh
+++ b/packer_templates/freebsd/scripts/postinstall.sh
@@ -15,7 +15,6 @@ ln -sf /usr/local/share/certs/ca-root-nss.crt /etc/ssl/cert.pem;
 cat >>/etc/loader.conf << LOADER_CONF
 autoboot_delay="-1"
 beastie_disable="YES"
-kern.hz=50
 LOADER_CONF
 
 # disable crash dumps


### PR DESCRIPTION
Remove customized kern.hz as it will be automatically adjusted

## Description
Remove customized kern.hz as it will be automatically adjusted. It will be automatically set to 100 in a VM environment.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
