### PR TITLE
Add qemuargs parameter for Fedora

### DIFF
--- a/packer_templates/fedora/fedora-31-x86_64.json
+++ b/packer_templates/fedora/fedora-31-x86_64.json
@@ -125,6 +125,7 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
+      "qemuargs": [["{{ user `qemuargs_opt` }}","{{ user `qemuargs_value` }}"]],
       "vm_name": "{{ user `template` }}"
     }
   ],
@@ -183,6 +184,8 @@
     "name": "fedora-31",
     "no_proxy": "{{env `no_proxy`}}",
     "template": "fedora-31-x86_64",
+    "qemuargs_opt": "-m",
+    "qemuargs_value": "1024M",
     "version": "TIMESTAMP"
   }
 }

--- a/packer_templates/fedora/fedora-32-x86_64.json
+++ b/packer_templates/fedora/fedora-32-x86_64.json
@@ -125,6 +125,7 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
+      "qemuargs": [["{{ user `qemuargs_opt` }}","{{ user `qemuargs_value` }}"]],
       "vm_name": "{{ user `template` }}"
     }
   ],
@@ -183,6 +184,8 @@
     "name": "fedora-32",
     "no_proxy": "{{env `no_proxy`}}",
     "template": "fedora-32-x86_64",
+    "qemuargs_opt": "-m",
+    "qemuargs_value": "1024M",
     "version": "TIMESTAMP"
   }
 }


### PR DESCRIPTION
Add qemuargs parameter for Fedora

## Description
Add qemuargs parameter for Fedora in order to use it during Fedora build (example : to load EFI firmware)

## Related Issue

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
