### PR TITLE
Modified the boot_command for all of the FreeBSD templates to include the pidfile path when executing dhclient.

### DIFF
--- a/packer_templates/freebsd/freebsd-11.3-amd64.json
+++ b/packer_templates/freebsd/freebsd-11.3-amd64.json
@@ -9,7 +9,7 @@
         "/bin/sh<enter><wait>",
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
-        "dhclient -l /tmp/dhclient.lease.em0 em0<enter><wait>",
+        "dhclient -p /tmp/dhclient.em0.pid -l /tmp/dhclient.lease.em0 em0<enter><wait>",
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "10s",
@@ -42,7 +42,7 @@
         "/bin/sh<enter><wait>",
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
-        "dhclient -l /tmp/dhclient.lease.em0 em0<enter><wait>",
+        "dhclient -p /tmp/dhclient.em0.pid -l /tmp/dhclient.lease.em0 em0<enter><wait>",
         "<wait5>",
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
@@ -78,7 +78,7 @@
         "/bin/sh<enter><wait>",
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
-        "dhclient -l /tmp/dhclient.lease.em0 em0<enter><wait>",
+        "dhclient -p /tmp/dhclient.em0.pid -l /tmp/dhclient.lease.em0 em0<enter><wait>",
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "8s",
@@ -132,7 +132,7 @@
         "/bin/sh<enter><wait>",
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
-        "dhclient -l /tmp/dhclient.lease.vtnet0 vtnet0<enter><wait>",
+        "dhclient -p /tmp/dhclient.vtnet0.pid -l /tmp/dhclient.lease.vtnet0 vtnet0<enter><wait>",
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "7s",

--- a/packer_templates/freebsd/freebsd-11.3-i386.json
+++ b/packer_templates/freebsd/freebsd-11.3-i386.json
@@ -9,7 +9,7 @@
         "/bin/sh<enter><wait>",
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
-        "dhclient -l /tmp/dhclient.lease.em0 em0<enter><wait>",
+        "dhclient /tmp/dhclient.em0.pid -l /tmp/dhclient.lease.em0 em0<enter><wait>",
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "10s",
@@ -42,7 +42,7 @@
         "/bin/sh<enter><wait>",
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
-        "dhclient -l /tmp/dhclient.lease.em0 em0<enter><wait>",
+        "dhclient -p /tmp/dhclient.em0.pid -l /tmp/dhclient.lease.em0 em0<enter><wait>",
         "<wait5>",
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
@@ -78,7 +78,7 @@
         "/bin/sh<enter><wait>",
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
-        "dhclient -l /tmp/dhclient.lease.em0 em0<enter><wait>",
+        "dhclient -p /tmp/dhclient.em0.pid -l /tmp/dhclient.lease.em0 em0<enter><wait>",
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "8s",
@@ -132,7 +132,7 @@
         "/bin/sh<enter><wait>",
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
-        "dhclient -l /tmp/dhclient.lease.vtnet0 vtnet0<enter><wait>",
+        "dhclient -p /tmp/dhclient.vtnet0.pid -l /tmp/dhclient.lease.vtnet0 vtnet0<enter><wait>",
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "7s",

--- a/packer_templates/freebsd/freebsd-12.0-amd64.json
+++ b/packer_templates/freebsd/freebsd-12.0-amd64.json
@@ -9,7 +9,7 @@
         "/bin/sh<enter><wait>",
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
-        "dhclient -l /tmp/dhclient.lease.em0 em0<enter><wait>",
+        "dhclient -p /tmp/dhclient.em0.pid -l /tmp/dhclient.lease.em0 em0<enter><wait>",
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "10s",
@@ -42,7 +42,7 @@
         "/bin/sh<enter><wait>",
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
-        "dhclient -l /tmp/dhclient.lease.em0 em0<enter><wait>",
+        "dhclient -p /tmp/dhclient.em0.pid -l /tmp/dhclient.lease.em0 em0<enter><wait>",
         "<wait5>",
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
@@ -78,7 +78,7 @@
         "/bin/sh<enter><wait>",
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
-        "dhclient -l /tmp/dhclient.lease.em0 em0<enter><wait>",
+        "dhclient -p /tmp/dhclient.em0.pid -l /tmp/dhclient.lease.em0 em0<enter><wait>",
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "8s",
@@ -132,7 +132,7 @@
         "/bin/sh<enter><wait>",
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
-        "dhclient -l /tmp/dhclient.lease.vtnet0 vtnet0<enter><wait>",
+        "dhclient -p /tmp/dhclient.vtnet0.pid -l /tmp/dhclient.lease.vtnet0 vtnet0<enter><wait>",
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "7s",

--- a/packer_templates/freebsd/freebsd-12.0-i386.json
+++ b/packer_templates/freebsd/freebsd-12.0-i386.json
@@ -9,7 +9,7 @@
         "/bin/sh<enter><wait>",
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
-        "dhclient -l /tmp/dhclient.lease.em0 em0<enter><wait>",
+        "dhclient -p /tmp/dhclient.em0.pid -l /tmp/dhclient.lease.em0 em0<enter><wait>",
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "10s",
@@ -42,7 +42,7 @@
         "/bin/sh<enter><wait>",
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
-        "dhclient -l /tmp/dhclient.lease.em0 em0<enter><wait>",
+        "dhclient -p /tmp/dhclient.em0.pid -l /tmp/dhclient.lease.em0 em0<enter><wait>",
         "<wait5>",
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
@@ -78,7 +78,7 @@
         "/bin/sh<enter><wait>",
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
-        "dhclient -l /tmp/dhclient.lease.em0 em0<enter><wait>",
+        "dhclient -p /tmp/dhclient.em0.pid -l /tmp/dhclient.lease.em0 em0<enter><wait>",
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "8s",
@@ -132,7 +132,7 @@
         "/bin/sh<enter><wait>",
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
-        "dhclient -l /tmp/dhclient.lease.vtnet0 vtnet0<enter><wait>",
+        "dhclient -p /tmp/dhclient.vtnet0.pid -l /tmp/dhclient.lease.vtnet0 vtnet0<enter><wait>",
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "7s",

--- a/packer_templates/freebsd/freebsd-12.1-amd64.json
+++ b/packer_templates/freebsd/freebsd-12.1-amd64.json
@@ -9,7 +9,7 @@
         "/bin/sh<enter><wait>",
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
-        "dhclient -l /tmp/dhclient.lease.em0 em0<enter><wait>",
+        "dhclient -p /tmp/dhclient.em0.pid -l /tmp/dhclient.lease.em0 em0<enter><wait>",
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "10s",
@@ -42,7 +42,7 @@
         "/bin/sh<enter><wait>",
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
-        "dhclient -l /tmp/dhclient.lease.em0 em0<enter><wait>",
+        "dhclient -p /tmp/dhclient.em0.pid -l /tmp/dhclient.lease.em0 em0<enter><wait>",
         "<wait5>",
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
@@ -78,7 +78,7 @@
         "/bin/sh<enter><wait>",
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
-        "dhclient -l /tmp/dhclient.lease.em0 em0<enter><wait>",
+        "dhclient -p /tmp/dhclient.em0.pid -l /tmp/dhclient.lease.em0 em0<enter><wait>",
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "8s",
@@ -132,7 +132,7 @@
         "/bin/sh<enter><wait>",
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
-        "dhclient -l /tmp/dhclient.lease.vtnet0 vtnet0<enter><wait>",
+        "dhclient -p /tmp/dhclient.vtnet0.pid -l /tmp/dhclient.lease.vtnet0 vtnet0<enter><wait>",
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "7s",

--- a/packer_templates/freebsd/freebsd-12.1-i386.json
+++ b/packer_templates/freebsd/freebsd-12.1-i386.json
@@ -9,7 +9,7 @@
         "/bin/sh<enter><wait>",
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
-        "dhclient -l /tmp/dhclient.lease.em0 em0<enter><wait>",
+        "dhclient -p /tmp/dhclient.em0.pid -l /tmp/dhclient.lease.em0 em0<enter><wait>",
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "10s",
@@ -42,7 +42,7 @@
         "/bin/sh<enter><wait>",
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
-        "dhclient -l /tmp/dhclient.lease.em0 em0<enter><wait>",
+        "dhclient -p /tmp/dhclient.em0.pid -l /tmp/dhclient.lease.em0 em0<enter><wait>",
         "<wait5>",
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
@@ -78,7 +78,7 @@
         "/bin/sh<enter><wait>",
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
-        "dhclient -l /tmp/dhclient.lease.em0 em0<enter><wait>",
+        "dhclient -p /tmp/dhclient.em0.pid -l /tmp/dhclient.lease.em0 em0<enter><wait>",
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "8s",
@@ -132,7 +132,7 @@
         "/bin/sh<enter><wait>",
         "mdmfs -s 100m md1 /tmp<enter><wait>",
         "mdmfs -s 100m md2 /mnt<enter><wait>",
-        "dhclient -l /tmp/dhclient.lease.vtnet0 vtnet0<enter><wait>",
+        "dhclient -p /tmp/dhclient.vtnet0.pid -l /tmp/dhclient.lease.vtnet0 vtnet0<enter><wait>",
         "fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `install_path`}} && bsdinstall script /tmp/installerconfig<enter><wait>"
       ],
       "boot_wait": "7s",


### PR DESCRIPTION
## Description
When booting up a FreeBSD template, the default "boot_command" creates two memory disks and then executes `dhclient` to setup a network interface. When setting up the interface, `dhclient` needs to write some files. One of these files is the lease file which caches the requested dhcp lease and is handled by the `-l` parameter. Another one of these files is the pidfile which stores the current pid so that it can interact with an already existing instance if necessary. Since this isn't explicitly specified, `dhclient` will use `/var/run/dhclient.$interface.pid` by default which is read-only. This seems to result in some builds blocking indefinitely while waiting for a lease.

This PR simply adds the `-p` parameter to tell `dhclient` to write its pidfile into the writable `/tmp` directory that already contains the lease cache.

## Related Issue
This closes issue #1263 for me.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin]