### PR TITLE
Add Springdale 8

### DIFF
--- a/builds.yml
+++ b/builds.yml
@@ -29,6 +29,7 @@ public:
 - 'rockylinux-8.5'
 - 'scientific-7.9'
 - 'springdalelinux-7.9'
+- 'springdalelinux-8.5'
 - 'ubuntu-16.04-i386'
 - 'ubuntu-16.04'
 - 'ubuntu-18.04'
@@ -55,3 +56,4 @@ slugs:
   'rockylinux-8': 'rockylinux-8'
   'scientific-7': 'scientific-7'
   'springdalelinux-7': 'springdalelinux-7'
+  'springdalelinux-8': 'springdalelinux-8'

--- a/packer_templates/springdalelinux/http/8-netinst/ks.cfg
+++ b/packer_templates/springdalelinux/http/8-netinst/ks.cfg
@@ -1,0 +1,84 @@
+install
+url --url="http://springdale.princeton.edu/data/Springdale/8.1/x86_64/os"
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp --noipv6 --onboot=on --device=eth0
+rootpw --plaintext vagrant
+firewall --disabled
+selinux --permissive
+timezone UTC
+bootloader --timeout=1 --location=mbr --append="net.ifnames=0 biosdevname=0"
+text
+skipx
+zerombr
+clearpart --all --initlabel
+autopart --nohome --nolvm --noboot
+firstboot --disabled
+reboot --eject
+user --name=vagrant --plaintext --password vagrant
+
+%packages --ignoremissing --excludedocs --instLangs=en_US.utf8
+# maybe prb needed for vbos guest additions? https://github.com/chef/bento/issues/1345
+# kernel-devel
+# gcc
+# make
+# perl
+# elfutils-libelf-devel
+# end vbox
+# vagrant needs this to copy initial files via scp
+openssh-clients
+sudo
+selinux-policy-devel
+wget
+nfs-utils
+net-tools
+tar
+bzip2
+deltarpm
+rsync
+dnf-utils
+redhat-lsb-core
+elfutils-libelf-devel
+network-scripts
+-fprintd-pam
+-intltool
+-iwl*-firmware
+-microcode_ctl
+%end
+
+%post
+# sudo
+echo 'Defaults:vagrant !requiretty' > /etc/sudoers.d/vagrant
+echo '%vagrant ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/vagrant
+chmod 440 /etc/sudoers.d/vagrant
+
+# Enable hyper-v daemons only if using hyper-v virtualization
+if [ $(virt-what) == "hyperv" ]; then
+    dnf -y install hyperv-daemons cifs-utils
+    systemctl enable hypervvssd
+    systemctl enable hypervkvpd
+fi
+
+# Since we disable consistent network naming, we need to make sure the eth0
+# configuration file is in place so it will come up.
+# Delete other network configuration first because RHEL/C7 networking will not
+# restart successfully if there are configuration files for devices that do not
+# exist.
+rm -f /etc/sysconfig/network-scripts/ifcfg-e*
+cat > /etc/sysconfig/network-scripts/ifcfg-eth0 << _EOF_
+TYPE=Ethernet
+PROXY_METHOD=none
+BROWSER_ONLY=no
+BOOTPROTO=dhcp
+DEFROUTE=yes
+IPV4_FAILURE_FATAL=no
+IPV6INIT=yes
+IPV6_AUTOCONF=yes
+IPV6_DEFROUTE=yes
+IPV6_FAILURE_FATAL=no
+IPV6_ADDR_GEN_MODE=stable-privacy
+NAME=eth0
+DEVICE=eth0
+ONBOOT=yes
+_EOF_
+%end

--- a/packer_templates/springdalelinux/springdalelinux-8.5-x86_64.json
+++ b/packer_templates/springdalelinux/springdalelinux-8.5-x86_64.json
@@ -1,0 +1,196 @@
+{
+  "builders": [
+    {
+      "boot_command": "{{ user `boot_command` }}",
+      "boot_wait": "5s",
+      "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{ user `guest_additions_url` }}",
+      "guest_os_type": "RedHat_64",
+      "hard_drive_interface": "sata",
+      "headless": "{{ user `headless` }}",
+      "http_directory": "{{user `http_directory`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "memory": "{{ user `memory` }}",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_timeout": "10000s",
+      "ssh_username": "vagrant",
+      "type": "virtualbox-iso",
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "{{ user `template` }}"
+    },
+    {
+      "boot_command": "{{ user `boot_command` }}",
+      "boot_wait": "5s",
+      "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "guest_os_type": "centos-64",
+      "headless": "{{ user `headless` }}",
+      "http_directory": "{{user `http_directory`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "memory": "{{ user `memory` }}",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "version": "12",
+      "ssh_timeout": "10000s",
+      "ssh_username": "vagrant",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
+      "vm_name": "{{ user `template` }}",
+      "vmx_data": {
+        "cpuid.coresPerSocket": "1"
+      },
+      "vmx_remove_ethernet_interfaces": true
+    },
+    {
+      "boot_command": "{{user `boot_command`}}",
+      "boot_wait": "5s",
+      "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "guest_os_type": "centos",
+      "http_directory": "{{user `http_directory`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "memory": "{{ user `memory` }}",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
+      "parallels_tools_flavor": "lin",
+      "prlctl_version_file": ".prlctl_version",
+      "prlctl": [
+        [
+          "set",
+          "{{.Name}}",
+          "--3d-accelerate",
+          "off"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--videosize",
+          "16"
+        ]
+      ],
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_timeout": "10000s",
+      "ssh_username": "vagrant",
+      "type": "parallels-iso",
+      "vm_name": "{{ user `template` }}"
+    },
+    {
+      "boot_command": [
+        "<wait5><up><wait5><tab> text ks=hd:fd0:/ks.cfg<enter><wait5><esc>"
+      ],
+      "boot_wait": "5s",
+      "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "{{user `http_directory`}}/{{user `ks_path`}}"
+      ],
+      "generation": "{{user `hyperv_generation`}}",
+      "guest_additions_mode": "disable",
+      "http_directory": "{{user `http_directory`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "memory": "{{ user `memory` }}",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-hyperv",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_timeout": "10000s",
+      "ssh_username": "vagrant",
+      "switch_name": "{{ user `hyperv_switch`}}",
+      "type": "hyperv-iso",
+      "vm_name": "{{ user `template` }}"
+    },
+    {
+      "boot_command": "{{ user `boot_command` }}",
+      "boot_wait": "5s",
+      "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "headless": "{{ user `headless` }}",
+      "http_directory": "{{user `http_directory`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "memory": "{{ user `memory` }}",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_timeout": "10000s",
+      "ssh_username": "vagrant",
+      "type": "qemu",
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
+    }
+  ],
+  "post-processors": [
+    {
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "type": "vagrant"
+    }
+  ],
+  "provisioners": [
+    {
+      "environment_vars": [
+        "HOME_DIR=/home/vagrant",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
+      "scripts": [
+        "{{template_dir}}/../centos/scripts/update.sh",
+        "{{template_dir}}/../centos/scripts/networking.sh",
+        "{{template_dir}}/../_common/motd.sh",
+        "{{template_dir}}/../_common/sshd.sh",
+        "{{template_dir}}/../_common/vagrant.sh",
+        "{{template_dir}}/../_common/virtualbox.sh",
+        "{{template_dir}}/../_common/vmware.sh",
+        "{{template_dir}}/../_common/parallels.sh",
+        "{{template_dir}}/../centos/scripts/cleanup.sh",
+        "{{template_dir}}/../_common/minimize.sh"
+      ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "box_basename": "springdalelinux-8.5",
+    "build_directory": "../../builds",
+    "build_timestamp": "{{isotime \"2019102650405\"}}",
+    "cpus": "2",
+    "disk_size": "65536",
+    "git_revision": "__unknown_git_revision__",
+    "guest_additions_url": "",
+    "headless": "",
+    "http_directory": "{{template_dir}}/../springdalelinux/http",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "hyperv_generation": "1",
+    "hyperv_switch": "bento",
+    "iso_checksum": "7b2b3c20e202bc8b0791e9a09555961dc7ef533cc6e5c6daac980f335a55614f",
+    "iso_name": "Springdale%20Linux-8.5-x86_64-netinst.iso",
+    "ks_path": "8-netinst/ks.cfg",
+    "memory": "1024",
+    "mirror": "http://springdale.princeton.edu/data/springdale",
+    "mirror_directory": "8.5/x86_64/iso",
+    "name": "springdalelinux-8.5",
+    "no_proxy": "{{env `no_proxy`}}",
+    "qemu_display": "none",
+    "template": "springdalelinux-8.5-x86_64",
+    "boot_command": "<up><wait><tab> inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>",
+    "version": "TIMESTAMP"
+  }
+}


### PR DESCRIPTION
Signed-off-by: Christopher Peterson <cspeterson@cspeterson.net>

Add Springdale Linux 8

## Description

Springdale 7 is already in the templates, but not 8. SDL8 is useful especially now that CentOS 8 is EOL.

I mostly just copied the Springdale 7 template to update to 8

Springdale does not publish a full ISO for 8.x, only a netinstall, so I also had to use an alternate `ks.cfg` (modified from the included centos `ks.cfg`) which provides `url`.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

## Guest additions

To build this for VirtualBox requires providing the current testing version of VBox guest additions, as the current stable releases will fail to build with the current kernels (https://www.virtualbox.org/ticket/20488)

The situation is the same for building the current Rocky Linux box using these templates

## Testing

I can verify that building this individually for VirtualBox (with compatible Guest Additions) works but it appears to me that the Rakefile is currently broken so not sure if that would yield different results. 

I only have the one provider to test. Maybe someone could test the others?
