### PR TITLE
fixing the opensuse build for different provider

### DIFF
--- a/os_pkrvars/opensuse/opensuse-leap-15-aarch64.pkrvars.hcl
+++ b/os_pkrvars/opensuse/opensuse-leap-15-aarch64.pkrvars.hcl
@@ -1,9 +1,24 @@
-os_name                 = "opensuse-leap"
-os_version              = "15.6"
-os_arch                 = "aarch64"
-iso_url                 = "http://provo-mirror.opensuse.org/distribution/leap/15.6/iso/openSUSE-Leap-15.6-DVD-aarch64-Media.iso"
-iso_checksum            = "file:https://provo-mirror.opensuse.org/distribution/leap/15.6/iso/openSUSE-Leap-15.6-DVD-aarch64-Media.iso.sha256"
-parallels_guest_os_type = "opensuse"
-vbox_guest_os_type      = "OpenSUSE_64"
-vmware_guest_os_type    = "arm-other-64"
-boot_command            = ["<wait5><esc><wait>e<wait><down><down><down><down><end> biosdevname=0 net.ifnames=0 netdevice=eth0 netsetup=dhcp lang=en_US textmode=1 modprobe.blacklist=vmwgfx autoyast=http://{{ .HTTPIP }}:{{ .HTTPPort }}/opensuse/autoinst-uefi.xml<f10><wait>"]
+os_name                     = "opensuse-leap"
+os_version                  = "15.6"
+os_arch                     = "aarch64"
+iso_url                     = "https://download.opensuse.org/distribution/leap/15.6/iso/openSUSE-Leap-15.6-DVD-aarch64-Build710.3-Media.iso"
+iso_checksum                = "sha256:6ecade658ef3e4dd7175176781f80fcd070250fe7e922f6240224ff810755ac6"
+parallels_guest_os_type     = "opensuse"
+vbox_guest_os_type          = "OpenSUSE_Leap_arm64"
+vmware_guest_os_type        = "arm-other-64"
+boot_command                = ["<wait5><esc><wait>e<wait><down><down><down><down><end> biosdevname=0 net.ifnames=0 netdevice=eth0 netsetup=dhcp lang=en_US textmode=1 modprobe.blacklist=vmwgfx autoyast=http://{{ .HTTPIP }}:{{ .HTTPPort }}/opensuse/autoinst-uefi.xml<f10><wait>"]
+vboxmanage                  = [
+  [
+    "modifyvm",
+    "{{.Name}}",
+    "--audio",
+    "none",
+    "--nat-localhostreachable1",
+    "on",
+    "--usb-xhci",
+    "on"
+  ]
+]
+vbox_hard_drive_interface   = "virtio"
+vbox_iso_interface          = "virtio"
+vbox_firmware_option        = "efi"

--- a/os_pkrvars/opensuse/opensuse-leap-15-x86_64.pkrvars.hcl
+++ b/os_pkrvars/opensuse/opensuse-leap-15-x86_64.pkrvars.hcl
@@ -1,9 +1,9 @@
 os_name                 = "opensuse-leap"
 os_version              = "15.6"
 os_arch                 = "x86_64"
-iso_url                 = "http://sfo-korg-mirror.kernel.org/opensuse/distribution/leap/15.6/iso/openSUSE-Leap-15.6-DVD-x86_64-Media.iso"
-iso_checksum            = "file:http://sfo-korg-mirror.kernel.org/opensuse/distribution/leap/15.6/iso/openSUSE-Leap-15.6-DVD-x86_64-Media.iso.sha256"
+iso_url                 = "https://download.opensuse.org/distribution/leap/15.6/iso/openSUSE-Leap-15.6-DVD-x86_64-Build710.3-Media.iso"
+iso_checksum            = "sha256:a74d4072e639c75ca127df3d869c1e57bcc44a093a969550f348a3ead561fe4f"
 parallels_guest_os_type = "opensuse"
-vbox_guest_os_type      = "OpenSUSE_64"
+vbox_guest_os_type      = "OpenSUSE_Leap_64"
 vmware_guest_os_type    = "opensuse-64"
 boot_command            = ["<wait5><esc><enter><wait>linux biosdevname=0 net.ifnames=0 netdevice=eth0 netsetup=dhcp lang=en_US textmode=1 autoyast=http://{{ .HTTPIP }}:{{ .HTTPPort }}/opensuse/autoinst.xml<enter><wait>"]

--- a/packer_templates/pkr-sources.pkr.hcl
+++ b/packer_templates/pkr-sources.pkr.hcl
@@ -254,7 +254,7 @@ source "qemu" "vm" {
 }
 source "virtualbox-iso" "vm" {
   # Virtualbox specific options
-  #firmware                  = "efi"
+  firmware                  = var.vbox_firmware_option
   gfx_controller            = local.vbox_gfx_controller
   gfx_vram_size             = local.vbox_gfx_vram_size
   guest_additions_path      = var.vbox_guest_additions_path

--- a/packer_templates/pkr-variables.pkr.hcl
+++ b/packer_templates/pkr-variables.pkr.hcl
@@ -249,6 +249,10 @@ variable "virtualbox_version_file" {
   type    = string
   default = ".vbox_version"
 }
+variable "vbox_firmware_option" {
+  type    = string
+  default = "bios"
+}
 
 # virtualbox-ovf
 variable "vbox_source_path" {

--- a/packer_templates/scripts/_common/parallels.sh
+++ b/packer_templates/scripts/_common/parallels.sh
@@ -3,37 +3,42 @@
 # set a default HOME_DIR environment variable if not set
 HOME_DIR="${HOME_DIR:-/home/vagrant}";
 
-case "$PACKER_BUILDER_TYPE" in
-parallels-iso|parallels-pvm)
-    mkdir -p /tmp/parallels;
-    if [ "$(uname -m)" = "aarch64" ] ; then
-        mount -o loop "$HOME_DIR"/prl-tools-lin-arm.iso /tmp/parallels;
-    else
-        mount -o loop "$HOME_DIR"/prl-tools-lin.iso /tmp/parallels;
-    fi
-    VER="$(cat /tmp/parallels/version)";
+if [ "$(uname -m)" != "aarch64" ]; then
 
-    echo "Parallels Tools Version: $VER";
+    case "$PACKER_BUILDER_TYPE" in
+    parallels-iso|parallels-pvm)
+        mkdir -p /tmp/parallels;
+        if [ "$(uname -m)" = "aarch64" ] ; then
+            mount -o loop "$HOME_DIR"/prl-tools-lin-arm.iso /tmp/parallels;
+        else
+            mount -o loop "$HOME_DIR"/prl-tools-lin.iso /tmp/parallels;
+        fi
+        VER="$(cat /tmp/parallels/version)";
 
-    /tmp/parallels/install --install-unattended-with-deps \
-      || (code="$?"; \
-          echo "Parallels tools installation exited $code, attempting" \
-          "to output /var/log/parallels-tools-install.log"; \
-          cat /var/log/parallels-tools-install.log; \
-          exit $code);
-    umount /tmp/parallels;
-    rm -rf /tmp/parallels;
-    rm -f "$HOME_DIR"/*.iso;
+        echo "Parallels Tools Version: $VER";
 
-    # Parallels Tools for Linux includes native auto-mount script,
-    # which causes losing some of Vagrant-relative shared folders.
-    # So, we should disable this behavior.
-    # https://github.com/Parallels/vagrant-parallels/issues/325#issuecomment-418727113
-    # TODO: verify this is fixed in latest version of parallels
-    # auto_mount_script='/usr/bin/prlfsmountd'
-    # if [ -f "${auto_mount_script}" ]; then
-    #     printf '#!/bin/sh\n # Shared folders auto-mount is disabled by Vagrant' > "${auto_mount_script}"
-    # fi
+        /tmp/parallels/install --install-unattended-with-deps \
+        || (code="$?"; \
+            echo "Parallels tools installation exited $code, attempting" \
+            "to output /var/log/parallels-tools-install.log"; \
+            cat /var/log/parallels-tools-install.log; \
+            exit $code);
+        umount /tmp/parallels;
+        rm -rf /tmp/parallels;
+        rm -f "$HOME_DIR"/*.iso;
 
-    ;;
-esac
+        # Parallels Tools for Linux includes native auto-mount script,
+        # which causes losing some of Vagrant-relative shared folders.
+        # So, we should disable this behavior.
+        # https://github.com/Parallels/vagrant-parallels/issues/325#issuecomment-418727113
+        # TODO: verify this is fixed in latest version of parallels
+        # auto_mount_script='/usr/bin/prlfsmountd'
+        # if [ -f "${auto_mount_script}" ]; then
+        #     printf '#!/bin/sh\n # Shared folders auto-mount is disabled by Vagrant' > "${auto_mount_script}"
+        # fi
+
+        ;;
+    esac
+else
+    echo "Skipping Parallels Tools installation on aarch64 architecture"
+fi

--- a/packer_templates/scripts/_common/virtualbox.sh
+++ b/packer_templates/scripts/_common/virtualbox.sh
@@ -1,55 +1,59 @@
 #!/bin/sh -eux
+if [ "$(uname -m)" != "aarch64" ]; then
 
-# set a default HOME_DIR environment variable if not set
-HOME_DIR="${HOME_DIR:-/home/vagrant}";
+    # set a default HOME_DIR environment variable if not set
+    HOME_DIR="${HOME_DIR:-/home/vagrant}";
 
-case "$PACKER_BUILDER_TYPE" in
-virtualbox-iso|virtualbox-ovf)
-    VER="$(cat "$HOME_DIR"/.vbox_version)";
-    ISO="VBoxGuestAdditions_$VER.iso";
+    case "$PACKER_BUILDER_TYPE" in
+    virtualbox-iso|virtualbox-ovf)
+        VER="$(cat "$HOME_DIR"/.vbox_version)";
+        ISO="VBoxGuestAdditions_$VER.iso";
 
-    # mount the ISO to /tmp/vbox
-    mkdir -p /tmp/vbox;
-    mount -o loop "$HOME_DIR"/"$ISO" /tmp/vbox;
+        # mount the ISO to /tmp/vbox
+        mkdir -p /tmp/vbox;
+        mount -o loop "$HOME_DIR"/"$ISO" /tmp/vbox;
 
-    echo "installing deps necessary to compile kernel modules"
-    # We install things like kernel-headers here vs. kickstart files so we make sure we install them for the updated kernel not the stock kernel
-    if [ -f "/bin/dnf" ]; then
-        dnf install -y --skip-broken perl cpp gcc make bzip2 tar kernel-headers kernel-devel kernel-uek-devel || true # not all these packages are on every system
-    elif [ -f "/bin/yum" ] || [ -f "/usr/bin/yum" ]; then
-        yum install -y --skip-broken perl cpp gcc make bzip2 tar kernel-headers kernel-devel kernel-uek-devel || true # not all these packages are on every system
-    elif [ -f "/usr/bin/apt-get" ]; then
-        apt-get install -y build-essential dkms bzip2 tar linux-headers-"$(uname -r)"
-    elif [ -f "/usr/bin/zypper" ]; then
-        zypper install -y perl cpp gcc make bzip2 tar kernel-default-devel
-    fi
+        echo "installing deps necessary to compile kernel modules"
+        # We install things like kernel-headers here vs. kickstart files so we make sure we install them for the updated kernel not the stock kernel
+        if [ -f "/bin/dnf" ]; then
+            dnf install -y --skip-broken perl cpp gcc make bzip2 tar kernel-headers kernel-devel kernel-uek-devel || true # not all these packages are on every system
+        elif [ -f "/bin/yum" ] || [ -f "/usr/bin/yum" ]; then
+            yum install -y --skip-broken perl cpp gcc make bzip2 tar kernel-headers kernel-devel kernel-uek-devel || true # not all these packages are on every system
+        elif [ -f "/usr/bin/apt-get" ]; then
+            apt-get install -y build-essential dkms bzip2 tar linux-headers-"$(uname -r)"
+        elif [ -f "/usr/bin/zypper" ]; then
+            zypper install -y perl cpp gcc make bzip2 tar kernel-default-devel
+        fi
 
-    echo "installing the vbox additions"
-    # this install script fails with non-zero exit codes for no apparent reason so we need better ways to know if it worked
-    /tmp/vbox/VBoxLinuxAdditions.run --nox11 || true
+        echo "installing the vbox additions"
+        # this install script fails with non-zero exit codes for no apparent reason so we need better ways to know if it worked
+        /tmp/vbox/VBoxLinuxAdditions.run --nox11 || true
 
-    if ! modinfo vboxsf >/dev/null 2>&1; then
-         echo "Cannot find vbox kernel module. Installation of guest additions unsuccessful!"
-         exit 1
-    fi
+        if ! modinfo vboxsf >/dev/null 2>&1; then
+            echo "Cannot find vbox kernel module. Installation of guest additions unsuccessful!"
+            exit 1
+        fi
 
-    echo "unmounting and removing the vbox ISO"
-    umount /tmp/vbox;
-    rm -rf /tmp/vbox;
-    rm -f "$HOME_DIR"/*.iso;
+        echo "unmounting and removing the vbox ISO"
+        umount /tmp/vbox;
+        rm -rf /tmp/vbox;
+        rm -f "$HOME_DIR"/*.iso;
 
-    echo "removing kernel dev packages and compilers we no longer need"
-    if [ -f "/bin/dnf" ]; then
-        dnf remove -y gcc cpp kernel-headers kernel-devel kernel-uek-devel
-    elif [ -f "/bin/yum" ] || [ -f "/usr/bin/yum" ]; then
-        yum remove -y gcc cpp kernel-headers kernel-devel kernel-uek-devel
-    elif [ -f "/usr/bin/apt-get" ]; then
-        apt-get remove -y build-essential gcc g++ make libc6-dev dkms linux-headers-"$(uname -r)"
-    elif [ -f "/usr/bin/zypper" ]; then
-        zypper -n rm -u kernel-default-devel gcc make
-    fi
+        echo "removing kernel dev packages and compilers we no longer need"
+        if [ -f "/bin/dnf" ]; then
+            dnf remove -y gcc cpp kernel-headers kernel-devel kernel-uek-devel
+        elif [ -f "/bin/yum" ] || [ -f "/usr/bin/yum" ]; then
+            yum remove -y gcc cpp kernel-headers kernel-devel kernel-uek-devel
+        elif [ -f "/usr/bin/apt-get" ]; then
+            apt-get remove -y build-essential gcc g++ make libc6-dev dkms linux-headers-"$(uname -r)"
+        elif [ -f "/usr/bin/zypper" ]; then
+            zypper -n rm -u kernel-default-devel gcc make
+        fi
 
-    echo "removing leftover logs"
-    rm -rf /var/log/vboxadd*
-    ;;
-esac
+        echo "removing leftover logs"
+        rm -rf /var/log/vboxadd*
+        ;;
+    esac
+else
+    echo "Skipping Virtualbox guest additions installation on aarch64 architecture"
+fi


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title above -->

## Description
 The PR  will fix builds for Opensuse distribution for several providers and archs:
 - Parallels: the build is completely fixed
 - VirtualBox: the build only fails during the  export phase for the arch aarch64 because of a bug  in [Virtualbox export](https://forums.virtualbox.org/viewtopic.php?t=112717)
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or StackOverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
