### PR TITLE
Fix a bug in freebsd-14.x due to changes in bsdinstall

### DIFF
--- a/packer_templates/http/freebsd/installerconfig
+++ b/packer_templates/http/freebsd/installerconfig
@@ -44,12 +44,22 @@ EOT
 # zfs doesn't use an fstab, but some rc scripts expect one
 touch /etc/fstab
 
+# Since FreeBSD 14.0 bsdinstall again creates dataset for /home rather then /usr/home
+# Thus on versions prior to 14.0 we have to create /home -> /usr/home symlink,
+# otherwise just use /home as the base for vagrant's home
+version=$(freebsd-version -u)
+if [ "${version%%.*}" -lt "14" ]; then
+   home_base="/usr/home"
+   ln -s $home_base /home
+else
+   home_base="/home"
+fi
+
 # Set up user accounts
-echo "vagrant" | pw -V /etc useradd vagrant -h 0 -s /bin/sh -G wheel -d /usr/home/vagrant -c "Vagrant User"
+echo "vagrant" | pw -V /etc useradd vagrant -h 0 -s /bin/sh -G wheel -d ${home_base}/vagrant -c "Vagrant User"
 echo "vagrant" | pw -V /etc usermod root
 
-mkdir -p /usr/home/vagrant
-chown 1001:1001 /usr/home/vagrant
-ln -s /usr/home /home
+mkdir -p ${home_base}/vagrant
+chown 1001:1001 ${home_base}/vagrant
 
 reboot


### PR DESCRIPTION
## Description

Initially the problem was like

```
❯ vagrant init bento/freebsd-14.0-arm64
A `Vagrantfile` has been placed in this directory. You are now
ready to `vagrant up` your first virtual environment! Please read
the comments in the Vagrantfile as well as documentation on
`vagrantup.com` for more information on using Vagrant.
❯ vagrant up
Bringing machine 'default' up with 'vmware_desktop' provider...
==> default: Cloning VMware VM: 'bento/freebsd-14.0-arm64'. This can take some time...
==> default: Checking if box 'bento/freebsd-14.0-arm64' version '202401.31.0' is up to date...
==> default: Verifying vmnet devices are healthy...
==> default: Preparing network adapters...
==> default: Starting the VMware VM...
==> default: Waiting for the VM to receive an address...
==> default: Forwarding ports...
    default: -- 22 => 2222
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2222
    default: SSH username: vagrant
    default: SSH auth method: private key
    default: Warning: Authentication failure. Retrying...
    default: Warning: Authentication failure. Retrying...
    default: Warning: Authentication failure. Retrying...
    default: Warning: Authentication failure. Retrying...
```

Really, there was no `.ssh` in `vagrant`s `$HOME`

```
❯ vagrant ssh
(vagrant@127.0.0.1) Password for vagrant@:
Last login: Thu Jul 18 23:38:48 2024 from 172.16.12.1
FreeBSD 14.0-RELEASE (GENERIC) #0 releng/14.0-n265380-f9716eee8ab4: Fri Nov 10 05:54:07 UTC 2023

Welcome to FreeBSD!

[...]
$ ls .ssh
ls: .ssh: No such file or directory
```

It turns out that since FreeBSD 14.0 `bsdinstall` reverted to it's former behaviour
and creates ZFS dataset for `home` rather than `/usr/home` [^1] [^2]

This PR fixes the issue, while preserving the former behaviour for the major versions of FreeBSD `< 14`, namely `freebsd-13.x` images.

[^1]: https://github.com/freebsd/freebsd-src/commit/3bb92304b4fe79babd19ba0d9c74d29af9117a22
[^2]: https://reviews.freebsd.org/D40086

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).