### PR TITLE
Fix vm_tools recipe

### DIFF
--- a/packer_templates/windows/cookbooks/packer/recipes/vm_tools.rb
+++ b/packer_templates/windows/cookbooks/packer/recipes/vm_tools.rb
@@ -23,12 +23,13 @@ end
 # install vmware tools on vmware guests
 # This is from https://github.com/luciusbono/Packer-Windows10/blob/master/install-guest-tools.ps1
 if vmware?
-  powershell_script 'install vbox guest additions' do
-    code <<-EOH
-      $isopath = "C:\\Windows\\Temp\\vmware.iso"
+  powershell_script 'install vmware tools' do
+    code <<-'EOH'
+      $isopath = 'C:\Windows\Temp\vmware.iso'
       Mount-DiskImage -ImagePath $isopath
       $exe = ((Get-DiskImage -ImagePath $isopath | Get-Volume).Driveletter + ':\setup.exe')
-      $parameters = '/S /v "/qr REBOOT=R"'
+      $parameters = '/S /v "/qn REBOOT=R"'
+      Start-Process -FilePath $exe -ArgumentList $parameters -Wait
       Dismount-DiskImage -ImagePath $isopath
       Remove-Item $isopath
     EOH


### PR DESCRIPTION
## Description
vm_tools.rb was incomplete for the vmware section -- the powershell didn't execute anything after unpacking the iso file.  There were some other slight problems with escaping in the ruby here-document block, and the vmware section was incorrectly reporting that it was installing vbox addons.

## Related Issue
I don't know if there are existing issues this addresses

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
