### PR TITLE
bumped iso url versions

### DIFF
--- a/os_pkrvars/ubuntu/ubuntu-22.04-aarch64.pkrvars.hcl
+++ b/os_pkrvars/ubuntu/ubuntu-22.04-aarch64.pkrvars.hcl
@@ -1,7 +1,7 @@
 os_name                 = "ubuntu"
 os_version              = "22.04"
 os_arch                 = "aarch64"
-iso_url                 = "https://cdimage.ubuntu.com/releases/jammy/release/ubuntu-22.04.3-live-server-arm64.iso"
+iso_url                 = "https://cdimage.ubuntu.com/releases/jammy/release/ubuntu-22.04.4-live-server-arm64.iso"
 iso_checksum            = "file:https://cdimage.ubuntu.com/releases/jammy/release/SHA256SUMS"
 parallels_guest_os_type = "ubuntu"
 vbox_guest_os_type      = "Ubuntu_64"

--- a/os_pkrvars/ubuntu/ubuntu-22.04-x86_64.pkrvars.hcl
+++ b/os_pkrvars/ubuntu/ubuntu-22.04-x86_64.pkrvars.hcl
@@ -1,7 +1,7 @@
 os_name                 = "ubuntu"
 os_version              = "22.04"
 os_arch                 = "x86_64"
-iso_url                 = "https://releases.ubuntu.com/jammy/ubuntu-22.04.3-live-server-amd64.iso"
+iso_url                 = "https://releases.ubuntu.com/jammy/ubuntu-22.04.4-live-server-amd64.iso"
 iso_checksum            = "file:https://releases.ubuntu.com/jammy/SHA256SUMS"
 parallels_guest_os_type = "ubuntu"
 vbox_guest_os_type      = "Ubuntu_64"


### PR DESCRIPTION
The latest Ubuntu 22.04 version is 22.04.4, but the ISO url is still pointing to 22.04.3.

## Description
The SHA256SUMS files already reference the new version, so this change fixes the version mismatch.

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
I have not done any of the following, because I could not really get `bento` to work for me locally.  I basically just call `packer` on the packer templates provided by `bento`.

- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
