### PR TITLE
Update ubuntu-24.04 to latest ISO urls (24.04 to 24.04.1)

### DIFF
--- a/os_pkrvars/ubuntu/ubuntu-24.04-aarch64.pkrvars.hcl
+++ b/os_pkrvars/ubuntu/ubuntu-24.04-aarch64.pkrvars.hcl
@@ -1,7 +1,7 @@
 os_name                 = "ubuntu"
 os_version              = "24.04"
 os_arch                 = "aarch64"
-iso_url                 = "https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04-live-server-arm64.iso"
+iso_url                 = "https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04.1-live-server-arm64.iso"
 iso_checksum            = "file:https://cdimage.ubuntu.com/releases/noble/release/SHA256SUMS"
 parallels_guest_os_type = "ubuntu"
 vbox_guest_os_type      = "Ubuntu_64"

--- a/os_pkrvars/ubuntu/ubuntu-24.04-x86_64.pkrvars.hcl
+++ b/os_pkrvars/ubuntu/ubuntu-24.04-x86_64.pkrvars.hcl
@@ -1,7 +1,7 @@
 os_name                 = "ubuntu"
 os_version              = "24.04"
 os_arch                 = "x86_64"
-iso_url                 = "https://releases.ubuntu.com/noble/ubuntu-24.04-live-server-amd64.iso"
+iso_url                 = "https://releases.ubuntu.com/noble/ubuntu-24.04.1-live-server-amd64.iso"
 iso_checksum            = "file:https://releases.ubuntu.com/noble/SHA256SUMS"
 parallels_guest_os_type = "ubuntu"
 vbox_guest_os_type      = "Ubuntu_64"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This change updates the ISO urls for ubuntu 24.04 to the latest URLs (modified 2024-08-29) 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
