### PR TITLE
Fix broken CentoOS 8.2 build due to firmware and authconfig

### DIFF
--- a/packer_templates/centos/http/8/ks.cfg
+++ b/packer_templates/centos/http/8/ks.cfg
@@ -13,7 +13,6 @@ skipx
 zerombr
 clearpart --all --initlabel
 autopart
-auth --enableshadow --passalgo=sha512 --kickstart
 firstboot --disabled
 reboot --eject
 user --name=vagrant --plaintext --password vagrant

--- a/packer_templates/centos/http/8/ks.cfg
+++ b/packer_templates/centos/http/8/ks.cfg
@@ -40,7 +40,7 @@ network-scripts
 -intltool
 
 # unnecessary firmware
--*firmware
+-iwl*-firmware
 -microcode_ctl
 %end
 

--- a/packer_templates/centos/scripts/cleanup.sh
+++ b/packer_templates/centos/scripts/cleanup.sh
@@ -33,6 +33,9 @@ fi
 # Remove development and kernel source packages
 $pkg_cmd -y remove gcc cpp kernel-devel kernel-headers;
 
+# Couldn't exclude it during kickstart (kernel-core requires it), remove it now
+$pkg_cmd -y remove linux-firmware
+
 # Clean up network interface persistence
 rm -f /etc/udev/rules.d/70-persistent-net.rules;
 mkdir -p /etc/udev/rules.d/70-persistent-net.rules;


### PR DESCRIPTION
## Description
The CentOS 8.2 build is currently broken in `master` for two reasons:
1. Firmware packages are being excluded with `-*firmware`, but the `linux-firmware` package needs to be present because it's a hard dependency for the `kernel-core` package in the installation media.
2. The kickstart file configures authentication options using the deprecated `auth` statement which doesn't seem to work anymore (`anaconda` complains about a missing `/usr/sbin/authconfig` even when the package that provides it — `authselect-compat` — is explicitly added to the list of included packages). 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
