### PR TITLE
Add packer_templates/ directory to README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,35 +40,35 @@ end
 To build an Ubuntu 18.04 box for only the VirtualBox provider
 
 ```
-$ cd ubuntu
+$ cd packer_templates/ubuntu
 $ packer build -only=virtualbox-iso ubuntu-18.04-amd64.json
 ```
 
 To build Debian 10.5 32bit boxes for all possible providers (simultaneously)
 
 ```
-$ cd debian
+$ cd packer_templates/debian
 $ packer build debian-10.5-i386.json
 ```
 
 To build CentOS 7.7 boxes for all providers except VMware and Parallels
 
 ```
-$ cd centos
+$ cd packer_templates/centos
 $ packer build -except=parallels-iso,vmware-iso centos-7.7-x86_64.json
 ```
 
 To use an alternate mirror
 
 ```
-$ cd fedora
+$ cd packer_templates/fedora
 $ packer build -var 'mirror=http://mirror.utexas.edu/fedora/linux' fedora-31-x86_64.json
 ```
 
 To build a Windows 10 Enterprise Gen 2 box for the Hyper-V provider
 
 ```
-$ cd windows
+$ cd packer_templates/windows
 $ packer build windows-10gen2.json
 ```
 
@@ -108,7 +108,6 @@ Hyper-V Gen 2 VMs do not support floppy drives. If you previously provided resou
 
 - `autounattend.xml`: The Gen 2 `autounattend.xml` file supports EFI partitions. Update the `autounattend.xml` with the correct Windows version for your systems and ensure that the partitions are correct for your situation. You also need to manage the driver disk that holds the hyper-v guest services drivers and adjust the `autounattend.xml` file as appropriate.
 - `base_setup.ps1`
-
 
 #### macOS / OSX
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

The examples in the README indicate the OS directories but it isn't (wasn't) specifically clear where these directories were.  They could be easily found by looking around in the repository - `packer_templates/` is fairly logical but it's easiest if it's documented.  

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document. -- I have but it's quite generic (https://github.com/chef/.github/blob/master/CONTRIBUTING.md is what GH links to)
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
