### PR TITLE
remove Fedora 36 and add Fedora 38

### DIFF
--- a/os_pkrvars/fedora/fedora-36-aarch64.pkrvars.hcl
+++ b/os_pkrvars/fedora/fedora-36-aarch64.pkrvars.hcl
@@ -1,9 +1,0 @@
-os_name                 = "fedora"
-os_version              = "36"
-os_arch                 = "aarch64"
-iso_url                 = "https://na.edge.kernel.org/fedora/releases/36/Server/aarch64/iso/Fedora-Server-dvd-aarch64-36-1.5.iso"
-iso_checksum            = "sha256:0ab4000575ff8b258576750ecf4ca39b266f0c88cab5fe3d8d2f88c9bea4830d"
-parallels_guest_os_type = "fedora-core"
-vbox_guest_os_type      = "Fedora_64"
-vmware_guest_os_type    = "arm-fedora-64"
-boot_command            = ["<wait><up><wait>e<down><down><end> inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora/ks.cfg<enter><wait><f10>"]

--- a/os_pkrvars/fedora/fedora-36-x86_64.pkrvars.hcl
+++ b/os_pkrvars/fedora/fedora-36-x86_64.pkrvars.hcl
@@ -1,9 +1,0 @@
-os_name                 = "fedora"
-os_version              = "36"
-os_arch                 = "x86_64"
-iso_url                 = "https://ftp-nyc.osuosl.org/pub/fedora/linux/releases/36/Server/x86_64/iso/Fedora-Server-dvd-x86_64-36-1.5.iso"
-iso_checksum            = "sha256:5edaf708a52687b09f9810c2b6d2a3432edac1b18f4d8c908c0da6bde0379148"
-parallels_guest_os_type = "fedora-core"
-vbox_guest_os_type      = "Fedora_64"
-vmware_guest_os_type    = "fedora-64"
-boot_command            = ["<wait><up><wait><tab> inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora/ks.cfg<enter><wait>"]

--- a/os_pkrvars/fedora/fedora-38-aarch64.pkrvars.hcl
+++ b/os_pkrvars/fedora/fedora-38-aarch64.pkrvars.hcl
@@ -1,0 +1,9 @@
+os_name                 = "fedora"
+os_version              = "38"
+os_arch                 = "aarch64"
+iso_url                 = "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Server/aarch64/iso/Fedora-Server-dvd-aarch64-38-1.6.iso"
+iso_checksum            = "sha256:0b40485d74fc60c0a78f071396aba78fafb2f8f3b1ab4cbc3388bda82f764f9b"
+parallels_guest_os_type = "fedora-core"
+vbox_guest_os_type      = "Fedora_64"
+vmware_guest_os_type    = "arm-fedora-64"
+boot_command            = ["<wait><up><up>e<wait><down><down><end> inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora/ks.cfg<F10><wait>"]

--- a/os_pkrvars/fedora/fedora-38-x86_64.pkrvars.hcl
+++ b/os_pkrvars/fedora/fedora-38-x86_64.pkrvars.hcl
@@ -1,0 +1,9 @@
+os_name                 = "fedora"
+os_version              = "38"
+os_arch                 = "x86_64"
+iso_url                 = "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Server/x86_64/iso/Fedora-Server-dvd-x86_64-38-1.6.iso"
+iso_checksum            = "sha256:66b52d7cb39386644cd740930b0bef0a5a2f2be569328fef6b1f9b3679fdc54d"
+parallels_guest_os_type = "fedora-core"
+vbox_guest_os_type      = "Fedora_64"
+vmware_guest_os_type    = "fedora-64"
+boot_command            = ["<wait><up>e<wait><down><down><end> inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/fedora/ks.cfg<F10><wait>"]


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Remove Fedora 36 and add Fedora 38

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Fedora 38 has been released, and Fedora 36 will be transitioned to End of Life .  This commit removes Fedora 36 support and adds Fedora 38.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
