### PR TITLE
Fix virtualbox additions build failure on CentOS 8.2

### DIFF
--- a/packer_templates/_common/virtualbox.sh
+++ b/packer_templates/_common/virtualbox.sh
@@ -15,9 +15,9 @@ virtualbox-iso|virtualbox-ovf)
     echo "installing deps necessary to compile kernel modules"
     # We install things like kernel-headers here vs. kickstart files so we make sure we install them for the updated kernel not the stock kernel
     if [ -f "/bin/dnf" ]; then
-        dnf install -y perl cpp gcc make bzip2 tar kernel-headers kernel-devel kernel-uek-devel || true # not all these packages are on every system
+        dnf install -y --skip-broken perl cpp gcc make bzip2 tar kernel-headers kernel-devel kernel-uek-devel || true # not all these packages are on every system
     elif [ -f "/bin/yum" ] || [ -f "/usr/bin/yum" ]; then
-        yum install -y perl cpp gcc make bzip2 tar kernel-headers kernel-devel kernel-uek-devel || true # not all these packages are on every system
+        yum install -y --skip-broken perl cpp gcc make bzip2 tar kernel-headers kernel-devel kernel-uek-devel || true # not all these packages are on every system
     elif [ -f "/usr/bin/apt-get" ]; then
         apt-get install -y build-essential dkms bzip2 tar linux-headers-`uname -r`
     elif [ -f "/usr/bin/zypper" ]; then
@@ -32,7 +32,7 @@ virtualbox-iso|virtualbox-ovf)
          echo "Cannot find vbox kernel module. Installation of guest additions unsuccessful!"
          exit 1
     fi
-    
+
     echo "unmounting and removing the vbox ISO"
     umount /tmp/vbox;
     rm -rf /tmp/vbox;


### PR DESCRIPTION
## Description
The build was failing for CentOS 8.2 because the necessary dependencies for virtualbox guest additions weren't being installed. It seems that a `dnf` default has changed and it now requires an explicit `--skip-broken` to ignore missing packages.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
