### PR TITLE
Bump to Debian 11.4

### DIFF
--- a/packer_templates/debian/debian-11.4-amd64.json
+++ b/packer_templates/debian/debian-11.4-amd64.json
@@ -130,7 +130,7 @@
     }
   ],
   "variables": {
-    "box_basename": "debian-11.3",
+    "box_basename": "debian-11.4",
     "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"20060102150405\"}}",
     "cpus": "2",
@@ -141,17 +141,17 @@
     "http_directory": "{{template_dir}}/http",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
-    "iso_checksum": "7892981e1da216e79fb3a1536ce5ebab157afdd20048fe458f2ae34fbc26c19b",
-    "iso_name": "debian-11.3.0-amd64-netinst.iso",
+    "iso_checksum": "d490a35d36030592839f24e468a5b818c919943967012037d6ab3d65d030ef7f",
+    "iso_name": "debian-11.4.0-amd64-netinst.iso",
     "memory": "1024",
     "mirror": "http://cdimage.debian.org/cdimage/release",
-    "mirror_directory": "11.3.0/amd64/iso-cd",
-    "name": "debian-11.3",
+    "mirror_directory": "11.4.0/amd64/iso-cd",
+    "name": "debian-11.4",
     "no_proxy": "{{env `no_proxy`}}",
     "preseed_path": "debian-9/preseed.cfg",
     "qemu_display": "none",
     "qemu_bios": "bios-256k.bin",
-    "template": "debian-11.3-amd64",
+    "template": "debian-11.4-amd64",
     "boot_command": "<esc><wait>install <wait> preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `preseed_path`}} <wait>debian-installer=en_US.UTF-8 <wait>auto <wait>locale=en_US.UTF-8 <wait>kbd-chooser/method=us <wait>keyboard-configuration/xkb-keymap=us <wait>netcfg/get_hostname={{ .Name }} <wait>netcfg/get_domain=vagrantup.com <wait>fb=false <wait>debconf/frontend=noninteractive <wait>console-setup/ask_detect=false <wait>console-keymaps-at/keymap=us <wait>grub-installer/bootdev=default <wait><enter><wait>",
     "version": "TIMESTAMP"
   }


### PR DESCRIPTION
Move to Debian 11.4

## Description
Update the Debian 11 to be based on 11.4 instead of 11.3, as 11.3 is no longer current (so the iso downloads fail).

## Related Issue
No issue filed, "Debian 11 doesn't build" would be the issue (was looking at building that as there's no vmware box published for that version).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
