### PR TITLE
Keep linux-kernel-header package installed for Parallels builds

### DIFF
--- a/packer_templates/pkr-builder.pkr.hcl
+++ b/packer_templates/pkr-builder.pkr.hcl
@@ -115,6 +115,7 @@ locals {
             "${path.root}/scripts/_common/parallels.sh",
             "${path.root}/scripts/${var.os_name}/hyperv_${var.os_name}.sh",
             "${path.root}/scripts/${var.os_name}/cleanup_${var.os_name}.sh",
+            "${path.root}/scripts/_common/parallels_post_cleanup_debian_ubuntu.sh",
             "${path.root}/scripts/_common/minimize.sh"
             ] : (
             var.os_name == "fedora" ? [

--- a/packer_templates/scripts/_common/parallels_post_cleanup_debian_ubuntu.sh
+++ b/packer_templates/scripts/_common/parallels_post_cleanup_debian_ubuntu.sh
@@ -1,0 +1,14 @@
+#!/bin/sh -eux
+
+case "$PACKER_BUILDER_TYPE" in
+parallels-iso|parallels-pvm)
+    # This runs in a special script after cleanup_{ubuntu|debian}.sh, which cleans up the kernel headers
+    # in general (we want to keep them for Parallels Desktop only).
+
+    echo "Installing linux-kernel-headers for the current kernel version, to allow re-compilation of Parallels Tools upon boot"
+
+    if [ -f "/usr/bin/apt-get" ]; then
+        apt-get install -y linux-headers-"$(uname -r)"
+    fi
+    ;;
+esac


### PR DESCRIPTION
When using [this Ubuntu Vagrant box](https://app.vagrantup.com/bento/boxes/ubuntu-22.04/versions/202303.13.0) with Parallels Desktop, the `vagrant-parallels` plugin upon boot detects  that the version of Parallels Tools installed in the box is outdated and tries to update it.

The problem is that a due re-compilation of Parallels Tools depends on `linux-headers-5.15.0-67-generic`, with the package name/version matching the version of the currently running kernel.

However, the Kernel version included in the box image has since then replaced with a newer version (in the upstream Ubuntu repositories), and it seems the matching header files can no longer be installed. They probably came from an Ubuntu security update release channel where the package has been replaced with a newer version since the box was built.

Full details can be found in the issue at https://github.com/Parallels/vagrant-parallels/issues/458.

By keeping the `linux-headers-*` package during/after installation, also a freshly booted box should be able to perform the update. The package is, in fact, installed automatically when Parallels Tools are added, but after that is is removed by the `cleanup_ubuntu.sh` script.