### PR TITLE
sudo-rs doesn't support exempt_group

### DIFF
--- a/packer_templates/scripts/ubuntu/sudoers_ubuntu.sh
+++ b/packer_templates/scripts/ubuntu/sudoers_ubuntu.sh
@@ -1,6 +1,8 @@
 #!/bin/sh -eux
 
-sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=sudo' /etc/sudoers;
+if ! sudo --version &>/dev/stdout | grep -q sudo-rs; then
+  sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=sudo' /etc/sudoers;
+fi
 
 # Set up password-less sudo for the vagrant user
 echo 'vagrant ALL=(ALL) NOPASSWD:ALL' >/etc/sudoers.d/99_vagrant;


### PR DESCRIPTION

## Description

```
/etc/sudoers:10:10: unknown setting: 'exempt_group'
Defaults        exempt_group=sudo
                ^~~~~~~~~~~~
```

## Related Issue

https://github.com/trifectatechfoundation/sudo-rs/pull/1387

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
