### PR TITLE
Reverts remove_defender cookbook updates for windows to windows_feature

### DIFF
--- a/packer_templates/windows/cookbooks/packer/recipes/remove_defender.rb
+++ b/packer_templates/windows/cookbooks/packer/recipes/remove_defender.rb
@@ -1,3 +1,3 @@
-windows_defender 'disable windows defender' do
-  action :disable
+windows_feature 'Windows-Defender' do
+  action :remove
 end


### PR DESCRIPTION
Signed-off-by: Collin McNeese <cmcneese@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Reverts updates made to the `remove_defender` recipe for the Windows cookbook configuration to use the `windows_feature` instead of `windows_defender` resource to resolve issues in #1380 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#1380 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
