### PR TITLE
Improve ARM64 Silicon OS X and Ubuntu ARM64 support for VMWare Fusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ Markdown table generated at <https://www.tablesgenerator.com/markdown_tables#>
 
 ## [unreleased] (2023-03-16)
 
+- Updated VMware disk and cdrom adaptor type to sata for aarch64 build compatability
+
 ## [v3.0.0] (2023-03-16)
 
 - fixed pipeline secrets issue for github api requests and secrets not working for forked repos

--- a/os_pkrvars/ubuntu/ubuntu-18.04-aarch64.pkrvars.hcl
+++ b/os_pkrvars/ubuntu/ubuntu-18.04-aarch64.pkrvars.hcl
@@ -1,10 +1,10 @@
-os_name                   = "ubuntu"
-os_version                = "18.04"
-os_arch                   = "aarch64"
-iso_url                   = "https://cdimage.ubuntu.com/releases/18.04.6/release/ubuntu-18.04.6-server-arm64.iso"
-iso_checksum              = "0a20ef21181a36588f8fb670cc63e8d326fa6e715b526543d300a68de389055f"
-hyperv_generation         = 2
-parallels_guest_os_type   = "ubuntu"
-vbox_guest_os_type        = "Ubuntu_64"
-vmware_guest_os_type      = "ubuntu-64"
-boot_command              = ["<wait>e<wait><down><down><down><end><wait>", "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>", "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>", "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>", "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>", "<bs><wait>auto console-setup/ask_detect=false", " console-setup/layoutcode=us", " console-setup/modelcode=pc105", " debconf/frontend=noninteractive", " debian-installer=en_US.UTF-8", " fb=false", " initrd=/install/initrd.gz", " kbd-chooser/method=us", " keyboard-configuration/layout=USA", " keyboard-configuration/variant=USA", " locale=en_US.UTF-8", " netcfg/get_hostname=vagrant", " grub-installer/bootdev=/dev/sda", " noapic", " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu/preseed.cfg", " ---", "<f10><wait>"]
+os_name                 = "ubuntu"
+os_version              = "18.04"
+os_arch                 = "aarch64"
+iso_url                 = "https://cdimage.ubuntu.com/releases/18.04.6/release/ubuntu-18.04.6-server-arm64.iso"
+iso_checksum            = "0a20ef21181a36588f8fb670cc63e8d326fa6e715b526543d300a68de389055f"
+hyperv_generation       = 2
+parallels_guest_os_type = "ubuntu"
+vbox_guest_os_type      = "Ubuntu_64"
+vmware_guest_os_type    = "ubuntu-64"
+boot_command            = ["<wait>e<wait><down><down><down><end><wait>", "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>", "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>", "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>", "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>", "<bs><wait>auto console-setup/ask_detect=false", " console-setup/layoutcode=us", " console-setup/modelcode=pc105", " debconf/frontend=noninteractive", " debian-installer=en_US.UTF-8", " fb=false", " initrd=/install/initrd.gz", " kbd-chooser/method=us", " keyboard-configuration/layout=USA", " keyboard-configuration/variant=USA", " locale=en_US.UTF-8", " netcfg/get_hostname=vagrant", " grub-installer/bootdev=/dev/sda", " noapic", " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu/preseed.cfg", " ---", "<f10><wait>"]

--- a/os_pkrvars/ubuntu/ubuntu-18.04-aarch64.pkrvars.hcl
+++ b/os_pkrvars/ubuntu/ubuntu-18.04-aarch64.pkrvars.hcl
@@ -1,10 +1,12 @@
-os_name                 = "ubuntu"
-os_version              = "18.04"
-os_arch                 = "aarch64"
-iso_url                 = "https://cdimage.ubuntu.com/releases/18.04.6/release/ubuntu-18.04.6-server-arm64.iso"
-iso_checksum            = "0a20ef21181a36588f8fb670cc63e8d326fa6e715b526543d300a68de389055f"
-hyperv_generation       = 2
-parallels_guest_os_type = "ubuntu"
-vbox_guest_os_type      = "Ubuntu_64"
-vmware_guest_os_type    = "ubuntu-64"
-boot_command            = ["<wait>e<wait><down><down><down><end><wait>", "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>", "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>", "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>", "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>", "<bs><wait>auto console-setup/ask_detect=false", " console-setup/layoutcode=us", " console-setup/modelcode=pc105", " debconf/frontend=noninteractive", " debian-installer=en_US.UTF-8", " fb=false", " initrd=/install/initrd.gz", " kbd-chooser/method=us", " keyboard-configuration/layout=USA", " keyboard-configuration/variant=USA", " locale=en_US.UTF-8", " netcfg/get_hostname=vagrant", " grub-installer/bootdev=/dev/sda", " noapic", " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu/preseed.cfg", " ---", "<f10><wait>"]
+os_name                   = "ubuntu"
+os_version                = "18.04"
+os_arch                   = "aarch64"
+iso_url                   = "https://cdimage.ubuntu.com/releases/18.04.6/release/ubuntu-18.04.6-server-arm64.iso"
+iso_checksum              = "0a20ef21181a36588f8fb670cc63e8d326fa6e715b526543d300a68de389055f"
+hyperv_generation         = 2
+parallels_guest_os_type   = "ubuntu"
+vbox_guest_os_type        = "Ubuntu_64"
+vmware_guest_os_type      = "ubuntu-64"
+boot_command              = ["<wait>e<wait><down><down><down><end><wait>", "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>", "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>", "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>", "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>", "<bs><wait>auto console-setup/ask_detect=false", " console-setup/layoutcode=us", " console-setup/modelcode=pc105", " debconf/frontend=noninteractive", " debian-installer=en_US.UTF-8", " fb=false", " initrd=/install/initrd.gz", " kbd-chooser/method=us", " keyboard-configuration/layout=USA", " keyboard-configuration/variant=USA", " locale=en_US.UTF-8", " netcfg/get_hostname=vagrant", " grub-installer/bootdev=/dev/sda", " noapic", " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu/preseed.cfg", " ---", "<f10><wait>"]
+vmware_cdrom_adapter_type = "sata"
+vmware_disk_adapter_type  = "sata"

--- a/os_pkrvars/ubuntu/ubuntu-18.04-aarch64.pkrvars.hcl
+++ b/os_pkrvars/ubuntu/ubuntu-18.04-aarch64.pkrvars.hcl
@@ -8,5 +8,3 @@ parallels_guest_os_type   = "ubuntu"
 vbox_guest_os_type        = "Ubuntu_64"
 vmware_guest_os_type      = "ubuntu-64"
 boot_command              = ["<wait>e<wait><down><down><down><end><wait>", "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>", "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>", "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>", "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>", "<bs><wait>auto console-setup/ask_detect=false", " console-setup/layoutcode=us", " console-setup/modelcode=pc105", " debconf/frontend=noninteractive", " debian-installer=en_US.UTF-8", " fb=false", " initrd=/install/initrd.gz", " kbd-chooser/method=us", " keyboard-configuration/layout=USA", " keyboard-configuration/variant=USA", " locale=en_US.UTF-8", " netcfg/get_hostname=vagrant", " grub-installer/bootdev=/dev/sda", " noapic", " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu/preseed.cfg", " ---", "<f10><wait>"]
-vmware_cdrom_adapter_type = "sata"
-vmware_disk_adapter_type  = "sata"

--- a/os_pkrvars/ubuntu/ubuntu-20.04-aarch64.pkrvars.hcl
+++ b/os_pkrvars/ubuntu/ubuntu-20.04-aarch64.pkrvars.hcl
@@ -1,10 +1,12 @@
-os_name                 = "ubuntu"
-os_version              = "20.04"
-os_arch                 = "aarch64"
-iso_url                 = "http://cdimage.ubuntu.com/releases/20.04/release/ubuntu-20.04.5-live-server-arm64.iso"
-iso_checksum            = "sha256:e42d6373dd39173094af5c26cbf2497770426f42049f8b9ea3e60ce35bebdedf"
-hyperv_generation       = 2
-parallels_guest_os_type = "ubuntu"
-vbox_guest_os_type      = "Ubuntu_64"
-vmware_guest_os_type    = "ubuntu-64"
-boot_command            = ["<wait><esc>linux /casper/vmlinuz quiet autoinstall ds='nocloud-net;s=http://{{.HTTPIP}}:{{.HTTPPort}}/ubuntu/'<enter>initrd /casper/initrd<enter>boot<enter>"]
+os_name                   = "ubuntu"
+os_version                = "20.04"
+os_arch                   = "aarch64"
+iso_url                   = "http://cdimage.ubuntu.com/releases/20.04/release/ubuntu-20.04.5-live-server-arm64.iso"
+iso_checksum              = "sha256:e42d6373dd39173094af5c26cbf2497770426f42049f8b9ea3e60ce35bebdedf"
+hyperv_generation         = 2
+parallels_guest_os_type   = "ubuntu"
+vbox_guest_os_type        = "Ubuntu_64"
+vmware_guest_os_type      = "arm-ubuntu-64"
+boot_command              = ["<wait><esc>linux /casper/vmlinuz quiet autoinstall ds='nocloud-net;s=http://{{.HTTPIP}}:{{.HTTPPort}}/ubuntu/'<enter>initrd /casper/initrd<enter>boot<enter>"]
+vmware_cdrom_adapter_type = "sata"
+vmware_disk_adapter_type  = "sata"

--- a/os_pkrvars/ubuntu/ubuntu-20.04-aarch64.pkrvars.hcl
+++ b/os_pkrvars/ubuntu/ubuntu-20.04-aarch64.pkrvars.hcl
@@ -8,5 +8,3 @@ parallels_guest_os_type   = "ubuntu"
 vbox_guest_os_type        = "Ubuntu_64"
 vmware_guest_os_type      = "arm-ubuntu-64"
 boot_command              = ["<wait><esc>linux /casper/vmlinuz quiet autoinstall ds='nocloud-net;s=http://{{.HTTPIP}}:{{.HTTPPort}}/ubuntu/'<enter>initrd /casper/initrd<enter>boot<enter>"]
-vmware_cdrom_adapter_type = "sata"
-vmware_disk_adapter_type  = "sata"

--- a/os_pkrvars/ubuntu/ubuntu-20.04-aarch64.pkrvars.hcl
+++ b/os_pkrvars/ubuntu/ubuntu-20.04-aarch64.pkrvars.hcl
@@ -1,10 +1,10 @@
-os_name                   = "ubuntu"
-os_version                = "20.04"
-os_arch                   = "aarch64"
-iso_url                   = "http://cdimage.ubuntu.com/releases/20.04/release/ubuntu-20.04.5-live-server-arm64.iso"
-iso_checksum              = "sha256:e42d6373dd39173094af5c26cbf2497770426f42049f8b9ea3e60ce35bebdedf"
-hyperv_generation         = 2
-parallels_guest_os_type   = "ubuntu"
-vbox_guest_os_type        = "Ubuntu_64"
-vmware_guest_os_type      = "arm-ubuntu-64"
-boot_command              = ["<wait><esc>linux /casper/vmlinuz quiet autoinstall ds='nocloud-net;s=http://{{.HTTPIP}}:{{.HTTPPort}}/ubuntu/'<enter>initrd /casper/initrd<enter>boot<enter>"]
+os_name                 = "ubuntu"
+os_version              = "20.04"
+os_arch                 = "aarch64"
+iso_url                 = "http://cdimage.ubuntu.com/releases/20.04/release/ubuntu-20.04.5-live-server-arm64.iso"
+iso_checksum            = "sha256:e42d6373dd39173094af5c26cbf2497770426f42049f8b9ea3e60ce35bebdedf"
+hyperv_generation       = 2
+parallels_guest_os_type = "ubuntu"
+vbox_guest_os_type      = "Ubuntu_64"
+vmware_guest_os_type    = "arm-ubuntu-64"
+boot_command            = ["<wait><esc>linux /casper/vmlinuz quiet autoinstall ds='nocloud-net;s=http://{{.HTTPIP}}:{{.HTTPPort}}/ubuntu/'<enter>initrd /casper/initrd<enter>boot<enter>"]

--- a/os_pkrvars/ubuntu/ubuntu-22.04-aarch64.pkrvars.hcl
+++ b/os_pkrvars/ubuntu/ubuntu-22.04-aarch64.pkrvars.hcl
@@ -1,10 +1,10 @@
-os_name                   = "ubuntu"
-os_version                = "22.04"
-os_arch                   = "aarch64"
-iso_url                   = "https://cdimage.ubuntu.com/releases/22.04/release/ubuntu-22.04.2-live-server-arm64.iso"
-iso_checksum              = "file:https://cdimage.ubuntu.com/releases/22.04/release/SHA256SUMS"
-hyperv_generation         = 2
-parallels_guest_os_type   = "ubuntu"
-vbox_guest_os_type        = "Ubuntu_64"
-vmware_guest_os_type      = "arm-ubuntu-64"
-boot_command              = ["<wait>e<wait><down><down><down><end><wait> autoinstall ds=nocloud-net\\;s=http://{{.HTTPIP}}:{{.HTTPPort}}/ubuntu/<f10><wait>"]
+os_name                 = "ubuntu"
+os_version              = "22.04"
+os_arch                 = "aarch64"
+iso_url                 = "https://cdimage.ubuntu.com/releases/22.04/release/ubuntu-22.04.2-live-server-arm64.iso"
+iso_checksum            = "file:https://cdimage.ubuntu.com/releases/22.04/release/SHA256SUMS"
+hyperv_generation       = 2
+parallels_guest_os_type = "ubuntu"
+vbox_guest_os_type      = "Ubuntu_64"
+vmware_guest_os_type    = "arm-ubuntu-64"
+boot_command            = ["<wait>e<wait><down><down><down><end><wait> autoinstall ds=nocloud-net\\;s=http://{{.HTTPIP}}:{{.HTTPPort}}/ubuntu/<f10><wait>"]

--- a/os_pkrvars/ubuntu/ubuntu-22.04-aarch64.pkrvars.hcl
+++ b/os_pkrvars/ubuntu/ubuntu-22.04-aarch64.pkrvars.hcl
@@ -8,5 +8,3 @@ parallels_guest_os_type   = "ubuntu"
 vbox_guest_os_type        = "Ubuntu_64"
 vmware_guest_os_type      = "arm-ubuntu-64"
 boot_command              = ["<wait>e<wait><down><down><down><end><wait> autoinstall ds=nocloud-net\\;s=http://{{.HTTPIP}}:{{.HTTPPort}}/ubuntu/<f10><wait>"]
-vmware_cdrom_adapter_type = "sata"
-vmware_disk_adapter_type  = "sata"

--- a/os_pkrvars/ubuntu/ubuntu-22.04-aarch64.pkrvars.hcl
+++ b/os_pkrvars/ubuntu/ubuntu-22.04-aarch64.pkrvars.hcl
@@ -1,10 +1,12 @@
-os_name                 = "ubuntu"
-os_version              = "22.04"
-os_arch                 = "aarch64"
-iso_url                 = "https://cdimage.ubuntu.com/releases/22.04/release/ubuntu-22.04.2-live-server-arm64.iso"
-iso_checksum            = "file:https://cdimage.ubuntu.com/releases/22.04/release/SHA256SUMS"
-hyperv_generation       = 2
-parallels_guest_os_type = "ubuntu"
-vbox_guest_os_type      = "Ubuntu_64"
-vmware_guest_os_type    = "ubuntu-64"
-boot_command            = ["<wait>e<wait><down><down><down><end><wait> autoinstall ds=nocloud-net\\;s=http://{{.HTTPIP}}:{{.HTTPPort}}/ubuntu/<f10><wait>"]
+os_name                   = "ubuntu"
+os_version                = "22.04"
+os_arch                   = "aarch64"
+iso_url                   = "https://cdimage.ubuntu.com/releases/22.04/release/ubuntu-22.04.2-live-server-arm64.iso"
+iso_checksum              = "file:https://cdimage.ubuntu.com/releases/22.04/release/SHA256SUMS"
+hyperv_generation         = 2
+parallels_guest_os_type   = "ubuntu"
+vbox_guest_os_type        = "Ubuntu_64"
+vmware_guest_os_type      = "arm-ubuntu-64"
+boot_command              = ["<wait>e<wait><down><down><down><end><wait> autoinstall ds=nocloud-net\\;s=http://{{.HTTPIP}}:{{.HTTPPort}}/ubuntu/<f10><wait>"]
+vmware_cdrom_adapter_type = "sata"
+vmware_disk_adapter_type  = "sata"

--- a/os_pkrvars/ubuntu/ubuntu-22.10-aarch64.pkrvars.hcl
+++ b/os_pkrvars/ubuntu/ubuntu-22.10-aarch64.pkrvars.hcl
@@ -8,5 +8,3 @@ parallels_guest_os_type   = "ubuntu"
 vbox_guest_os_type        = "Ubuntu_64"
 vmware_guest_os_type      = "arm-ubuntu-64"
 boot_command              = ["<wait>e<wait><down><down><down><end> autoinstall ds=nocloud-net\\;s=http://{{.HTTPIP}}:{{.HTTPPort}}/ubuntu/<wait><f10><wait>"]
-vmware_cdrom_adapter_type = "sata"
-vmware_disk_adapter_type  = "sata"

--- a/os_pkrvars/ubuntu/ubuntu-22.10-aarch64.pkrvars.hcl
+++ b/os_pkrvars/ubuntu/ubuntu-22.10-aarch64.pkrvars.hcl
@@ -1,10 +1,10 @@
-os_name                   = "ubuntu"
-os_version                = "22.10"
-os_arch                   = "aarch64"
-iso_url                   = "https://cdimage.ubuntu.com/releases/22.10/release/ubuntu-22.10-live-server-arm64.iso"
-iso_checksum              = "a19d956e993a16fc6496c371e36dcc0eb85d2bdf6a8e86028b92ce62e9f585cd"
-hyperv_generation         = 2
-parallels_guest_os_type   = "ubuntu"
-vbox_guest_os_type        = "Ubuntu_64"
-vmware_guest_os_type      = "arm-ubuntu-64"
-boot_command              = ["<wait>e<wait><down><down><down><end> autoinstall ds=nocloud-net\\;s=http://{{.HTTPIP}}:{{.HTTPPort}}/ubuntu/<wait><f10><wait>"]
+os_name                 = "ubuntu"
+os_version              = "22.10"
+os_arch                 = "aarch64"
+iso_url                 = "https://cdimage.ubuntu.com/releases/22.10/release/ubuntu-22.10-live-server-arm64.iso"
+iso_checksum            = "a19d956e993a16fc6496c371e36dcc0eb85d2bdf6a8e86028b92ce62e9f585cd"
+hyperv_generation       = 2
+parallels_guest_os_type = "ubuntu"
+vbox_guest_os_type      = "Ubuntu_64"
+vmware_guest_os_type    = "arm-ubuntu-64"
+boot_command            = ["<wait>e<wait><down><down><down><end> autoinstall ds=nocloud-net\\;s=http://{{.HTTPIP}}:{{.HTTPPort}}/ubuntu/<wait><f10><wait>"]

--- a/os_pkrvars/ubuntu/ubuntu-22.10-aarch64.pkrvars.hcl
+++ b/os_pkrvars/ubuntu/ubuntu-22.10-aarch64.pkrvars.hcl
@@ -1,10 +1,12 @@
-os_name                 = "ubuntu"
-os_version              = "22.10"
-os_arch                 = "aarch64"
-iso_url                 = "https://cdimage.ubuntu.com/releases/22.10/release/ubuntu-22.10-live-server-arm64.iso"
-iso_checksum            = "a19d956e993a16fc6496c371e36dcc0eb85d2bdf6a8e86028b92ce62e9f585cd"
-hyperv_generation       = 2
-parallels_guest_os_type = "ubuntu"
-vbox_guest_os_type      = "Ubuntu_64"
-vmware_guest_os_type    = "ubuntu-64"
-boot_command            = ["<wait>e<wait><down><down><down><end> autoinstall ds=nocloud-net\\;s=http://{{.HTTPIP}}:{{.HTTPPort}}/ubuntu/<wait><f10><wait>"]
+os_name                   = "ubuntu"
+os_version                = "22.10"
+os_arch                   = "aarch64"
+iso_url                   = "https://cdimage.ubuntu.com/releases/22.10/release/ubuntu-22.10-live-server-arm64.iso"
+iso_checksum              = "a19d956e993a16fc6496c371e36dcc0eb85d2bdf6a8e86028b92ce62e9f585cd"
+hyperv_generation         = 2
+parallels_guest_os_type   = "ubuntu"
+vbox_guest_os_type        = "Ubuntu_64"
+vmware_guest_os_type      = "arm-ubuntu-64"
+boot_command              = ["<wait>e<wait><down><down><down><end> autoinstall ds=nocloud-net\\;s=http://{{.HTTPIP}}:{{.HTTPPort}}/ubuntu/<wait><f10><wait>"]
+vmware_cdrom_adapter_type = "sata"
+vmware_disk_adapter_type  = "sata"

--- a/packer_templates/pkr-sources.pkr.hcl
+++ b/packer_templates/pkr-sources.pkr.hcl
@@ -274,4 +274,5 @@ source "vmware-iso" "vm" {
   winrm_timeout                  = var.winrm_timeout
   winrm_username                 = var.winrm_username
   vm_name                        = local.vm_name
+  cdrom_adapter_type             = var.vmware_cdrom_adapter_type
 }

--- a/packer_templates/pkr-sources.pkr.hcl
+++ b/packer_templates/pkr-sources.pkr.hcl
@@ -64,11 +64,6 @@ locals {
     var.os_name == "amazonlinux" ? "${path.root}/amz_working_files/amazon2.ovf" : null
   ) : var.vbox_source
 
-  # vmware-iso
-  vmware_disk_adapter_type = var.vmware_disk_adapter_type == null ? (
-    var.is_windows ? "lsisas1068" : null
-  ) : var.vmware_disk_adapter_type
-
   # Source block common
   boot_wait = var.boot_wait == null ? (
     var.is_windows ? "60s" : "10s"
@@ -245,8 +240,9 @@ source "virtualbox-ovf" "amazonlinux" {
   vm_name                 = local.vm_name
 }
 source "vmware-iso" "vm" {
+  cdrom_adapter_type             = var.vmware_cdrom_adapter_type
+  disk_adapter_type              = var.vmware_disk_adapter_type
   guest_os_type                  = var.vmware_guest_os_type
-  disk_adapter_type              = local.vmware_disk_adapter_type
   tools_upload_flavor            = var.vmware_tools_upload_flavor
   tools_upload_path              = var.vmware_tools_upload_path
   version                        = var.vmware_version
@@ -274,5 +270,4 @@ source "vmware-iso" "vm" {
   winrm_timeout                  = var.winrm_timeout
   winrm_username                 = var.winrm_username
   vm_name                        = local.vm_name
-  cdrom_adapter_type             = var.vmware_cdrom_adapter_type
 }

--- a/packer_templates/pkr-variables.pkr.hcl
+++ b/packer_templates/pkr-variables.pkr.hcl
@@ -175,9 +175,15 @@ variable "vbox_source" {
 }
 
 # vmware-iso
+variable "vmware_cdrom_adapter_type" {
+  type        = string
+  default     = null
+  description = "CDROM adapter type.  Needs to be SATA (or non-SCSI) for ARM64 builds."
+}
 variable "vmware_disk_adapter_type" {
-  type    = string
-  default = null
+  type        = string
+  default     = null
+  description = "Disk adapter type.  Needs to be SATA (PVSCSI, or non-SCSI) for ARM64 builds."
 }
 variable "vmware_guest_os_type" {
   type        = string

--- a/packer_templates/pkr-variables.pkr.hcl
+++ b/packer_templates/pkr-variables.pkr.hcl
@@ -177,12 +177,12 @@ variable "vbox_source" {
 # vmware-iso
 variable "vmware_cdrom_adapter_type" {
   type        = string
-  default     = null
+  default     = "sata"
   description = "CDROM adapter type.  Needs to be SATA (or non-SCSI) for ARM64 builds."
 }
 variable "vmware_disk_adapter_type" {
   type        = string
-  default     = null
+  default     = "sata"
   description = "Disk adapter type.  Needs to be SATA (PVSCSI, or non-SCSI) for ARM64 builds."
 }
 variable "vmware_guest_os_type" {


### PR DESCRIPTION
## On VMWare Fusion, OS X M1/M2 ARM64 (Silicon) chips, I've been running into difficulties building anything.

<!--- Provide a short summary of your changes in the Title above -->

## Description
Fails to load the VM due to processor type mismatch.  Resolves with tacking on -arm64 or whatever onto the OS type in the template.

This initially starts with boot failures due to the LSILogic disk type preventing the VMX from loading at the vmxrun stage.  Changing the disk to SATA (longer term solution), or the disk adapter to PVSCSI from LSILOGIC resolves this.  There's builtin support for SATA, so I go that direction.

Next, IDE support for CDROM's is removed in Fusion 13.  Not sure if this is an M1/M2 thing or VMWare Fusion 13 change, I've been out of things for a bit.  Regardless, changing to SATA resolves it.  Just copied the same coding pattern from logical drives.

At this point things seem to boot to the point where they get into the GRUB loader then divert into PXE - so it's improved a good bit, but that's more of a software than virtualization issue.

<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).


_On checklist, existing tests do not appear to pass due to environment issues and are therefore not covered.  Tests are closer to passing now.  New tests are not necessary; integration (full machine build) tests should cover same functionality._
