### PR TITLE
Apple M1 support (Ubuntu 20.04, Parallels)

### DIFF
--- a/packer_templates/_common/parallels.sh
+++ b/packer_templates/_common/parallels.sh
@@ -6,7 +6,11 @@ HOME_DIR="${HOME_DIR:-/home/vagrant}";
 case "$PACKER_BUILDER_TYPE" in
 parallels-iso|parallels-pvm)
     mkdir -p /tmp/parallels;
-    mount -o loop $HOME_DIR/prl-tools-lin.iso /tmp/parallels;
+    if [ `uname -m` = "aarch64" ] ; then
+        mount -o loop $HOME_DIR/prl-tools-lin-arm.iso /tmp/parallels;
+    else
+        mount -o loop $HOME_DIR/prl-tools-lin.iso /tmp/parallels;
+    fi
     VER="`cat /tmp/parallels/version`";
 
     echo "Parallels Tools Version: $VER";

--- a/packer_templates/ubuntu/scripts/networking.sh
+++ b/packer_templates/ubuntu/scripts/networking.sh
@@ -13,6 +13,6 @@ network:
 EOF
 
 # Disable Predictable Network Interface names and use eth0
-sed -i 's/en[[:alnum:]]*/eth0/g' /etc/network/interfaces;
+[ -e /etc/network/interfaces ] && sed -i 's/en[[:alnum:]]*/eth0/g' /etc/network/interfaces;
 sed -i 's/GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0 \1"/g' /etc/default/grub;
 update-grub;

--- a/packer_templates/ubuntu/ubuntu-20.04-live-arm64.json
+++ b/packer_templates/ubuntu/ubuntu-20.04-live-arm64.json
@@ -1,0 +1,92 @@
+{
+    "builders": [
+        {
+            "boot_command": [
+                "<esc>",
+                "linux /casper/vmlinuz",
+                " quiet",
+                " autoinstall",
+                " ds='nocloud-net;s=http://{{.HTTPIP}}:{{.HTTPPort}}/'",
+                "<enter>",
+                "initrd /casper/initrd<enter>",
+                "boot<enter>"
+              ],
+            "boot_wait": "5s",
+            "cpus": "{{ user `cpus` }}",
+            "disk_size": "{{user `disk_size`}}",
+            "guest_os_type": "ubuntu",
+            "http_directory": "{{user `http_directory`}}",
+            "iso_checksum": "{{user `iso_checksum`}}",
+            "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+            "memory": "{{ user `memory` }}",
+            "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
+            "parallels_tools_flavor": "lin-arm",
+            "prlctl_version_file": ".prlctl_version",
+            "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
+            "ssh_password": "vagrant",
+            "ssh_port": 22,
+            "ssh_timeout": "10000s",
+            "ssh_username": "vagrant",
+            "type": "parallels-iso",
+            "vm_name": "{{ user `template` }}"
+        }
+    ],
+    "post-processors": [
+        {
+            "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
+            "type": "vagrant"
+        }
+    ],
+    "provisioners": [
+        {
+            "environment_vars": [
+                "HOME_DIR=/home/vagrant",
+                "http_proxy={{user `http_proxy`}}",
+                "https_proxy={{user `https_proxy`}}",
+                "no_proxy={{user `no_proxy`}}"
+            ],
+            "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+            "expect_disconnect": true,
+            "scripts": [
+                "{{template_dir}}/scripts/update.sh",
+                "{{template_dir}}/../_common/motd.sh",
+                "{{template_dir}}/../_common/sshd.sh",
+                "{{template_dir}}/scripts/networking.sh",
+                "{{template_dir}}/scripts/sudoers.sh",
+                "{{template_dir}}/scripts/vagrant.sh",
+                "{{template_dir}}/../_common/virtualbox.sh",
+                "{{template_dir}}/scripts/vmware.sh",
+                "{{template_dir}}/../_common/parallels.sh",
+                "{{template_dir}}/scripts/hyperv.sh",
+                "{{template_dir}}/scripts/cleanup.sh",
+                "{{template_dir}}/../_common/minimize.sh"
+            ],
+            "type": "shell"
+        }
+    ],
+    "variables": {
+        "box_basename": "ubuntu-20.04-live",
+        "build_directory": "../../builds",
+        "build_timestamp": "{{isotime \"20060102150405\"}}",
+        "cpus": "2",
+        "disk_size": "65536",
+        "git_revision": "__unknown_git_revision__",
+        "guest_additions_url": "",
+        "headless": "",
+        "http_directory": "{{template_dir}}/http",
+        "http_proxy": "{{env `http_proxy`}}",
+        "https_proxy": "{{env `https_proxy`}}",
+        "hyperv_generation": "2",
+        "hyperv_switch": "bento",
+        "iso_checksum": "d6fea1f11b4d23b481a48198f51d9b08258a36f6024cb5cec447fe78379959ce",
+        "iso_name": "ubuntu-20.04.3-live-server-arm64.iso",
+        "memory": "1024",
+        "mirror": "http://cdimage.ubuntu.com",
+        "mirror_directory": "releases/20.04/release",
+        "name": "ubuntu-20.04-live",
+        "no_proxy": "{{env `no_proxy`}}",
+        "preseed_path": "preseed.cfg",
+        "template": "ubuntu-20.04-live-arm64",
+        "version": "TIMESTAMP"
+    }
+}


### PR DESCRIPTION
Signed-off-by: Jeff Noxon <jeff@noxon.cc>

This PR adds support for Ubuntu 20.04 on Apple M1 using Parallels

## Description

Note that Parallels version 17.0.1 (51482) has a bug where performance falls off a cliff after an ISO is ejected. A simple boot will take over 5 minutes with a detached CD-ROM. This affects building this box. The only workaround I am aware of is to immediately reconnect the ISO to the CD-ROM device after the installer ejects it.

When using this image with Vagrant, `v.customize ["set", :id, "--device-del", "cdrom0" ]` may be useful, as well.

## Related Issue

https://github.com/chef/bento/issues/1344

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
