### PR TITLE
Handle missing /var/lib/dbus/machine-id

### DIFF
--- a/packer_templates/scripts/fedora/cleanup_dnf.sh
+++ b/packer_templates/scripts/fedora/cleanup_dnf.sh
@@ -38,7 +38,7 @@ rm -f /var/lib/systemd/random-seed
 
 echo "Wipe netplan machine-id (DUID) so machines get unique ID generated on boot"
 truncate -s 0 /etc/machine-id
-truncate -s 0 /var/lib/dbus/machine-id  # if not symlinked to "/etc/machine-id"
+[ -f /var/lib/dbus/machine-id ] && truncate -s 0 /var/lib/dbus/machine-id || true  # if not symlinked to "/etc/machine-id"
 
 echo "Clear the history so our install commands aren't there"
 rm -f /root/.wget-hsts


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

I was building fedora 37 aarch64 locally and `/var/lib/dbus/machine-id` did not exist as file. This improves the cleanup script to not fail if the file does not exist.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
