### PR TITLE
Replace legacy service name with open-vm-tools

### DIFF
--- a/packer_templates/ubuntu/scripts/vmware.sh
+++ b/packer_templates/ubuntu/scripts/vmware.sh
@@ -4,7 +4,7 @@ case "$PACKER_BUILDER_TYPE" in
 vmware-iso|vmware-vmx)
     apt-get install -y open-vm-tools;
     mkdir /mnt/hgfs;
-    systemctl enable vmtoolsd
-    systemctl start vmtoolsd
+    systemctl enable open-vm-tools
+    systemctl start open-vm-tools
     echo "platform specific vmware.sh executed";
 esac


### PR DESCRIPTION
The script was partially modified to use open-vm-tools instead of the legacy "official" vmware tools, but missed changing to the different service name that open-vm-tools uses.