### PR TITLE
Avoid downloading application to implement eject-media

### DIFF
--- a/packer_templates/scripts/windows/eject-media.ps1
+++ b/packer_templates/scripts/windows/eject-media.ps1
@@ -45,16 +45,20 @@ trap {
 #
 # eject removable volume media.
 
-Write-Host 'Downloaing EjectVolumeMedia...'
-$ejectVolumeMediaExeUrl = 'https://github.com/rgl/EjectVolumeMedia/releases/download/v1.0.0/EjectVolumeMedia.exe'
-$ejectVolumeMediaExeHash = 'f7863394085e1b3c5aa999808b012fba577b4a027804ea292abf7962e5467ba0'
-$ejectVolumeMediaExe = "$env:TEMP\EjectVolumeMedia.exe"
-Invoke-WebRequest $ejectVolumeMediaExeUrl -OutFile $ejectVolumeMediaExe
-$ejectVolumeMediaExeActualHash = (Get-FileHash $ejectVolumeMediaExe -Algorithm SHA256).Hash
-if ($ejectVolumeMediaExeActualHash -ne $ejectVolumeMediaExeHash) {
-    throw "the $ejectVolumeMediaExeUrl file hash $ejectVolumeMediaExeActualHash does not match the expected $ejectVolumeMediaExeHash"
-}
+$volList = Get-Volume | Where-Object {$_.DriveType -ne 'Fixed' -and $_.DriveLetter}
 
-Get-Volume | Where-Object {$_.DriveType -ne 'Fixed' -and $_.DriveLetter} | ForEach-Object {
-    &$ejectVolumeMediaExe $_.DriveLetter
+ForEach ($vol in $volList) {
+    $volLetter = $vol.DriveLetter
+    Write-Host "Ejecting drive ${volLetter}:"
+
+    try {
+        $Eject = New-Object -comObject Shell.Application
+
+        # Namespace 17 represents ssfDRIVES
+        # See: https://learn.microsoft.com/en-us/windows/win32/api/shldisp/ne-shldisp-shellspecialfolderconstants
+
+        $Eject.NameSpace(17).ParseName("${volLetter}:").InvokeVerb("Eject")
+    } finally {
+        [System.Runtime.InteropServices.Marshal]::ReleaseComObject($Eject) | Out-Null
+    }
 }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

Avoid downloading application to implement [eject-media.ps1](https://github.com/chef/bento/blob/main/packer_templates/scripts/windows/eject-media.ps1).

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

eject-media.ps1 is currently implemented using [EjectVolumeMedia](https://github.com/rgl/EjectVolumeMedia). For Windows VMs that do not have internet access at build time they will be unable to download and execute this tool. So this change implements ejecting media (Floppy disk drives and CD drives) using pure powershell.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
