### PR TITLE
rhel: Check for networking-scripts before removal

### DIFF
--- a/packer_templates/scripts/rhel/cleanup_dnf.sh
+++ b/packer_templates/scripts/rhel/cleanup_dnf.sh
@@ -31,12 +31,14 @@ mkdir -p /etc/udev/rules.d/70-persistent-net.rules;
 rm -f /lib/udev/rules.d/75-persistent-net-generator.rules;
 rm -rf /dev/.udev/;
 
-for ndev in /etc/sysconfig/network-scripts/ifcfg-*; do
-    if [ "$(basename "$ndev")" != "ifcfg-lo" ]; then
-        sed -i '/^HWADDR/d' "$ndev";
-        sed -i '/^UUID/d' "$ndev";
-    fi
-done
+if test -f /etc/sysconfig/network-scripts/ifcfg-*; then
+    for ndev in /etc/sysconfig/network-scripts/ifcfg-*; do
+        if [ "$(basename "$ndev")" != "ifcfg-lo" ]; then
+            sed -i '/^HWADDR/d' "$ndev";
+            sed -i '/^UUID/d' "$ndev";
+        fi
+    done
+fi
 
 echo "truncate any logs that have built up during the install"
 find /var/log -type f -exec truncate --size=0 {} \;

--- a/packer_templates/scripts/rhel/cleanup_yum.sh
+++ b/packer_templates/scripts/rhel/cleanup_yum.sh
@@ -31,13 +31,14 @@ mkdir -p /etc/udev/rules.d/70-persistent-net.rules;
 rm -f /lib/udev/rules.d/75-persistent-net-generator.rules;
 rm -rf /dev/.udev/;
 
-for ndev in /etc/sysconfig/network-scripts/ifcfg-*; do
-    if [ "$(basename "$ndev")" != "ifcfg-lo" ]; then
-        sed -i '/^HWADDR/d' "$ndev";
-        sed -i '/^UUID/d' "$ndev";
-    fi
-done
+if test -f /etc/sysconfig/network-scripts/ifcfg-*; then
+    for ndev in /etc/sysconfig/network-scripts/ifcfg-*; do
+        if [ "$(basename "$ndev")" != "ifcfg-lo" ]; then
 
+            sed -i '/^UUID/d' "$ndev";
+        fi
+    done
+fi
 echo "truncate any logs that have built up during the install"
 find /var/log -type f -exec truncate --size=0 {} \;
 


### PR DESCRIPTION
Bugfix for `packer build` on centos-stream-9.

## Description
The cleanup for centos-stream-9 fails during execution.

This is caused due to missing files in `/etc/sysconfig/network-scripts/ifcfg-*`.

Simple to reproduce:
`packer build -only=virtualbox-iso.vm -var-file=./os_pkrvars/centos/centos-stream-9-x86_64.pkrvars.hcl packer_templates`

```
==> virtualbox-iso.vm: + for ndev in /etc/sysconfig/network-scripts/ifcfg-*
==> virtualbox-iso.vm: ++ basename '/etc/sysconfig/network-scripts/ifcfg-*'
==> virtualbox-iso.vm: + '[' 'ifcfg-*' '!=' ifcfg-lo ']'
==> virtualbox-iso.vm: + sed -i '/^HWADDR/d' '/etc/sysconfig/network-scripts/ifcfg-*'
==> virtualbox-iso.vm: sed: can't read /etc/sysconfig/network-scripts/ifcfg-*: No such file or directory
==> virtualbox-iso.vm: Provisioning step had errors: Running the cleanup provisioner, if present...
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
