### PR TITLE
fix: adding qemuargs to mount secondary drive

### DIFF
--- a/packer_templates/sles/sles-15-sp1.json
+++ b/packer_templates/sles/sles-15-sp1.json
@@ -131,7 +131,15 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        ["-drive", "file=../../builds/packer-{{user `template`}}-qemu/{{user `template`}},if=virtio,cache=writeback,discard=ignore,format=qcow2"],
+        ["-drive", "file={{user `mirror`}}/{{user `packages_iso`}},format=raw,if=none,id=cdrom1,readonly=on"],
+        ["-object", "iothread,id=iothread1"],
+        ["-device", "virtio-scsi-pci,iothread=iothread1,id=scsi1"],
+        ["-device", "scsi-cd,bus=scsi1.0,drive=cdrom1"]
+      ]
+
     }
   ],
   "post-processors": [

--- a/packer_templates/sles/sles-15.json
+++ b/packer_templates/sles/sles-15.json
@@ -131,7 +131,14 @@
       "ssh_username": "vagrant",
       "ssh_wait_timeout": "10000s",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        ["-drive", "file=../../builds/packer-{{user `template`}}-qemu/{{user `template`}},if=virtio,cache=writeback,discard=ignore,format=qcow2"],
+        ["-drive", "file={{user `mirror`}}/{{user `packages_iso`}},format=raw,if=none,id=cdrom1,readonly=on"],
+        ["-object", "iothread,id=iothread1"],
+        ["-device", "virtio-scsi-pci,iothread=iothread1,id=scsi1"],
+        ["-device", "scsi-cd,bus=scsi1.0,drive=cdrom1"]
+      ]
     }
   ],
   "post-processors": [


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Adding necessary qemu-args in order to mount additional iso used within autoyast 

## Related Issue
#1252 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
