### PR TITLE
Incorrect calculation of block count

### DIFF
--- a/packer_templates/_common/minimize.sh
+++ b/packer_templates/_common/minimize.sh
@@ -5,14 +5,12 @@ case "$PACKER_BUILDER_TYPE" in
 esac
 
 # Whiteout root
-count=$(df --sync -kP / | tail -n1  | awk -F ' ' '{print $4}')
-count=$(($count-1))
+count=$(df --sync -kP / | tail -n1  | awk -F ' ' '{printf("%d",($4-1)/1024-1)}')
 dd if=/dev/zero of=/tmp/whitespace bs=1M count=$count || echo "dd exit code $? is suppressed";
 rm /tmp/whitespace
 
 # Whiteout /boot
-count=$(df --sync -kP /boot | tail -n1 | awk -F ' ' '{print $4}')
-count=$(($count-1))
+  count=$(df --sync -kP /boot | tail -n1  | awk -F ' ' '{printf("%d",($4-1)/1024-1)}')
 dd if=/dev/zero of=/boot/whitespace bs=1M count=$count || echo "dd exit code $? is suppressed";
 rm /boot/whitespace
 


### PR DESCRIPTION
## Description

Block count were returned assuming 1 bloc = 1 KB, but in the `dd` command, blocks of 1MB were written. This results in 1000x write operation.

Block count should be returned in MB.

## Related Issue
https://github.com/chef/bento/issues/1175

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
