### PR TITLE
rectify typo for amazonlinux in locals data structure comparison test

### DIFF
--- a/packer_templates/pkr-builder.pkr.hcl
+++ b/packer_templates/pkr-builder.pkr.hcl
@@ -131,7 +131,7 @@ locals {
               "${path.root}/scripts/fedora/cleanup_dnf.sh",
               "${path.root}/scripts/_common/minimize.sh"
               ] : (
-              "${var.os_name}-${substr(var.os_version, 0, 1)}" == "amazonliunux-2" ||
+              "${var.os_name}-${substr(var.os_version, 0, 1)}" == "amazonlinux-2" ||
               "${var.os_name}-${substr(var.os_version, 0, 1)}" == "centos-7" ||
               "${var.os_name}-${substr(var.os_version, 0, 1)}" == "oraclelinux-7" ||
               "${var.os_name}-${substr(var.os_version, 0, 1)}" == "rhel-7" ||


### PR DESCRIPTION
Signed-off-by: Michael Campfield <michael.campfield@mailbox.org>

## Description
In the locals data structure there is a string misspelling which is part of a value equality conditional test.

The lefthand of the comparison operation is an equality test against the string 'amazonlinux-2' .  However, the string amazonlinux-2 has a character addition typo with a 'u' added between the i and n of linux: amazonliunux-2.  

Rectifying this issue will cause the value test against amazonlinux-2 to evaluate correctly.  

## Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

Obvious fix.
