### PR TITLE
set fedora crypto policy to legacy

### DIFF
--- a/packer_templates/fedora/fedora-33-x86_64.json
+++ b/packer_templates/fedora/fedora-33-x86_64.json
@@ -148,6 +148,7 @@
         "{{template_dir}}/../_common/vagrant.sh",
         "{{template_dir}}/scripts/real-tmp.sh",
         "{{template_dir}}/scripts/cleanup.sh",
+        "{{template_dir}}/scripts/crypto-policy.sh",
         "{{template_dir}}/../_common/minimize.sh"
       ],
       "type": "shell"

--- a/packer_templates/fedora/scripts/crypto-policy.sh
+++ b/packer_templates/fedora/scripts/crypto-policy.sh
@@ -1,0 +1,2 @@
+#!/bin/bash -eux
+update-crypto-policies --set LEGACY


### PR DESCRIPTION
Fedora now [disables RSA](https://dev.to/bowmanjd/upgrade-ssh-client-keys-and-remote-servers-after-fedora-33-s-new-crypto-policy-47ag) cause it's considered as insecure

## Description
This PR sets the crypto mode as LEGACY

## Types of changes
- [ X ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ X ] I have read the **CONTRIBUTING** document.
- [ X ] I have run the pre-merge tests locally and they pass.
- [ X ] I have updated the documentation accordingly.
- [ X ] I have added tests to cover my changes.
- [ X ] All new and existing tests passed.
- [] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
