### PR TITLE
FreeBSD minimize: let dd(1) automatically exit on disk full

### DIFF
--- a/packer_templates/freebsd/scripts/minimize.sh
+++ b/packer_templates/freebsd/scripts/minimize.sh
@@ -8,17 +8,8 @@ ZROOT="zroot/ROOT/default"
 COMPRESSION=$(zfs get -H compression $ZROOT | cut -f3);
 
 zfs set compression=off $ZROOT;
-dd if=/dev/zero of=/EMPTY bs=1m &
-PID=$!;
-
-avail=$(zfs get -pH avail $ZROOT | cut -f3);
-while [ "$avail" -ne 0 ]; do
-  sleep 15;
-  avail=$(zfs get -pH avail $ZROOT | cut -f3);
-done
-
-kill $PID || echo "dd already exited";
-
+dd if=/dev/zero of=/EMPTY bs=1m || echo "dd(1) exits after taking over all the space"
+sync
 rm -f /EMPTY;
 # Block until the empty file has been removed, otherwise, Packer
 # will try to kill the box while the disk is still full and that's bad


### PR DESCRIPTION
Don't need to periodically check the space left, dd(1) will
automatically exit after it cannot write to the disk anymore.
This mitigate the issue that fs may reserve some space so the
available space size will never get to 0.

Signed-off-by: Li-Wen Hsu <lwhsu@lwhsu.org>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
