### PR TITLE
add Ubuntu 24.10 (Oracular Oriole)

### DIFF
--- a/os_pkrvars/ubuntu/ubuntu-24.10-aarch64.pkrvars.hcl
+++ b/os_pkrvars/ubuntu/ubuntu-24.10-aarch64.pkrvars.hcl
@@ -1,0 +1,9 @@
+os_name                 = "ubuntu"
+os_version              = "24.10"
+os_arch                 = "aarch64"
+iso_url                 = "https://cdimage.ubuntu.com/releases/oracular/release/ubuntu-24.10-live-server-arm64.iso"
+iso_checksum            = "file:https://cdimage.ubuntu.com/releases/oracular/release/SHA256SUMS"
+parallels_guest_os_type = "ubuntu"
+vbox_guest_os_type      = "Ubuntu_64"
+vmware_guest_os_type    = "arm-ubuntu-64"
+boot_command            = ["<wait>e<wait><down><down><down><end> autoinstall ds=nocloud-net\\;s=http://{{.HTTPIP}}:{{.HTTPPort}}/ubuntu/<wait><f10><wait>"]

--- a/os_pkrvars/ubuntu/ubuntu-24.10-x86_64.pkrvars.hcl
+++ b/os_pkrvars/ubuntu/ubuntu-24.10-x86_64.pkrvars.hcl
@@ -1,0 +1,9 @@
+os_name                 = "ubuntu"
+os_version              = "24.10"
+os_arch                 = "x86_64"
+iso_url                 = "https://releases.ubuntu.com/oracular/ubuntu-24.10-live-server-amd64.iso"
+iso_checksum            = "file:https://releases.ubuntu.com/oracular/SHA256SUMS"
+parallels_guest_os_type = "ubuntu"
+vbox_guest_os_type      = "Ubuntu_64"
+vmware_guest_os_type    = "ubuntu-64"
+boot_command            = ["<wait>e<wait><down><down><down><end> autoinstall ds=nocloud-net\\;s=http://{{.HTTPIP}}:{{.HTTPPort}}/ubuntu/<wait><f10><wait>"]


### PR DESCRIPTION
## Description

This PR adds support for Ubuntu 24.10 (Oracular Oriole)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
