### PR TITLE
Add support for AlmaLinux 9 aarch64 parallels box

### DIFF
--- a/packer_templates/_common/parallels.sh
+++ b/packer_templates/_common/parallels.sh
@@ -9,39 +9,36 @@ parallels-iso|parallels-pvm)
     major_version="`sed 's/^.\+ release \([.0-9]\+\).*/\1/' /etc/redhat-release | awk -F. '{print $1}'`";
 
     # make sure we use dnf on EL 8+
-    if [ "$major_version" -ge 9 ]; then
-      echo "Parallels Tools doesn't support AlmaLinux 9 Yet"
+    mkdir -p /tmp/parallels;
+    if [ `uname -m` = "aarch64" ] ; then
+        mount -o loop $HOME_DIR/prl-tools-lin-arm.iso /tmp/parallels;
     else
-      mkdir -p /tmp/parallels;
-      if [ `uname -m` = "aarch64" ] ; then
-          mount -o loop $HOME_DIR/prl-tools-lin-arm.iso /tmp/parallels;
-      else
-          mount -o loop $HOME_DIR/prl-tools-lin.iso /tmp/parallels;
-      fi
-      VER="`cat /tmp/parallels/version`";
-
-      echo "Parallels Tools Version: $VER";
-
-      /tmp/parallels/install --install-unattended-with-deps \
-        || (code="$?"; \
-            echo "Parallels tools installation exited $code, attempting" \
-            "to output /var/log/parallels-tools-install.log"; \
-            cat /var/log/parallels-tools-install.log; \
-            exit $code);
-      umount /tmp/parallels;
-      rm -rf /tmp/parallels;
-      rm -f $HOME_DIR/*.iso;
-
-      # Parallels Tools for Linux includes native auto-mount script,
-      # which causes losing some of Vagrant-relative shared folders.
-      # So, we should disable this behavior.
-      # https://github.com/Parallels/vagrant-parallels/issues/325#issuecomment-418727113
-      auto_mount_script='/usr/bin/prlfsmountd'
-      if [ -f "${auto_mount_script}" ]; then
-          echo -e '#!/bin/sh\n'\
-          '# Shared folders auto-mount is disabled by Vagrant ' \
-          > "${auto_mount_script}"
-      fi
+        mount -o loop $HOME_DIR/prl-tools-lin.iso /tmp/parallels;
     fi
+    VER="`cat /tmp/parallels/version`";
+
+    echo "Parallels Tools Version: $VER";
+
+    /tmp/parallels/install --install-unattended-with-deps \
+      || (code="$?"; \
+          echo "Parallels tools installation exited $code, attempting" \
+          "to output /var/log/parallels-tools-install.log"; \
+          cat /var/log/parallels-tools-install.log; \
+          exit $code);
+    umount /tmp/parallels;
+    rm -rf /tmp/parallels;
+    rm -f $HOME_DIR/*.iso;
+
+    # Parallels Tools for Linux includes native auto-mount script,
+    # which causes losing some of Vagrant-relative shared folders.
+    # So, we should disable this behavior.
+    # https://github.com/Parallels/vagrant-parallels/issues/325#issuecomment-418727113
+    auto_mount_script='/usr/bin/prlfsmountd'
+    if [ -f "${auto_mount_script}" ]; then
+        echo -e '#!/bin/sh\n'\
+        '# Shared folders auto-mount is disabled by Vagrant ' \
+        > "${auto_mount_script}"
+    fi
+    
     ;;
 esac

--- a/packer_templates/almalinux/almalinux-9.0-aarch64.json
+++ b/packer_templates/almalinux/almalinux-9.0-aarch64.json
@@ -1,0 +1,195 @@
+  {
+  "builders": [
+    {
+      "boot_command": "{{ user `boot_command` }}",
+      "boot_wait": "5s",
+      "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_additions_url": "{{ user `guest_additions_url` }}",
+      "guest_os_type": "RedHat_64",
+      "hard_drive_interface": "sata",
+      "headless": "{{ user `headless` }}",
+      "http_directory": "{{user `http_directory`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "memory": "{{ user `memory` }}",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-virtualbox",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_timeout": "10000s",
+      "ssh_username": "vagrant",
+      "type": "virtualbox-iso",
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "{{ user `template` }}"
+    },
+    {
+      "boot_command": "{{ user `boot_command` }}",
+      "boot_wait": "5s",
+      "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "guest_os_type": "centos-64",
+      "headless": "{{ user `headless` }}",
+      "http_directory": "{{user `http_directory`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "memory": "{{ user `memory` }}",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-vmware",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "version": 19,
+      "ssh_timeout": "10000s",
+      "ssh_username": "vagrant",
+      "tools_upload_flavor": "linux",
+      "type": "vmware-iso",
+      "vm_name": "{{ user `template` }}",
+      "vmx_data": {
+        "cpuid.coresPerSocket": "1"
+      },
+      "vmx_remove_ethernet_interfaces": true
+    },
+    {
+      "boot_command": "{{user `boot_command`}}",
+      "boot_wait": "5s",
+      "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "guest_os_type": "centos",
+      "http_directory": "{{user `http_directory`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "memory": "{{ user `memory` }}",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-parallels",
+      "parallels_tools_flavor": "lin-arm",
+      "prlctl_version_file": ".prlctl_version",
+      "prlctl": [
+        [
+          "set",
+          "{{.Name}}",
+          "--3d-accelerate",
+          "off"
+        ],
+        [
+          "set",
+          "{{.Name}}",
+          "--videosize",
+          "16"
+        ]
+      ],
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_timeout": "10000s",
+      "ssh_username": "vagrant",
+      "type": "parallels-iso",
+      "vm_name": "{{ user `template` }}"
+    },
+    {
+      "boot_command": [
+        "<wait5><up><wait5><tab> text ks=hd:fd0:/ks.cfg<enter><wait5><esc>"
+      ],
+      "boot_wait": "5s",
+      "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "{{user `http_directory`}}/{{user `ks_path`}}"
+      ],
+      "generation": "{{user `hyperv_generation`}}",
+      "guest_additions_mode": "disable",
+      "http_directory": "{{user `http_directory`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "memory": "{{ user `memory` }}",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-hyperv",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_timeout": "10000s",
+      "ssh_username": "vagrant",
+      "switch_name": "{{ user `hyperv_switch`}}",
+      "type": "hyperv-iso",
+      "vm_name": "{{ user `template` }}"
+    },
+    {
+      "boot_command": "{{ user `boot_command` }}",
+      "boot_wait": "5s",
+      "cpus": "{{ user `cpus` }}",
+      "disk_size": "{{user `disk_size`}}",
+      "headless": "{{ user `headless` }}",
+      "http_directory": "{{user `http_directory`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_url": "{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}",
+      "memory": "{{ user `memory` }}",
+      "output_directory": "{{ user `build_directory` }}/packer-{{user `template`}}-qemu",
+      "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_timeout": "10000s",
+      "ssh_username": "vagrant",
+      "type": "qemu",
+      "vm_name": "{{ user `template` }}",
+      "qemuargs": [
+        [ "-m", "{{ user `memory` }}" ],
+        [ "-display", "{{ user `qemu_display` }}" ]
+      ]
+    }
+  ],
+  "post-processors": [
+    {
+      "output": "{{ user `build_directory` }}/{{user `box_basename`}}.{{.Provider}}.box",
+      "type": "vagrant"
+    }
+  ],
+  "provisioners": [
+    {
+      "environment_vars": [
+        "HOME_DIR=/home/vagrant",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": true,
+      "scripts": [
+        "{{template_dir}}/scripts/update.sh",
+        "{{template_dir}}/../_common/motd.sh",
+        "{{template_dir}}/../_common/sshd.sh",
+        "{{template_dir}}/../_common/vagrant.sh",
+        "{{template_dir}}/../_common/virtualbox.sh",
+        "{{template_dir}}/../_common/vmware.sh",
+        "{{template_dir}}/../_common/parallels.sh",
+        "{{template_dir}}/scripts/cleanup.sh",
+        "{{template_dir}}/../_common/minimize.sh"
+      ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "box_basename": "almalinux-9.0",
+    "build_directory": "../../builds",
+    "build_timestamp": "{{isotime \"202205251531\"}}",
+    "cpus": "2",
+    "disk_size": "65536",
+    "git_revision": "__unknown_git_revision__",
+    "guest_additions_url": "",
+    "headless": "",
+    "http_directory": "{{template_dir}}/http",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "hyperv_generation": "1",
+    "hyperv_switch": "bento",
+    "iso_checksum": "dcbb69c766575d8107b34371fb8b947abf3d6aea3df04515385fff0edb9c16ed",
+    "iso_name": "AlmaLinux-9.0-aarch64-dvd.iso",
+    "ks_path": "9/ks.cfg",
+    "memory": "1024",
+    "mirror": "http://mirror.cov.ukservers.com/almalinux",
+    "mirror_directory": "9.0/isos/aarch64",
+    "name": "almalinux-9.0",
+    "no_proxy": "{{env `no_proxy`}}",
+    "qemu_display": "none",
+    "template": "almalinux-9.0-aarch64",
+    "boot_command": "e<down><down><end><bs><bs><bs><bs><bs>inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<leftCtrlOn>x<leftCtrlOff>",
+    "version": "TIMESTAMP"
+  }
+}

--- a/packer_templates/almalinux/almalinux-9.0-aarch64.json
+++ b/packer_templates/almalinux/almalinux-9.0-aarch64.json
@@ -151,8 +151,22 @@
       ],
       "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
       "expect_disconnect": true,
+      "pause_after": "30s",
       "scripts": [
-        "{{template_dir}}/scripts/update.sh",
+        "{{template_dir}}/scripts/update.sh"
+      ],
+      "type": "shell"
+    },
+    {
+      "environment_vars": [
+        "HOME_DIR=/home/vagrant",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "expect_disconnect": false,
+      "scripts": [
         "{{template_dir}}/../_common/motd.sh",
         "{{template_dir}}/../_common/sshd.sh",
         "{{template_dir}}/../_common/vagrant.sh",
@@ -183,7 +197,7 @@
     "iso_name": "AlmaLinux-9.0-aarch64-dvd.iso",
     "ks_path": "9/ks.cfg",
     "memory": "1024",
-    "mirror": "http://mirror.cov.ukservers.com/almalinux",
+    "mirror": "https://mirrors.ukfast.co.uk/sites/almalinux.org",
     "mirror_directory": "9.0/isos/aarch64",
     "name": "almalinux-9.0",
     "no_proxy": "{{env `no_proxy`}}",


### PR DESCRIPTION
This pull request adds support for building AlmaLinux 9 aarch64 parallels vagrant boxes.

## Description
x86_64 images won't work on M1/M2 (arm) Macs, so this PR adds support for building an AlmaLinux 9 parallels box.  It mostly works, but the parallels tools do not currently support AlmaLinux 9. Once those are [updated](https://forum.parallels.com/threads/parallels-tools-do-not-install-on-rhel9.357546/page-2) the build should work properly. 

```
==> parallels-iso: Provisioning with shell script: ~/bento/packer_templates/almalinux/../_common/parallels.sh
==> parallels-iso: + HOME_DIR=/home/vagrant
==> parallels-iso: + case "$PACKER_BUILDER_TYPE" in
==> parallels-iso: ++ sed 's/^.\+ release \([.0-9]\+\).*/\1/' /etc/redhat-release
==> parallels-iso: ++ awk -F. '{print $1}'
    parallels-iso: Parallels Tools doesn't support AlmaLinux 9 Yet
==> parallels-iso: + major_version=9
==> parallels-iso: + '[' 9 -ge 9 ']'
==> parallels-iso: + echo 'Parallels Tools doesn'\''t support AlmaLinux 9 Yet'
```

When running packer it also complained about `Parallels Virtualization SDK is not installed` even though it was installed. To overcome this I had to specify the python path as an environment variable. 

To build the packer template, I therefore used the following:

`PYTHONPATH=/Library/Frameworks/ParallelsVirtualizationSDK.framework/Versions/10/Libraries/Python/3.7 packer build --only=parallels-iso packer_templates/almalinux/almalinux-9.0-aarch64.json`