### PR TITLE
provision.ps1: fixed virtio-win-guest-tools.exe installation

### DIFF
--- a/packer_templates/scripts/windows/provision.ps1
+++ b/packer_templates/scripts/windows/provision.ps1
@@ -59,11 +59,14 @@ Add-Type -A System.IO.Compression.FileSystem
 # install Guest Additions.
 $systemVendor = (Get-CimInstance -ClassName Win32_ComputerSystemProduct -Property Vendor).Vendor
 if ($systemVendor -eq 'QEMU') {
-    $guestToolsPath = "e:\drivers\virtio-win-guest-tools.exe"
-    $guestTools = "$env:TEMP\$(Split-Path -Leaf $guestToolsPath)"
-    $guestToolsLog = "$guestTools.log"
+    # in more recent virtio-win.iso virtio-win-guest-tools.exe has move to E:\
+    $guestToolsPath = dir -Path E:\ -Filter virtio-win-guest-tools.exe -Recurse | %{$_.FullName}
+    if (!$guestToolsPath) {
+        throw "did not find virtio-win-guest-tools.exe on E:\"
+    }
+    $guestToolsLog = "$env:TEMP\$(Split-Path -Leaf $guestToolsPath).log"
     Write-Host 'Installing the guest tools...'
-    &$guestTools /install /norestart /quiet /log $guestToolsLog | Out-String -Stream
+    &$guestToolsPath /install /norestart /quiet /log $guestToolsLog | Out-String -Stream
     if ($LASTEXITCODE) {
         throw "failed to install guest tools with exit code $LASTEXITCODE"
     }


### PR DESCRIPTION


<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

We need to execute \$guestToolsPath not \$guestTools. (\$guestTools is just an intermediate variable for setting \$guestToolsLog.)

Newer virtio-win.iso has E:\virtio-win-guest-tools.exe. From the code it seems like older virtio-win.iso has this file in  E:\driver. Made sure script works with both old and new virtio-win.iso.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
