### PR TITLE
fix: wrap late_command in sh -c to ensure proper redirection

### DIFF
--- a/packer_templates/http/debian/preseed.cfg
+++ b/packer_templates/http/debian/preseed.cfg
@@ -96,9 +96,8 @@ popularity-contest popularity-contest/participate boolean false
 # Select base install
 tasksel tasksel/first multiselect standard, ssh-server
 
-# Setup passwordless sudo for packer user
+# Setup passwordless sudo for packer user and remove cdrom from apt sources
 d-i preseed/late_command string \
-echo "vagrant ALL=(ALL:ALL) NOPASSWD:ALL" > /target/etc/sudoers.d/vagrant && chmod 0440 /target/etc/sudoers.d/vagrant
-
-# remove cdrom from apt sources
-d-i preseed/late_command string sed -i '/^deb cdrom:/s/^/#/' /target/etc/apt/sources.list
+sh -c "echo 'vagrant ALL=(ALL:ALL) NOPASSWD:ALL' > /target/etc/sudoers.d/vagrant && \
+chmod 0440 /target/etc/sudoers.d/vagrant && \
+sed -i '/^deb cdrom:/s/^/#/' /target/etc/apt/sources.list"


### PR DESCRIPTION
This PR fixes an issue in the preseed.cfg where multiple d-i preseed/late_command entries silently override each other, causing only the last one to execute.

Additionally, shell constructs like > (redirection) and && are not reliably interpreted by the installer unless explicitly passed to sh -c.

Changes:
- Combined multiple late_command lines into a single command chain
- Wrapped the full command in sh -c "..." to ensure correct shell parsing and file redirection

This ensures all late-stage installation tasks (like configuring sudo access and modifying APT sources) are executed consistently and predictably.