### PR TITLE
bugfix: fix welcome message 404

### DIFF
--- a/packer_templates/_common/motd.sh
+++ b/packer_templates/_common/motd.sh
@@ -2,7 +2,7 @@
 
 bento='
 This system is built by the Bento project by Chef Software
-More information can be found at https://github.com/chef/bento/README.md'
+More information can be found at https://github.com/chef/bento'
 
 if [ -d /etc/update-motd.d ]; then
     MOTD_CONFIG='/etc/update-motd.d/99-bento'


### PR DESCRIPTION
The message when login is a 404 url.

<img width="858" alt="image" src="https://user-images.githubusercontent.com/9675939/70689227-9cff6980-1cee-11ea-89f2-abf62f734ff7.png">


## Description
I updated the url.

- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
