### PR TITLE
Fix arm64 builds for debian 11

### DIFF
--- a/packer_templates/scripts/_common/vmware_debian_ubuntu.sh
+++ b/packer_templates/scripts/_common/vmware_debian_ubuntu.sh
@@ -2,7 +2,16 @@
 
 case "$PACKER_BUILDER_TYPE" in
 vmware-iso|vmware-vmx)
+    # determine the major Debian version we're runninng
+    major_version="$(grep VERSION_ID /etc/os-release | awk -F= '{print $2}' | tr -d '"')"
+    architecture="$(uname -m)"
+
+    # open-vm-tools for amd64 are only available in bullseye-backports repo
     echo "install open-vm-tools"
+    if [ "$major_version" -eq 11 ] && [ "$architecture" = "aarch64" ]; then
+        echo 'deb http://deb.debian.org/debian bullseye-backports main' >> /etc/apt/sources.list
+        apt-get update
+    fi
     apt-get install -y open-vm-tools;
     mkdir /mnt/hgfs;
     systemctl enable open-vm-tools

--- a/packer_templates/scripts/_common/vmware_debian_ubuntu.sh
+++ b/packer_templates/scripts/_common/vmware_debian_ubuntu.sh
@@ -11,6 +11,10 @@ vmware-iso|vmware-vmx)
     if [ "$major_version" -eq 11 ] && [ "$architecture" = "aarch64" ]; then
         echo 'deb http://deb.debian.org/debian bullseye-backports main' >> /etc/apt/sources.list
         apt-get update
+        cat > /etc/modprobe.d/blacklist.conf <<EOF
+blacklist vsock_loopback
+blacklist vmw_vsock_virtio_transport_common
+EOF
     fi
     apt-get install -y open-vm-tools;
     mkdir /mnt/hgfs;


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
This pull request fixes the arm64 builds for debian 11 (bullseye).

## Description
The main problem was, that the packages `open-vm-tools` is not available for arm64 in the _bullseye_ nor the _bullseye-updates_ suite. The arm64 build is only available in the _bullseye-backports_ suite. By adding the _bullseye-backports_ suite the build succeeds.

When starting the VM a lot of _Unknown ioctl 1976_ messages are logged into kernel message log and the console. According to https://github.com/vmware/open-vm-tools/issues/495 this is because the kernel module _vmw_vsock_vmci_transport_ is missing. The kernel module is neither available in the _debian-security_ kernel (5.10.218) nor in the _bullseye-backports_ kernel (6.1.90).

The easiest fix at the moment it to blacklist the modules _vmw_vsock_virtio_transport_common_ and _vsock_loopback_. As soon as _vsock_loopback_ is loaded, the error messages appear.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#1371 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
