### PR TITLE
Standardize qemuargs for qemu type across packer templates

### DIFF
--- a/packer_templates/almalinux/almalinux-8.4-x86_64.json
+++ b/packer_templates/almalinux/almalinux-8.4-x86_64.json
@@ -113,7 +113,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -169,6 +173,7 @@
     "mirror_directory": "8.4/isos/x86_64",
     "name": "almalinux-8.4",
     "no_proxy": "{{env `no_proxy`}}",
+    "qemu_display": "none",
     "template": "almalinux-8.4-x86_64",
     "boot_command": "<up><wait><tab> inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>",
     "version": "TIMESTAMP"

--- a/packer_templates/centos/centos-7.9-x86_64.json
+++ b/packer_templates/centos/centos-7.9-x86_64.json
@@ -121,7 +121,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -177,6 +181,7 @@
     "mirror_directory": "7.9.2009/isos/x86_64",
     "name": "centos-7.9",
     "no_proxy": "{{env `no_proxy`}}",
+    "qemu_display": "none",
     "template": "centos-7.9-x86_64",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/centos/centos-8.4-x86_64.json
+++ b/packer_templates/centos/centos-8.4-x86_64.json
@@ -113,7 +113,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -169,6 +173,7 @@
     "mirror_directory": "8.4.2105/isos/x86_64",
     "name": "centos-8.4",
     "no_proxy": "{{env `no_proxy`}}",
+    "qemu_display": "none",
     "template": "centos-8.4-x86_64",
     "boot_command": "<up><wait><tab> inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>",
     "version": "TIMESTAMP"

--- a/packer_templates/centos/centos-stream-8-x86_64.json
+++ b/packer_templates/centos/centos-stream-8-x86_64.json
@@ -113,7 +113,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -169,6 +173,7 @@
     "mirror_directory": "8-stream/isos/x86_64",
     "name": "centos-stream-8",
     "no_proxy": "{{env `no_proxy`}}",
+    "qemu_display": "none",
     "template": "centos-stream-8-x86_64",
     "boot_command": "<up><wait><tab> inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>",
     "version": "TIMESTAMP"

--- a/packer_templates/debian/debian-10.10-amd64.json
+++ b/packer_templates/debian/debian-10.10-amd64.json
@@ -156,7 +156,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -212,6 +216,7 @@
     "name": "debian-10.10",
     "no_proxy": "{{env `no_proxy`}}",
     "preseed_path": "debian-9/preseed.cfg",
+    "qemu_display": "none",
     "template": "debian-10.10-amd64",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/debian/debian-10.10-i386.json
+++ b/packer_templates/debian/debian-10.10-i386.json
@@ -156,7 +156,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -212,6 +216,7 @@
     "name": "debian-10.10-i386",
     "no_proxy": "{{env `no_proxy`}}",
     "preseed_path": "debian-9/preseed.cfg",
+    "qemu_display": "none",
     "template": "debian-10.10-i386",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/debian/debian-11.0-amd64.json
+++ b/packer_templates/debian/debian-11.0-amd64.json
@@ -156,7 +156,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -212,6 +216,7 @@
     "name": "debian-11.0",
     "no_proxy": "{{env `no_proxy`}}",
     "preseed_path": "debian-9/preseed.cfg",
+    "qemu_display": "none",
     "template": "debian-11.0-amd64",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/debian/debian-11.0-i386.json
+++ b/packer_templates/debian/debian-11.0-i386.json
@@ -156,7 +156,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -212,6 +216,7 @@
     "name": "debian-11.0-i386",
     "no_proxy": "{{env `no_proxy`}}",
     "preseed_path": "debian-9/preseed.cfg",
+    "qemu_display": "none",
     "template": "debian-11.0-i386",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/debian/debian-9.13-amd64.json
+++ b/packer_templates/debian/debian-9.13-amd64.json
@@ -156,7 +156,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -212,6 +216,7 @@
     "name": "debian-9.13",
     "no_proxy": "{{env `no_proxy`}}",
     "preseed_path": "debian-9/preseed.cfg",
+    "qemu_display": "none",
     "template": "debian-9.13-amd64",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/debian/debian-9.13-i386.json
+++ b/packer_templates/debian/debian-9.13-i386.json
@@ -156,7 +156,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -212,6 +216,7 @@
     "name": "debian-9.13-i386",
     "no_proxy": "{{env `no_proxy`}}",
     "preseed_path": "debian-9/preseed.cfg",
+    "qemu_display": "none",
     "template": "debian-9.13-i386",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/debian/debian-9.13-ppc64el.json
+++ b/packer_templates/debian/debian-9.13-ppc64el.json
@@ -43,7 +43,11 @@
       "ssh_username": "vagrant",
       "type": "qemu",
       "use_default_display": true,
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -98,6 +102,7 @@
     "name": "debian-9.13",
     "no_proxy": "{{env `no_proxy`}}",
     "preseed_path": "debian-9/preseed.cfg",
+    "qemu_display": "none",
     "template": "debian-9.13-ppc64el",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/fedora/fedora-33-x86_64.json
+++ b/packer_templates/fedora/fedora-33-x86_64.json
@@ -25,7 +25,11 @@
       "ssh_timeout": "3600s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     },
     {
       "boot_command": "{{user `boot_command`}}",
@@ -117,7 +121,10 @@
       "ssh_username": "vagrant",
       "type": "qemu",
       "vm_name": "{{ user `template` }}",
-      "qemuargs": [["{{ user `qemuargs_opt` }}","{{ user `qemuargs_value` }}"]]
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -175,9 +182,8 @@
     "mirror_directory": "releases/33/Server/x86_64/iso",
     "name": "fedora-33",
     "no_proxy": "{{env `no_proxy`}}",
+    "qemu_display": "none",
     "template": "fedora-33-x86_64",
-    "qemuargs_opt": "-m",
-    "qemuargs_value": "1024M",
     "boot_command": "<up><wait><tab> inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/fedora/fedora-34-x86_64.json
+++ b/packer_templates/fedora/fedora-34-x86_64.json
@@ -25,7 +25,11 @@
       "ssh_timeout": "3600s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     },
     {
       "boot_command": "{{user `boot_command`}}",
@@ -117,7 +121,10 @@
       "ssh_username": "vagrant",
       "type": "qemu",
       "vm_name": "{{ user `template` }}",
-      "qemuargs": [["{{ user `qemuargs_opt` }}","{{ user `qemuargs_value` }}"]]
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -174,9 +181,8 @@
     "mirror_directory": "releases/34/Server/x86_64/iso",
     "name": "fedora-34",
     "no_proxy": "{{env `no_proxy`}}",
+    "qemu_display": "none",
     "template": "fedora-34-x86_64",
-    "qemuargs_opt": "-m",
-    "qemuargs_value": "1024M",
     "boot_command": "<up><wait><tab> inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/freebsd/freebsd-11.4-amd64.json
+++ b/packer_templates/freebsd/freebsd-11.4-amd64.json
@@ -147,7 +147,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -200,6 +204,7 @@
     "name": "freebsd-11.4",
     "no_proxy": "{{env `no_proxy`}}",
     "pkg_branch": "quarterly",
+    "qemu_display": "none",
     "template": "freebsd-11.4-amd64",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/freebsd/freebsd-11.4-i386.json
+++ b/packer_templates/freebsd/freebsd-11.4-i386.json
@@ -147,7 +147,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -200,6 +204,7 @@
     "name": "freebsd-11.4-i386",
     "no_proxy": "{{env `no_proxy`}}",
     "pkg_branch": "quarterly",
+    "qemu_display": "none",
     "template": "freebsd-11.4-i386",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/freebsd/freebsd-12.2-amd64.json
+++ b/packer_templates/freebsd/freebsd-12.2-amd64.json
@@ -147,7 +147,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -200,6 +204,7 @@
     "name": "freebsd-12.2",
     "no_proxy": "{{env `no_proxy`}}",
     "pkg_branch": "quarterly",
+    "qemu_display": "none",
     "template": "freebsd-12.2-amd64",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/freebsd/freebsd-12.2-i386.json
+++ b/packer_templates/freebsd/freebsd-12.2-i386.json
@@ -147,7 +147,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -200,6 +204,7 @@
     "name": "freebsd-12.2-i386",
     "no_proxy": "{{env `no_proxy`}}",
     "pkg_branch": "quarterly",
+    "qemu_display": "none",
     "template": "freebsd-12.2-i386",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/freebsd/freebsd-13.0-amd64.json
+++ b/packer_templates/freebsd/freebsd-13.0-amd64.json
@@ -147,7 +147,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -200,6 +204,7 @@
     "name": "freebsd-13.0",
     "no_proxy": "{{env `no_proxy`}}",
     "pkg_branch": "quarterly",
+    "qemu_display": "none",
     "template": "freebsd-13.0-amd64",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/hardenedbsd/hardenedbsd-11-amd64.json
+++ b/packer_templates/hardenedbsd/hardenedbsd-11-amd64.json
@@ -147,7 +147,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -197,6 +201,7 @@
     "mirror_directory": "pub/hardenedbsd/11-stable/amd64/amd64/build-3",
     "name": "hardenedbsd-11",
     "no_proxy": "{{env `no_proxy`}}",
+    "qemu_display": "none",
     "template": "hardenedbsd-11-amd64",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/opensuse/opensuse-leap-15.3-x86_64.json
+++ b/packer_templates/opensuse/opensuse-leap-15.3-x86_64.json
@@ -126,7 +126,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -184,6 +188,7 @@
     "mirror_directory": "leap/15.3/iso",
     "name": "opensuse-leap-15.3",
     "no_proxy": "{{env `no_proxy`}}",
+    "qemu_display": "none",
     "template": "opensuse-leap-15.3-x86_64",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/oraclelinux/oracle-6.10-i386.json
+++ b/packer_templates/oraclelinux/oracle-6.10-i386.json
@@ -121,7 +121,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -177,6 +181,7 @@
     "mirror_directory": "OL6/U9/i386",
     "name": "oracle-6.10-i386",
     "no_proxy": "{{env `no_proxy`}}",
+    "qemu_display": "none",
     "template": "oracle-6.10-i386",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/oraclelinux/oracle-6.10-x86_64.json
+++ b/packer_templates/oraclelinux/oracle-6.10-x86_64.json
@@ -121,7 +121,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -178,6 +182,7 @@
     "mirror_directory": "OL6/U9/x86_64",
     "name": "oracle-6.10",
     "no_proxy": "{{env `no_proxy`}}",
+    "qemu_display": "none",
     "template": "oracle-6.10-x86_64",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/oraclelinux/oracle-7.9-x86_64.json
+++ b/packer_templates/oraclelinux/oracle-7.9-x86_64.json
@@ -121,7 +121,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -178,6 +182,7 @@
     "mirror_directory": "OL7/u9/x86_64",
     "name": "oracle-7.9",
     "no_proxy": "{{env `no_proxy`}}",
+    "qemu_display": "none",
     "template": "oracle-7.9-x86_64",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/oraclelinux/oracle-8.3-x86_64.json
+++ b/packer_templates/oraclelinux/oracle-8.3-x86_64.json
@@ -113,7 +113,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -169,6 +173,7 @@
     "mirror_directory": "OL8/u3/x86_64",
     "name": "oracle-8.3",
     "no_proxy": "{{env `no_proxy`}}",
+    "qemu_display": "none",
     "template": "oracle-8.3-x86_64",
     "boot_command": "<up><wait><tab> inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>",
     "version": "TIMESTAMP"

--- a/packer_templates/rhel/rhel-6.10-i386.json
+++ b/packer_templates/rhel/rhel-6.10-i386.json
@@ -95,7 +95,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -149,6 +153,7 @@
     "mirror_directory": "rhel",
     "name": "rhel-6.10-i386",
     "no_proxy": "{{env `no_proxy`}}",
+    "qemu_display": "none",
     "template": "rhel-6.10-i386",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/rhel/rhel-6.10-x86_64.json
+++ b/packer_templates/rhel/rhel-6.10-x86_64.json
@@ -95,7 +95,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -149,6 +153,7 @@
     "mirror_directory": "rhel",
     "name": "rhel-6.10",
     "no_proxy": "{{env `no_proxy`}}",
+    "qemu_display": "none",
     "template": "rhel-6.10-x86_64",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/rhel/rhel-7.6-x86_64.json
+++ b/packer_templates/rhel/rhel-7.6-x86_64.json
@@ -95,7 +95,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -149,6 +153,7 @@
     "mirror_directory": "rhel",
     "name": "rhel-7.6",
     "no_proxy": "{{env `no_proxy`}}",
+    "qemu_display": "none",
     "template": "rhel-7.6-x86_64",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/rhel/rhel-8.0-x86_64.json
+++ b/packer_templates/rhel/rhel-8.0-x86_64.json
@@ -95,7 +95,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -149,6 +153,7 @@
     "mirror_directory": "rhel",
     "name": "rhel-8.0",
     "no_proxy": "{{env `no_proxy`}}",
+    "qemu_display": "none",
     "template": "rhel-8.0-x86_64",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/rockylinux/rockylinux-8.4-x86_64.json
+++ b/packer_templates/rockylinux/rockylinux-8.4-x86_64.json
@@ -113,7 +113,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -169,6 +173,7 @@
     "mirror_directory": "8.4/isos/x86_64",
     "name": "rockylinux-8.4",
     "no_proxy": "{{env `no_proxy`}}",
+    "qemu_display": "none",
     "template": "rockylinux-8.4-x86_64",
     "boot_command": "<up><wait><tab> inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>",
     "version": "TIMESTAMP"

--- a/packer_templates/scientificlinux/scientific-7.9-x86_64.json
+++ b/packer_templates/scientificlinux/scientific-7.9-x86_64.json
@@ -121,7 +121,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -177,6 +181,7 @@
     "mirror_directory": "7.9/x86_64/iso",
     "name": "scientific-7.9",
     "no_proxy": "{{env `no_proxy`}}",
+    "qemu_display": "none",
     "template": "scientific-7-x86_64",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/sles/sles-11-sp4-x86_64.json
+++ b/packer_templates/sles/sles-11-sp4-x86_64.json
@@ -111,7 +111,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -167,6 +171,7 @@
     "memory": "1024",
     "mirror": "./packer_cache",
     "name": "sles-11-sp4",
+    "qemu_display": "none",
     "template": "sles-11-sp4-x86_64",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/sles/sles-12-sp2-x86_64.json
+++ b/packer_templates/sles/sles-12-sp2-x86_64.json
@@ -111,7 +111,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -168,6 +172,7 @@
     "memory": "1024",
     "mirror": "./packer_cache",
     "name": "sles-12-sp2",
+    "qemu_display": "none",
     "template": "sles-12-sp2-x86_64",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/sles/sles-12-sp3-x86_64.json
+++ b/packer_templates/sles/sles-12-sp3-x86_64.json
@@ -111,7 +111,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -168,6 +172,7 @@
     "memory": "1024",
     "mirror": "./packer_cache",
     "name": "sles-12-sp3",
+    "qemu_display": "none",
     "template": "sles-12-sp3-x86_64",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/sles/sles-15-sp1.json
+++ b/packer_templates/sles/sles-15-sp1.json
@@ -149,7 +149,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -207,6 +211,7 @@
     "mirror": "./packer_cache",
     "name": "sles-15-sp1",
     "packages_iso": "SLE-15-SP1-Packages-x86_64-GM-DVD1.iso",
+    "qemu_display": "none",
     "template": "sles-15-sp1-x86_64",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/sles/sles-15-sp1.json
+++ b/packer_templates/sles/sles-15-sp1.json
@@ -141,6 +141,14 @@
         [
           "-device",
           "scsi-cd,bus=scsi1.0,drive=cdrom1"
+        ],
+        [
+          "-m",
+          "{{ user `memory` }}"
+        ],
+        [
+          "-display",
+          "{{ user `qemu_display` }}"
         ]
       ],
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
@@ -149,11 +157,7 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}",
-      "qemuargs": [
-        [ "-m", "{{ user `memory` }}" ],
-        [ "-display", "{{ user `qemu_display` }}" ]
-      ]
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/packer_templates/sles/sles-15.json
+++ b/packer_templates/sles/sles-15.json
@@ -149,7 +149,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -207,6 +211,7 @@
     "mirror": "./packer_cache",
     "name": "sles-15",
     "packages_iso": "SLE-15-Packages-x86_64-GM-DVD1.iso",
+    "qemu_display": "none",
     "template": "sles-15-x86_64",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/sles/sles-15.json
+++ b/packer_templates/sles/sles-15.json
@@ -141,6 +141,14 @@
         [
           "-device",
           "scsi-cd,bus=scsi1.0,drive=cdrom1"
+        ],
+        [
+          "-m",
+          "{{ user `memory` }}"
+        ],
+        [
+          "-display",
+          "{{ user `qemu_display` }}"
         ]
       ],
       "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
@@ -149,11 +157,7 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}",
-      "qemuargs": [
-        [ "-m", "{{ user `memory` }}" ],
-        [ "-display", "{{ user `qemu_display` }}" ]
-      ]
+      "vm_name": "{{ user `template` }}"
     }
   ],
   "post-processors": [

--- a/packer_templates/solaris/solaris-11-4-x86.json
+++ b/packer_templates/solaris/solaris-11-4-x86.json
@@ -139,6 +139,7 @@
     "memory": "4096",
     "mirror": "./packer_cache",
     "name": "solaris-11.4",
+    "qemu_display": "none",
     "template": "solaris-11.4-x86",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/solaris/solaris-11-x86.json
+++ b/packer_templates/solaris/solaris-11-x86.json
@@ -138,6 +138,7 @@
     "memory": "2048",
     "mirror": "./packer_cache",
     "name": "solaris-11.3",
+    "qemu_display": "none",
     "template": "solaris-11.3-x86",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/springdalelinux/springdalelinux-7.9-x86_64.json
+++ b/packer_templates/springdalelinux/springdalelinux-7.9-x86_64.json
@@ -113,7 +113,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     }
   ],
   "post-processors": [
@@ -169,6 +173,7 @@
     "mirror_directory": "7.5/x86_64/iso",
     "name": "springdalelinux-7.9",
     "no_proxy": "{{env `no_proxy`}}",
+    "qemu_display": "none",
     "template": "springdalelinux-7.9-x86_64",
     "boot_command": "<up><wait><tab> inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>",
     "version": "TIMESTAMP"

--- a/packer_templates/ubuntu/ubuntu-18.04-amd64.json
+++ b/packer_templates/ubuntu/ubuntu-18.04-amd64.json
@@ -184,7 +184,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     },
     {
       "boot_command": [
@@ -276,6 +280,7 @@
     "name": "ubuntu-18.04",
     "no_proxy": "{{env `no_proxy`}}",
     "preseed_path": "preseed.cfg",
+    "qemu_display": "none",
     "template": "ubuntu-18.04-amd64",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/ubuntu/ubuntu-20.04-amd64.json
+++ b/packer_templates/ubuntu/ubuntu-20.04-amd64.json
@@ -184,7 +184,11 @@
       "ssh_timeout": "10000s",
       "ssh_username": "vagrant",
       "type": "qemu",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
     },
     {
       "boot_command": [
@@ -276,6 +280,7 @@
     "name": "ubuntu-20.04",
     "no_proxy": "{{env `no_proxy`}}",
     "preseed_path": "preseed.cfg",
+    "qemu_display": "none",
     "template": "ubuntu-20.04-amd64",
     "version": "TIMESTAMP"
   }

--- a/packer_templates/ubuntu/ubuntu-20.04-live-amd64.json
+++ b/packer_templates/ubuntu/ubuntu-20.04-live-amd64.json
@@ -148,7 +148,11 @@
             "ssh_timeout": "10000s",
             "ssh_username": "vagrant",
             "type": "qemu",
-            "vm_name": "{{ user `template` }}"
+            "vm_name": "{{ user `template` }}",
+            "qemuargs": [
+              [ "-m", "{{ user `memory` }}" ],
+              [ "-display", "{{ user `qemu_display` }}" ]
+            ]
         },
         {
             "boot_command": [
@@ -243,6 +247,7 @@
         "name": "ubuntu-20.04-live",
         "no_proxy": "{{env `no_proxy`}}",
         "preseed_path": "preseed.cfg",
+        "qemu_display": "none",
         "template": "ubuntu-20.04-live-amd64",
         "version": "TIMESTAMP"
     }

--- a/packer_templates/ubuntu/ubuntu-20.10-amd64.json
+++ b/packer_templates/ubuntu/ubuntu-20.10-amd64.json
@@ -173,7 +173,11 @@
             "ssh_timeout": "10000s",
             "ssh_username": "vagrant",
             "type": "qemu",
-            "vm_name": "{{ user `template` }}"
+            "vm_name": "{{ user `template` }}",
+            "qemuargs": [
+              [ "-m", "{{ user `memory` }}" ],
+              [ "-display", "{{ user `qemu_display` }}" ]
+            ]
         },
         {
             "boot_command": [
@@ -274,6 +278,7 @@
         "name": "ubuntu-20.10",
         "no_proxy": "{{env `no_proxy`}}",
         "preseed_path": "preseed.cfg",
+        "qemu_display": "none",
         "template": "ubuntu-20.10-amd64",
         "version": "TIMESTAMP"
     }

--- a/packer_templates/ubuntu/ubuntu-21.04-amd64.json
+++ b/packer_templates/ubuntu/ubuntu-21.04-amd64.json
@@ -173,7 +173,11 @@
             "ssh_timeout": "10000s",
             "ssh_username": "vagrant",
             "type": "qemu",
-            "vm_name": "{{ user `template` }}"
+            "vm_name": "{{ user `template` }}",
+            "qemuargs": [
+              [ "-m", "{{ user `memory` }}" ],
+              [ "-display", "{{ user `qemu_display` }}" ]
+            ]
         },
         {
             "boot_command": [
@@ -274,6 +278,7 @@
         "name": "ubuntu-21.04",
         "no_proxy": "{{env `no_proxy`}}",
         "preseed_path": "preseed.cfg",
+        "qemu_display": "none",
         "template": "ubuntu-21.04-amd64",
         "version": "TIMESTAMP"
     }

--- a/packer_templates/windows/windows-10.json
+++ b/packer_templates/windows/windows-10.json
@@ -147,6 +147,10 @@
         [
           "-drive",
           "file={{ user `build_directory` }}/packer-{{ user `template` }}-qemu/{{ .Name }},if=virtio,cache=writeback,discard=ignore,format=qcow2,index=1"
+        ],
+        [
+          "-display",
+          "{{ user `qemu_display` }}"
         ]
       ],
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
@@ -233,6 +237,7 @@
     "iso_checksum": "489ebee676e26cdb81377b0e6385c001a22589b8",
     "iso_url": "https://software-download.microsoft.com/download/pr/18363.418.191007-0143.19h2_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso",
     "memory": "4096",
+    "qemu_display": "none",
     "template": "windows-10",
     "unattended_file_path": "10/Autounattend.xml",
     "virtio_win_iso": "~/virtio-win.iso"

--- a/packer_templates/windows/windows-10gen2.json
+++ b/packer_templates/windows/windows-10gen2.json
@@ -51,6 +51,10 @@
         [
           "-bios",
           "{{ user `qemu_bios` }}"
+        ],
+        [
+          "-display",
+          "{{ user `qemu_display` }}"
         ]
       ],
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
@@ -150,6 +154,7 @@
     "winrm_timeout": "6h",
     "working_directory": "",
     "qemu_bios": "/usr/share/OVMF/OVMF_CODE.fd",
+    "qemu_display": "none",
     "disk_interface": "ide",
     "boot_wait": "10s",
     "cd_files": "{{template_dir}}/answer_files/10/Autounattend.xml"

--- a/packer_templates/windows/windows-2012.json
+++ b/packer_templates/windows/windows-2012.json
@@ -141,6 +141,10 @@
         [
           "-drive",
           "file={{ user `build_directory` }}/packer-{{ user `template` }}-qemu/{{ .Name }},if=virtio,cache=writeback,discard=ignore,format=qcow2,index=1"
+        ],
+        [
+          "-display",
+          "{{ user `qemu_display` }}"
         ]
       ],
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
@@ -227,6 +231,7 @@
     "iso_checksum": "922b365c3360ce630f6a4b4f2f3c79e66165c0fb",
     "iso_url": "http://download.microsoft.com/download/6/D/A/6DAB58BA-F939-451D-9101-7DE07DC09C03/9200.16384.WIN8_RTM.120725-1247_X64FRE_SERVER_EVAL_EN-US-HRM_SSS_X64FREE_EN-US_DV5.ISO",
     "memory": "4096",
+    "qemu_display": "none",
     "template": "windows-2012-standard",
     "unattended_file_path": "2012/Autounattend.xml",
     "virtio_win_iso": "~/virtio-win.iso"

--- a/packer_templates/windows/windows-2012r2.json
+++ b/packer_templates/windows/windows-2012r2.json
@@ -141,6 +141,10 @@
         [
           "-drive",
           "file={{ user `build_directory` }}/packer-{{ user `template` }}-qemu/{{ .Name }},if=virtio,cache=writeback,discard=ignore,format=qcow2,index=1"
+        ],
+        [
+          "-display",
+          "{{ user `qemu_display` }}"
         ]
       ],
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
@@ -227,6 +231,7 @@
     "iso_checksum": "849734f37346385dac2c101e4aacba4626bb141c",
     "iso_url": "http://download.microsoft.com/download/6/2/A/62A76ABB-9990-4EFC-A4FE-C7D698DAEB96/9600.17050.WINBLUE_REFRESH.140317-1640_X64FRE_SERVER_EVAL_EN-US-IR3_SSS_X64FREE_EN-US_DV9.ISO",
     "memory": "4096",
+    "qemu_display": "none",
     "template": "windows-2012r2-standard",
     "unattended_file_path": "2012_r2/Autounattend.xml",
     "virtio_win_iso": "~/virtio-win.iso"

--- a/packer_templates/windows/windows-2016.json
+++ b/packer_templates/windows/windows-2016.json
@@ -141,6 +141,10 @@
         [
           "-drive",
           "file={{ user `build_directory` }}/packer-{{ user `template` }}-qemu/{{ .Name }},if=virtio,cache=writeback,discard=ignore,format=qcow2,index=1"
+        ],
+        [
+          "-display",
+          "{{ user `qemu_display` }}"
         ]
       ],
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
@@ -227,6 +231,7 @@
     "iso_checksum": "772700802951b36c8cb26a61c040b9a8dc3816a3",
     "iso_url": "https://software-download.microsoft.com/download/pr/Windows_Server_2016_Datacenter_EVAL_en-us_14393_refresh.ISO",
     "memory": "4096",
+    "qemu_display": "none",
     "template": "windows-2016-standard",
     "unattended_file_path": "2016/Autounattend.xml",
     "virtio_win_iso": "~/virtio-win.iso"

--- a/packer_templates/windows/windows-2019.json
+++ b/packer_templates/windows/windows-2019.json
@@ -141,6 +141,10 @@
         [
           "-drive",
           "file={{ user `build_directory` }}/packer-{{ user `template` }}-qemu/{{ .Name }},if=virtio,cache=writeback,discard=ignore,format=qcow2,index=1"
+        ],
+        [
+          "-display",
+          "{{ user `qemu_display` }}"
         ]
       ],
       "shutdown_command": "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"",
@@ -227,6 +231,7 @@
     "iso_checksum": "3022424f777b66a698047ba1c37812026b9714c5",
     "iso_url": "https://software-download.microsoft.com/download/pr/17763.737.190906-2324.rs5_release_svc_refresh_SERVER_EVAL_x64FRE_en-us_1.iso",
     "memory": "4096",
+    "qemu_display": "none",
     "template": "windows-2019-standard",
     "unattended_file_path": "2019/Autounattend.xml",
     "virtio_win_iso": "~/virtio-win.iso"


### PR DESCRIPTION
## Description

I found that for headless installations of qemu-type bento builds would fail as the qemu frontend is not available. I saw that some of the packer templates for the qemu type use qemuargs (mostly to explicitly pass `-m` memory argument, although a few other uses for the windows ones). I've gone through the packer templates and standardized a qemuargs section for all of the templates that have a qemu type.

Now, minimally `qemuargs` has -m (using `memory` in the user variables)
and -display (using `qemu_display`, which defaults to "none" in the
user variables to support headless builds).

This allows for headless builds with qemu. If you want to see the GUI you can set qemu_display to gtk or simply connect to the VNC port displayed in the output.

I have tested the builds for all of the templates supported by my system (alma, centos, debian, fedora, oracle, rockylinux, scientific, springdale, ubuntu) and they all worked. For the Windows and PPC ones I don't have any reason to expect they wouldn't, I did the same thing on all of them.

Signed-off-by: SG <13872653+mmguero@users.noreply.github.com>

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue, the issue being "can't build qemu images in headless configuration")
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
