### PR TITLE
Match any kernel version in debian purge command

### DIFF
--- a/packer_templates/scripts/debian/cleanup_debian.sh
+++ b/packer_templates/scripts/debian/cleanup_debian.sh
@@ -9,7 +9,7 @@ dpkg --list \
 echo "remove specific Linux kernels, such as linux-image-4.9.0-13-amd64 but keeps the current kernel and does not touch the virtual packages"
 dpkg --list \
     | awk '{ print $2 }' \
-    | grep 'linux-image-[234].*' \
+    | grep 'linux-image-[1-9].*' \
     | grep -v "$(uname -r)" \
     | xargs apt-get -y purge;
 


### PR DESCRIPTION
The `cleanup_debian.sh` script was only removing kernel versions starting with `[234]` and thus not matching the current kernel versions 5 or 6. This PR suggests to match any version `[1-9]`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
