### PR TITLE
Enabling disk size overrides for Windows

### DIFF
--- a/packer_templates/windows/windows-10.json
+++ b/packer_templates/windows/windows-10.json
@@ -3,12 +3,13 @@
     {
       "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "{{ user `floppy_dir` }}/{{ user `unattended_file_path` }}",
         "{{template_dir}}/scripts/base_setup.ps1"
       ],
       "headless": "{{ user `headless` }}",
-      "iso_checksum": "sha1:{{ user `iso_checksum` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
       "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
@@ -23,6 +24,7 @@
     {
       "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "{{ user `floppy_dir` }}/{{ user `unattended_file_path` }}",
         "{{template_dir}}/scripts/base_setup.ps1"
@@ -33,7 +35,7 @@
       "guest_os_type": "Windows10_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
-      "iso_checksum": "sha1:{{ user `iso_checksum` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_interface": "sata",
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
@@ -62,12 +64,13 @@
     {
       "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "{{ user `floppy_dir` }}/{{ user `unattended_file_path` }}",
         "{{template_dir}}/scripts/base_setup.ps1"
       ],
       "guest_os_type": "win-10",
-      "iso_checksum": "sha1:{{ user `iso_checksum` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
       "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
@@ -93,13 +96,14 @@
       "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
       "disk_adapter_type": "lsisas1068",
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "{{ user `floppy_dir` }}/{{ user `unattended_file_path` }}",
         "{{template_dir}}/scripts/base_setup.ps1"
       ],
       "guest_os_type": "windows9srv-64",
       "headless": "{{ user `headless` }}",
-      "iso_checksum": "sha1:{{ user `iso_checksum` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
       "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
@@ -116,12 +120,13 @@
     {
       "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "{{ user `floppy_dir` }}/{{ user `unattended_file_path` }}",
         "{{template_dir}}/scripts/base_setup.ps1"
       ],
       "headless": "{{ user `headless` }}",
-      "iso_checksum": "sha1:{{ user `iso_checksum` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
       "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
@@ -219,6 +224,7 @@
   "variables": {
     "build_directory": "../../builds",
     "cpus": "2",
+    "disk_size": "40000",
     "floppy_dir": "{{template_dir}}/answer_files",
     "guest_additions_mode": "attach",
     "guest_additions_url": "",

--- a/packer_templates/windows/windows-2012.json
+++ b/packer_templates/windows/windows-2012.json
@@ -3,11 +3,12 @@
     {
       "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "{{ user `floppy_dir` }}/{{ user `unattended_file_path` }}"
       ],
       "headless": "{{ user `headless` }}",
-      "iso_checksum": "sha1:{{ user `iso_checksum` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
       "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
@@ -22,6 +23,7 @@
     {
       "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "{{ user `floppy_dir` }}/{{ user `unattended_file_path` }}"
       ],
@@ -31,7 +33,7 @@
       "guest_os_type": "Windows2012_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
-      "iso_checksum": "sha1:{{ user `iso_checksum` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_interface": "sata",
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
@@ -60,11 +62,12 @@
     {
       "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "{{ user `floppy_dir` }}/{{ user `unattended_file_path` }}"
       ],
       "guest_os_type": "win-2012",
-      "iso_checksum": "sha1:{{ user `iso_checksum` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
       "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
@@ -89,12 +92,13 @@
       "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
       "disk_adapter_type": "lsisas1068",
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "{{ user `floppy_dir` }}/{{ user `unattended_file_path` }}"
       ],
       "guest_os_type": "windows9srv-64",
       "headless": "{{ user `headless` }}",
-      "iso_checksum": "sha1:{{ user `iso_checksum` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
       "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
@@ -111,11 +115,12 @@
     {
       "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "{{ user `floppy_dir` }}/{{ user `unattended_file_path` }}"
       ],
       "headless": "{{ user `headless` }}",
-      "iso_checksum": "sha1:{{ user `iso_checksum` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
       "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
@@ -212,13 +217,13 @@
   "variables": {
     "build_directory": "../../builds",
     "cpus": "2",
+    "disk_size": "40000",
     "floppy_dir": "{{template_dir}}/answer_files",
     "guest_additions_mode": "attach",
     "guest_additions_url": "",
     "headless": "true",
     "hyperv_switch": "{{env `hyperv_switch`}}",
     "iso_checksum": "922b365c3360ce630f6a4b4f2f3c79e66165c0fb",
-    "iso_checksum_type": "sha1",
     "iso_url": "http://download.microsoft.com/download/6/D/A/6DAB58BA-F939-451D-9101-7DE07DC09C03/9200.16384.WIN8_RTM.120725-1247_X64FRE_SERVER_EVAL_EN-US-HRM_SSS_X64FREE_EN-US_DV5.ISO",
     "memory": "4096",
     "template": "windows-2012-standard",

--- a/packer_templates/windows/windows-2012r2.json
+++ b/packer_templates/windows/windows-2012r2.json
@@ -3,11 +3,12 @@
     {
       "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "{{ user `floppy_dir` }}/{{ user `unattended_file_path` }}"
       ],
       "headless": "{{ user `headless` }}",
-      "iso_checksum": "sha1:{{ user `iso_checksum` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
       "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
@@ -22,6 +23,7 @@
     {
       "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "{{ user `floppy_dir` }}/{{ user `unattended_file_path` }}"
       ],
@@ -31,7 +33,7 @@
       "guest_os_type": "Windows2012_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
-      "iso_checksum": "sha1:{{ user `iso_checksum` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_interface": "sata",
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
@@ -60,11 +62,12 @@
     {
       "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "{{ user `floppy_dir` }}/{{ user `unattended_file_path` }}"
       ],
       "guest_os_type": "win-2012",
-      "iso_checksum": "sha1:{{ user `iso_checksum` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
       "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
@@ -89,12 +92,13 @@
       "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
       "disk_adapter_type": "lsisas1068",
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "{{ user `floppy_dir` }}/{{ user `unattended_file_path` }}"
       ],
       "guest_os_type": "windows9srv-64",
       "headless": "{{ user `headless` }}",
-      "iso_checksum": "sha1:{{ user `iso_checksum` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
       "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
@@ -111,11 +115,12 @@
     {
       "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "{{ user `floppy_dir` }}/{{ user `unattended_file_path` }}"
       ],
       "headless": "{{ user `headless` }}",
-      "iso_checksum": "sha1:{{ user `iso_checksum` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
       "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
@@ -212,6 +217,7 @@
   "variables": {
     "build_directory": "../../builds",
     "cpus": "2",
+    "disk_size": "40000",
     "floppy_dir": "{{template_dir}}/answer_files",
     "guest_additions_mode": "attach",
     "guest_additions_url": "",

--- a/packer_templates/windows/windows-2016.json
+++ b/packer_templates/windows/windows-2016.json
@@ -3,11 +3,12 @@
     {
       "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "{{ user `floppy_dir` }}/{{ user `unattended_file_path` }}"
       ],
       "headless": "{{ user `headless` }}",
-      "iso_checksum": "sha1:{{ user `iso_checksum` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
       "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
@@ -22,6 +23,7 @@
     {
       "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "{{ user `floppy_dir` }}/{{ user `unattended_file_path` }}"
       ],
@@ -31,7 +33,7 @@
       "guest_os_type": "Windows2016_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
-      "iso_checksum": "sha1:{{ user `iso_checksum` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_interface": "sata",
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
@@ -60,11 +62,12 @@
     {
       "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "{{ user `floppy_dir` }}/{{ user `unattended_file_path` }}"
       ],
       "guest_os_type": "win-2016",
-      "iso_checksum": "sha1:{{ user `iso_checksum` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
       "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
@@ -89,12 +92,13 @@
       "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
       "disk_adapter_type": "lsisas1068",
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "{{ user `floppy_dir` }}/{{ user `unattended_file_path` }}"
       ],
       "guest_os_type": "windows9srv-64",
       "headless": "{{ user `headless` }}",
-      "iso_checksum": "sha1:{{ user `iso_checksum` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
       "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
@@ -111,11 +115,12 @@
     {
       "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "{{ user `floppy_dir` }}/{{ user `unattended_file_path` }}"
       ],
       "headless": "{{ user `headless` }}",
-      "iso_checksum": "sha1:{{ user `iso_checksum` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
       "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
@@ -212,6 +217,7 @@
   "variables": {
     "build_directory": "../../builds",
     "cpus": "2",
+    "disk_size": "40000",
     "floppy_dir": "{{template_dir}}/answer_files",
     "guest_additions_mode": "attach",
     "guest_additions_url": "",

--- a/packer_templates/windows/windows-2019.json
+++ b/packer_templates/windows/windows-2019.json
@@ -3,11 +3,12 @@
     {
       "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "{{ user `floppy_dir` }}/{{ user `unattended_file_path` }}"
       ],
       "headless": "{{ user `headless` }}",
-      "iso_checksum": "sha1:{{ user `iso_checksum` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
       "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
@@ -22,6 +23,7 @@
     {
       "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "{{ user `floppy_dir` }}/{{ user `unattended_file_path` }}"
       ],
@@ -31,7 +33,7 @@
       "guest_os_type": "Windows2016_64",
       "hard_drive_interface": "sata",
       "headless": "{{ user `headless` }}",
-      "iso_checksum": "sha1:{{ user `iso_checksum` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_interface": "sata",
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
@@ -60,11 +62,12 @@
     {
       "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "{{ user `floppy_dir` }}/{{ user `unattended_file_path` }}"
       ],
       "guest_os_type": "win-2019",
-      "iso_checksum": "sha1:{{ user `iso_checksum` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
       "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
@@ -89,12 +92,13 @@
       "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
       "disk_adapter_type": "lsisas1068",
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "{{ user `floppy_dir` }}/{{ user `unattended_file_path` }}"
       ],
       "guest_os_type": "windows9srv-64",
       "headless": "{{ user `headless` }}",
-      "iso_checksum": "sha1:{{ user `iso_checksum` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
       "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
@@ -111,11 +115,12 @@
     {
       "communicator": "winrm",
       "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
       "floppy_files": [
         "{{ user `floppy_dir` }}/{{ user `unattended_file_path` }}"
       ],
       "headless": "{{ user `headless` }}",
-      "iso_checksum": "sha1:{{ user `iso_checksum` }}",
+      "iso_checksum": "{{ user `iso_checksum` }}",
       "iso_url": "{{ user `iso_url` }}",
       "memory": "{{ user `memory` }}",
       "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
@@ -212,6 +217,7 @@
   "variables": {
     "build_directory": "../../builds",
     "cpus": "2",
+    "disk_size": "40000",
     "floppy_dir": "{{template_dir}}/answer_files",
     "guest_additions_mode": "attach",
     "guest_additions_url": "",


### PR DESCRIPTION
Explicitly sets value matching Packer default of approximately 40GB (40000 megabytes)
Removes deprecated iso_checksum_type
Removes hardcoded `sha1:` prefixed to iso_checksum as Packer can infer the type and supports getting checksums from a file: URI which this would have broken.

https://www.packer.io/docs/builders/virtualbox/iso#iso_checksum

## Description
The "public" boxes all supported disk_size but the Windows ones for some reason did not. Added in appropriate block to all providers and variables blocks.

## Related Issue
Fixes #1294 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
