### PR TITLE
Fix failing Amazon Linux builds

### DIFF
--- a/packer_templates/amazonlinux/README_FIRST.md
+++ b/packer_templates/amazonlinux/README_FIRST.md
@@ -4,5 +4,5 @@ This is not your normal Bento box. Instead of building a system from an ISO we'r
 
 1. Download the VirtualBox .vdi file for Amazon Linux 2 and place it in the same directory as this readme file. Amazon hosts these at https://cdn.amazonlinux.com/os-images/latest/virtualbox/. Make sure to name it amazon.vdi instead of the version specific name that Amazon gives it on their site.
 2. Run the STEP1_build_ovf.sh script to prepare this VDI file for packer and export it as a OVF file.
-3. Run packer: bento build packer_templates/amazonlinux/amazon-2-x86_64.json
+3. From the amazonlinux directory run packer: bento build amazon-2-x86_64.json
 4. OPTIONAL: Cleanup the leftover files in the directory

--- a/packer_templates/amazonlinux/amazon-2-x86_64.json
+++ b/packer_templates/amazonlinux/amazon-2-x86_64.json
@@ -67,7 +67,6 @@
     "disk_size": "65536",
     "git_revision": "__unknown_git_revision__",
     "headless": "",
-    "http_directory": "{{template_dir}}/http",
     "http_proxy": "{{env `http_proxy`}}",
     "https_proxy": "{{env `https_proxy`}}",
     "memory": "1024",


### PR DESCRIPTION
The http variable without the dir causes failures and the instructions were a tiny bit wrong

Signed-off-by: Tim Smith <tim@mondoo.com>