### PR TITLE
Possible increase performance for some Virtualbox builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Bento is a project that encapsulates [Packer](https://www.packer.io/) templates 
 ***NOTE:**
 
 - Virutalbox 7.x requires extra config to allow nat network to connect to the host. To use uncomment lines #154 and #155 in bento/packer_templates/pkr-variables.pkr.hcl
+- Virtualbox disable by default the host I/O cache of the SATA controler. This reduce the performance of the VM. It is possible to evaluate if enable this swtich can improve the speed of the box creation when uncomment lines #157 to #164 in bento/packer_templates/pkr-variables.pkr.hcl.
 - When running packer build command the output directory is relative to the working directory the command is currently running in. Suggest running packer build commands from bento root directory for build working files to be placed in bento/builds/(build_name) directory by default. If the output_directory variable isn't overwritten a directory called builds/(build_name) will be created in the current working directory that you are running the command from
 
 ## Using Public Boxes

--- a/packer_templates/pkr-variables.pkr.hcl
+++ b/packer_templates/pkr-variables.pkr.hcl
@@ -154,6 +154,14 @@ variable "vboxmanage" {
       # "--nat-localhostreachable1",
       # "on",
     ]
+    #,
+    #[
+    #  "storagectl",
+    #  "{{.Name}}",
+    #  "--name",
+    #  "SATA Controller",
+    #  "--hostiocache", "on",
+    #]
   ]
 }
 variable "virtualbox_version_file" {


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Some virtualbox are build with 'SATA Controler' with host I/O cache disable by default.
This reduce the performance of the VM.
Fortunately it is possible put this switch on (which also increase the speed of the VM.)
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
