### PR TITLE
Update Ubuntu 22.04 `iso_url`

### DIFF
--- a/os_pkrvars/ubuntu/ubuntu-22.04-aarch64.pkrvars.hcl
+++ b/os_pkrvars/ubuntu/ubuntu-22.04-aarch64.pkrvars.hcl
@@ -1,7 +1,7 @@
 os_name                 = "ubuntu"
 os_version              = "22.04"
 os_arch                 = "aarch64"
-iso_url                 = "https://cdimage.ubuntu.com/releases/22.04/release/ubuntu-22.04.2-live-server-arm64.iso"
+iso_url                 = "https://cdimage.ubuntu.com/releases/22.04/release/ubuntu-22.04.3-live-server-arm64.iso"
 iso_checksum            = "file:https://cdimage.ubuntu.com/releases/22.04/release/SHA256SUMS"
 hyperv_generation       = 2
 parallels_guest_os_type = "ubuntu"

--- a/os_pkrvars/ubuntu/ubuntu-22.04-x86_64.pkrvars.hcl
+++ b/os_pkrvars/ubuntu/ubuntu-22.04-x86_64.pkrvars.hcl
@@ -1,7 +1,7 @@
 os_name                 = "ubuntu"
 os_version              = "22.04"
 os_arch                 = "x86_64"
-iso_url                 = "https://releases.ubuntu.com/jammy/ubuntu-22.04.2-live-server-amd64.iso"
+iso_url                 = "https://releases.ubuntu.com/jammy/ubuntu-22.04.3-live-server-amd64.iso"
 iso_checksum            = "file:https://releases.ubuntu.com/jammy/SHA256SUMS"
 hyperv_generation       = 2
 parallels_guest_os_type = "ubuntu"


### PR DESCRIPTION
The https://releases.ubuntu.com/jammy/ubuntu-22.04.2-live-server-amd64.iso address is no longer available (404). Since August 2023, there is a .3 release.
