### PR TITLE
Update copyright notices to Progress Software Corporation

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -2,8 +2,7 @@
 
 Chef Bento
 Copyright 2019-2023, Progress Software Corporation
-Copyright 2012-2019, Chef Software, Inc.
-
+Copyright (c) 2012-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 The baseboxes in the "definitions" directory is from Tim Dysinger's
 "basebox" project.
 


### PR DESCRIPTION
This PR updates copyright notices from Chef Software and Opscode to Progress Software Corporation as part of the repository standardization effort.

## Changes

- Updated copyright notices to use Progress Software Corporation
- Applied year range: 2012-2025
- Updated 1 copyright notice across 1 file
- Preserved original formatting and comment styles

This is an automated update using the copyright-automator tool.