### PR TITLE
Update vmware vars for el9 derivitives

### DIFF
--- a/os_pkrvars/almalinux/almalinux-9-aarch64.pkrvars.hcl
+++ b/os_pkrvars/almalinux/almalinux-9-aarch64.pkrvars.hcl
@@ -5,5 +5,5 @@ iso_url                 = "https://repo.almalinux.org/almalinux/9/isos/aarch64/A
 iso_checksum            = "file:https://repo.almalinux.org/almalinux/9/isos/aarch64/CHECKSUM"
 parallels_guest_os_type = "centos"
 vbox_guest_os_type      = "RedHat_64"
-vmware_guest_os_type    = "arm-centos-64"
+vmware_guest_os_type    = "arm-rhel9-64"
 boot_command            = ["<wait><up>e<wait><down><down><end><wait> inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/rhel/9ks.cfg <leftCtrlOn>x<leftCtrlOff>"]

--- a/os_pkrvars/rockylinux/rockylinux-9-aarch64.pkrvars.hcl
+++ b/os_pkrvars/rockylinux/rockylinux-9-aarch64.pkrvars.hcl
@@ -5,5 +5,5 @@ iso_url                 = "https://download.rockylinux.org/pub/rocky/9/isos/aarc
 iso_checksum            = "file:https://download.rockylinux.org/pub/rocky/9/isos/aarch64/CHECKSUM"
 parallels_guest_os_type = "centos"
 vbox_guest_os_type      = "RedHat_64"
-vmware_guest_os_type    = "arm-centos-64"
+vmware_guest_os_type    = "arm-rhel9-64"
 boot_command            = ["<wait><up>e<wait><down><down><end><wait> inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/rhel/9ks.cfg <leftCtrlOn>x<leftCtrlOff>"]


### PR DESCRIPTION
* updates `vmware_guest_os_type` for almalinux and rockylinux 9 aarch64 to match the vmware hardware profile which reliably results in a successful build

<!--- Provide a short summary of your changes in the Title above -->

## Description
Neither rockylinux nor almalinux 9.x targets for aarch64 would build on vmware fusion 13.x with the current specified `vmware_guest_os_type` as centos is no longer an officially supported target os of VMWare it seems reasonable to adopt their RedHat targeted support when building EL derivative distros.

This change has been tested on Apple Arm64 hardware running VMWare fusion 13.0.2, similar changes might be desirable for the x86_64 targets as well, but I suspect that those guest hardware profiles are more generic and have fewer unanticipated compatibility issues.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
