### PR TITLE
Set crypto-policy to legacy on Fedora 34

### DIFF
--- a/packer_templates/fedora/fedora-34-x86_64.json
+++ b/packer_templates/fedora/fedora-34-x86_64.json
@@ -155,6 +155,7 @@
         "{{template_dir}}/../_common/vagrant.sh",
         "{{template_dir}}/scripts/real-tmp.sh",
         "{{template_dir}}/scripts/cleanup.sh",
+        "{{template_dir}}/scripts/crypto-policy.sh",
         "{{template_dir}}/../_common/minimize.sh"
       ],
       "type": "shell"


### PR DESCRIPTION
Without this, vagrant cannot log into this boxes without some work as the default rsa key is rejected.

Signed-off-by: Lance Albertson <lance@osuosl.org>
