### PR TITLE
update hashicorp/qemu packer plugin to fix QEMU build, supporting efi_drop_efivars variable

### DIFF
--- a/packer_templates/pkr-builder.pkr.hcl
+++ b/packer_templates/pkr-builder.pkr.hcl
@@ -10,7 +10,7 @@ packer {
       source  = "github.com/parallels/parallels"
     }
     qemu = {
-      version = ">= 1.0.8"
+      version = ">= 1.1.0"
       source  = "github.com/hashicorp/qemu"
     }
     vagrant = {


### PR DESCRIPTION
## Description

With the v1.0.8 of the packer pluging hashicorp/qemu a qemu build fails with

```
Error: Unsupported argument
  on packer_templates/pkr-sources.pkr.hcl line 225:
  (source code not available)
An argument named "efi_drop_efivars" is not expected here.
```

v1.1.0 of the plugin fixes the build. 

## Related Issue
See hashicorp/packer-plugin-qemu#140

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
