### PR TITLE
Improve vsphere boot_command

### DIFF
--- a/packer_templates/ubuntu/ubuntu-20.04-live-amd64.json
+++ b/packer_templates/ubuntu/ubuntu-20.04-live-amd64.json
@@ -41,20 +41,15 @@
         },
         {
             "boot_command": [
-                " <wait>",
-                " <wait>",
-                " <wait>",
-                " <wait>",
-                " <wait>",
+                "<escOn><wait5><escOff><enter><wait>",
+                "<esc><wait5>",
+                "<enter><wait>",
+                "<f6><wait5>",
                 "<esc><wait>",
-                "<f6><wait>",
-                "<esc><wait>",
-                "<bs><bs><bs><bs><wait>",
-                " autoinstall<wait5>",
-                " ds=nocloud-net<wait5>",
-                ";s=http://<wait5>{{.HTTPIP}}<wait5>:{{.HTTPPort}}/<wait5>",
-                " ---<wait5>",
-                "<enter><wait5>"
+                "<bs><bs><bs><bs>",
+                "autoinstall ds=nocloud-net;s=http://<wait5>{{.HTTPIP}}<wait5>:{{.HTTPPort}}/<wait5>",
+                " ---",
+                "<enter>"
             ],
             "boot_wait": "5s",
             "cpus": "{{ user `cpus` }}",


### PR DESCRIPTION

## Description
In production vsphere hosts with highly variable loads it is difficult to accurately predict how long to wait before sending the boot_command.  By holding down "escape" at the beginning of the boot command you force the VMware soft-bios to show the "boot device" selection menu. From there you can more easily predict when to send the <esc> key that loads the ubuntu graphical boot menu and in-turn be able to predict what keys to press.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
