### PR TITLE
Update Rocky Linux from 9.0 to 9.1

### DIFF
--- a/packer_templates/rockylinux/rockylinux-9.1-x86_64.json
+++ b/packer_templates/rockylinux/rockylinux-9.1-x86_64.json
@@ -22,10 +22,7 @@
       "ssh_username": "vagrant",
       "type": "virtualbox-iso",
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "{{ user `template` }}",
-      "vboxmanage": [
-        ["modifyvm", "{{.Name}}", "--nat-localhostreachable1", "on"]
-      ]
+      "vm_name": "{{ user `template` }}"
     },
     {
       "boot_command": "{{ user `boot_command` }}",

--- a/packer_templates/rockylinux/rockylinux-9.1-x86_64.json
+++ b/packer_templates/rockylinux/rockylinux-9.1-x86_64.json
@@ -22,7 +22,10 @@
       "ssh_username": "vagrant",
       "type": "virtualbox-iso",
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "{{ user `template` }}"
+      "vm_name": "{{ user `template` }}",
+      "vboxmanage": [
+        ["modifyvm", "{{.Name}}", "--nat-localhostreachable1", "on"]
+      ]
     },
     {
       "boot_command": "{{ user `boot_command` }}",
@@ -167,7 +170,7 @@
     }
   ],
   "variables": {
-    "box_basename": "rockylinux-9.0",
+    "box_basename": "rockylinux-9.1",
     "build_directory": "../../builds",
     "build_timestamp": "{{isotime \"202207180452\"}}",
     "cpus": "2",
@@ -180,16 +183,16 @@
     "https_proxy": "{{env `https_proxy`}}",
     "hyperv_generation": "1",
     "hyperv_switch": "bento",
-    "iso_checksum": "55dbf904b35969be9f6d96f042b7470d1a3cb5c953bba47ab8f79740560d8a8d",
-    "iso_name": "Rocky-9.0-x86_64-dvd.iso",
+    "iso_checksum": "file:https://download.rockylinux.org/pub/rocky/9.1/isos/x86_64/Rocky-9.1-x86_64-dvd.iso.CHECKSUM",
+    "iso_name": "Rocky-9.1-x86_64-dvd.iso",
     "ks_path": "9/ks.cfg",
     "memory": "1024",
-    "mirror": "http://download.rockylinux.org/pub/rocky",
+    "mirror": "https://download.rockylinux.org/pub/rocky",
     "mirror_directory": "9/isos/x86_64",
-    "name": "rockylinux-9.0",
+    "name": "rockylinux-9.1",
     "no_proxy": "{{env `no_proxy`}}",
     "qemu_display": "none",
-    "template": "rockylinux-9.0-x86_64",
+    "template": "rockylinux-9.1-x86_64",
     "boot_command": "<up><wait><tab> inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/{{user `ks_path`}}<enter><wait>",
     "version": "TIMESTAMP"
   }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Update Rocky Linux from 9.0 to 9.1, as the former doesn't even build anymore due to the referenced ISO no longer being available.

This also includes a fix for VirtualBox 7, where access to the NAT local host from the VM must be enabled explicitly.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
