### PR TITLE
remove excess curly brace in fedora 37 aarch64

### DIFF
--- a/os_pkrvars/fedora/fedora-37-aarch64.pkrvars.hcl
+++ b/os_pkrvars/fedora/fedora-37-aarch64.pkrvars.hcl
@@ -6,4 +6,4 @@ iso_checksum            = "sha256:1c2deba876bd2da3a429b1b0cd5e294508b8379b299913
 parallels_guest_os_type = "fedora-core"
 vbox_guest_os_type      = "Fedora_64"
 vmware_guest_os_type    = "fedora-64"
-boot_command            = ["<up><up>e<wait><down><down><end> inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora/ks.cfg}<F10><wait>"]
+boot_command            = ["<up><up>e<wait><down><down><end> inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora/ks.cfg<F10><wait>"]


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Fixes an invalid boot command because of an excess `}`.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
