### PR TITLE
fix: truncate `/var/lib/dbus/machine-id` in case it's separate from `/etc/machine-id`

### DIFF
--- a/packer_templates/scripts/debian/cleanup_debian.sh
+++ b/packer_templates/scripts/debian/cleanup_debian.sh
@@ -49,6 +49,7 @@ find /var/log -type f -exec truncate --size=0 {} \;
 
 echo "blank netplan machine-id (DUID) so machines get unique ID generated on boot"
 truncate -s 0 /etc/machine-id
+truncate -s 0 /var/lib/dbus/machine-id  # if not symlinked to "/etc/machine-id"
 
 echo "remove the contents of /tmp and /var/tmp"
 rm -rf /tmp/* /var/tmp/*

--- a/packer_templates/scripts/fedora/cleanup_dnf.sh
+++ b/packer_templates/scripts/fedora/cleanup_dnf.sh
@@ -38,6 +38,7 @@ rm -f /var/lib/systemd/random-seed
 
 echo "Wipe netplan machine-id (DUID) so machines get unique ID generated on boot"
 truncate -s 0 /etc/machine-id
+truncate -s 0 /var/lib/dbus/machine-id  # if not symlinked to "/etc/machine-id"
 
 echo "Clear the history so our install commands aren't there"
 rm -f /root/.wget-hsts

--- a/packer_templates/scripts/rhel/cleanup_dnf.sh
+++ b/packer_templates/scripts/rhel/cleanup_dnf.sh
@@ -52,6 +52,7 @@ rm -f /var/lib/systemd/random-seed
 
 echo "Wipe netplan machine-id (DUID) so machines get unique ID generated on boot"
 truncate -s 0 /etc/machine-id
+truncate -s 0 /var/lib/dbus/machine-id  # if not symlinked to "/etc/machine-id"
 
 echo "Clear the history so our install commands aren't there"
 rm -f /root/.wget-hsts

--- a/packer_templates/scripts/rhel/cleanup_yum.sh
+++ b/packer_templates/scripts/rhel/cleanup_yum.sh
@@ -52,6 +52,7 @@ rm -f /var/lib/systemd/random-seed
 
 echo "Wipe netplan machine-id (DUID) so machines get unique ID generated on boot"
 truncate -s 0 /etc/machine-id
+truncate -s 0 /var/lib/dbus/machine-id  # if not symlinked to "/etc/machine-id"
 
 echo "Clear the history so our install commands aren't there"
 rm -f /root/.wget-hsts

--- a/packer_templates/scripts/suse/cleanup_suse.sh
+++ b/packer_templates/scripts/suse/cleanup_suse.sh
@@ -19,6 +19,7 @@ rm -rf /tmp/* /var/tmp/*
 
 echo "blank netplan machine-id (DUID) so machines get unique ID generated on boot"
 truncate -s 0 /etc/machine-id
+truncate -s 0 /var/lib/dbus/machine-id  # if not symlinked to "/etc/machine-id"
 
 echo "force a new random seed to be generated"
 rm -f /var/lib/systemd/random-seed

--- a/packer_templates/scripts/ubuntu/cleanup_ubuntu.sh
+++ b/packer_templates/scripts/ubuntu/cleanup_ubuntu.sh
@@ -90,6 +90,7 @@ find /var/log -type f -exec truncate --size=0 {} \;
 
 echo "blank netplan machine-id (DUID) so machines get unique ID generated on boot"
 truncate -s 0 /etc/machine-id
+truncate -s 0 /var/lib/dbus/machine-id  # if not symlinked to "/etc/machine-id"
 
 echo "remove the contents of /tmp and /var/tmp"
 rm -rf /tmp/* /var/tmp/*


### PR DESCRIPTION
Signed-off-by: Cory Francis Myers <cory@freedom.press>

## Description

`/var/lib/dbus/machine-id` [MAY][1] be a symlink to `/etc/machine-id`.  If it isn't, however, we need to truncate it separately to avoid reuse.

[1]: https://www.mail-archive.com/debian-bugs-dist@lists.debian.org/msg1818499.html

## Related Issue

Fixes #1421.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
