### PR TITLE
Fix boot command for ubuntu 22.10 aarch64

### DIFF
--- a/os_pkrvars/ubuntu/ubuntu-22.10-aarch64.pkrvars.hcl
+++ b/os_pkrvars/ubuntu/ubuntu-22.10-aarch64.pkrvars.hcl
@@ -7,5 +7,5 @@ hyperv_generation       = 2
 parallels_guest_os_type = "ubuntu"
 vbox_guest_os_type      = "Ubuntu_64"
 vmware_guest_os_type    = "ubuntu-64"
-boot_command            = ["<wait5><esc><wait><f6><wait><esc><wait> <bs><bs><bs><bs><wait> autoinstall<wait5> ds=nocloud-net<wait5>;s=http://<wait5>{{ .HTTPIP }}<wait5>:{{ .HTTPPort }}/ubuntu/<wait5> ---<wait5><enter><wait5>"]
-boot_command_hyperv     = ["<wait5><esc><wait><f6><wait><esc><wait> <bs><bs><bs><bs><wait> autoinstall<wait5> ds=nocloud-net<wait5>;s=http://<wait5>{{ .HTTPIP }}<wait5>:{{ .HTTPPort }}/ubuntu/<wait5> ---<wait5><enter><wait5>"]
+boot_command            = ["<wait>e<wait><down><down><down><end> autoinstall ds=nocloud-net\\;s=http://{{.HTTPIP}}:{{.HTTPPort}}/ubuntu/<wait><f10><wait>"]
+boot_command_hyperv     = ["<wait>e<wait><down><down><down><end> autoinstall ds=nocloud-net\\;s=http://{{.HTTPIP}}:{{.HTTPPort}}/ubuntu/<wait><f10><wait>"]


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Fixes the boot command to successfully boot ubuntu 22.10 on aarch64. Previously it would do nothing until the `c` in `nocloud` was typed, and then get a error because the command was invalid.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
