### PR TITLE
Fix: prevent cleanup script crash when no packages are found

### DIFF
--- a/packer_templates/scripts/debian/cleanup_debian.sh
+++ b/packer_templates/scripts/debian/cleanup_debian.sh
@@ -3,27 +3,27 @@
 echo "remove linux-headers"
 dpkg --list \
   | awk '{ print $2 }' \
-  | grep 'linux-headers' \
-  | xargs apt-get -y purge;
+  | grep 'linux-headers' || true \
+  | xargs -r apt-get -y purge;
 
 echo "remove specific Linux kernels, such as linux-image-4.9.0-13-amd64 but keeps the current kernel and does not touch the virtual packages"
 dpkg --list \
     | awk '{ print $2 }' \
-    | grep 'linux-image-[1-9].*' \
-    | grep -v "$(uname -r)" \
-    | xargs apt-get -y purge;
+    | grep 'linux-image-[1-9].*' || true \
+    | grep -v "$(uname -r)" || true \
+    | xargs -r apt-get -y purge;
 
 echo "remove linux-source package"
 dpkg --list \
     | awk '{ print $2 }' \
-    | grep linux-source \
-    | xargs apt-get -y purge;
+    | grep linux-source || true \
+    | xargs -r apt-get -y purge;
 
 echo "remove all development packages"
 dpkg --list \
     | awk '{ print $2 }' \
-    | grep -- '-dev\(:[a-z0-9]\+\)\?$' \
-    | xargs apt-get -y purge;
+    | grep -- '-dev\(:[a-z0-9]\+\)\?$' || true \
+    | xargs -r apt-get -y purge;
 
 echo "remove X11 libraries"
 apt-get -y purge libx11-data xauth libxmuu1 libxcb1 libx11-6 libxext6;

--- a/packer_templates/scripts/ubuntu/cleanup_ubuntu.sh
+++ b/packer_templates/scripts/ubuntu/cleanup_ubuntu.sh
@@ -3,41 +3,41 @@
 echo "remove linux-headers"
 dpkg --list \
   | awk '{ print $2 }' \
-  | grep 'linux-headers' \
-  | xargs apt-get -y purge;
+  | grep 'linux-headers' || true \
+  | xargs -r apt-get -y purge;
 
 echo "remove specific Linux kernels, such as linux-image-3.11.0-15-generic but keeps the current kernel and does not touch the virtual packages"
 dpkg --list \
     | awk '{ print $2 }' \
-    | grep 'linux-image-.*-generic' \
-    | grep -v "$(uname -r)" \
-    | xargs apt-get -y purge;
+    | grep 'linux-image-.*-generic' || true \
+    | grep -v "$(uname -r)" || true \
+    | xargs -r apt-get -y purge;
 
 echo "remove old kernel modules packages"
 dpkg --list \
     | awk '{ print $2 }' \
-    | grep 'linux-modules-.*-generic' \
-    | grep -v "$(uname -r)" \
-    | xargs apt-get -y purge;
+    | grep 'linux-modules-.*-generic' || true \
+    | grep -v "$(uname -r)" || true \
+    | xargs -r apt-get -y purge;
 
 echo "remove linux-source package"
 dpkg --list \
     | awk '{ print $2 }' \
-    | grep linux-source \
-    | xargs apt-get -y purge;
+    | grep linux-source || true \
+    | xargs -r apt-get -y purge;
 
 # 23.10 gives dependency errors for systemd-dev package
 echo "remove all development packages"
 dpkg --list \
     | awk '{ print $2 }' \
-    | grep -- '-dev\(:[a-z0-9]\+\)\?$' \
-    | xargs -I % apt-get -y purge % || true;
+    | grep -- '-dev\(:[a-z0-9]\+\)\?$' || true \
+    | xargs -r -I % apt-get -y purge % || true;
 
 echo "remove docs packages"
 dpkg --list \
     | awk '{ print $2 }' \
-    | grep -- '-doc$' \
-    | xargs apt-get -y purge;
+    | grep -- '-doc$' || true \
+    | xargs -r apt-get -y purge;
 
 echo "remove X11 libraries"
 apt-get -y purge libx11-data xauth libxmuu1 libxcb1 libx11-6 libxext6;


### PR DESCRIPTION
This PR fixes a bug in the cleanup_debian.sh and cleanup_ubuntu.sh scripts where certain dpkg | grep | xargs apt-get purge pipelines may fail if no matching packages are found.

When running on minimal images (e.g. with headers or dev packages already removed), grep returns non-zero code and causes the script to exit under set -e. Additionally, xargs without -r may invoke apt-get with no arguments, which leads to an error.

Changes:
- added '|| true' after all grep calls to avoid pipeline failures
- added xargs '-r' to skip apt-get if the input is empty

These changes are safe, maintain existing logic, and ensure the scripts work reliably in clean or partially pre-cleaned environments.