### PR TITLE
Add FreeBSD 15.0-RELEASE

### DIFF
--- a/.github/workflows/pkr-bld-hyperv-x64.yml
+++ b/.github/workflows/pkr-bld-hyperv-x64.yml
@@ -27,6 +27,7 @@ jobs:
           - fedora-43
           - freebsd-13
           - freebsd-14
+          - freebsd-15
           - opensuse-leap-15
           - opensuse-leap-16
           - oraclelinux-8

--- a/.github/workflows/pkr-bld-parallels-arm64.yml
+++ b/.github/workflows/pkr-bld-parallels-arm64.yml
@@ -26,6 +26,7 @@ jobs:
           - fedora-43
           - freebsd-13
           - freebsd-14
+          - freebsd-15
           - opensuse-leap-15
           - opensuse-leap-16
           - oraclelinux-9

--- a/.github/workflows/pkr-bld-parallels-x64.yml
+++ b/.github/workflows/pkr-bld-parallels-x64.yml
@@ -27,6 +27,7 @@ jobs:
           - fedora-43
           - freebsd-13
           - freebsd-14
+          - freebsd-15
           - opensuse-leap-15
           - opensuse-leap-16
           - oraclelinux-8

--- a/.github/workflows/pkr-bld-qemu-arm64.yml
+++ b/.github/workflows/pkr-bld-qemu-arm64.yml
@@ -26,6 +26,7 @@ jobs:
           - fedora-43
           - freebsd-13
           - freebsd-14
+          - freebsd-15
           - opensuse-leap-15
           - opensuse-leap-16
           - oraclelinux-9

--- a/.github/workflows/pkr-bld-qemu-x64.yml
+++ b/.github/workflows/pkr-bld-qemu-x64.yml
@@ -27,6 +27,7 @@ jobs:
           - fedora-43
           - freebsd-13
           - freebsd-14
+          - freebsd-15
           - opensuse-leap-15
           - opensuse-leap-16
           - oraclelinux-8

--- a/.github/workflows/pkr-bld-utm-arm64.yml
+++ b/.github/workflows/pkr-bld-utm-arm64.yml
@@ -25,6 +25,7 @@ jobs:
           - fedora-42
           - freebsd-13
           - freebsd-14
+          - freebsd-15
           - opensuse-leap-15
           - opensuse-leap-16
           - oraclelinux-9

--- a/.github/workflows/pkr-bld-utm-x64.yml
+++ b/.github/workflows/pkr-bld-utm-x64.yml
@@ -26,6 +26,7 @@ jobs:
           - fedora-42
           - freebsd-13
           - freebsd-14
+          - freebsd-15
           - opensuse-leap-15
           - opensuse-leap-16
           - oraclelinux-8

--- a/.github/workflows/pkr-bld-virtualbox-arm64.yml
+++ b/.github/workflows/pkr-bld-virtualbox-arm64.yml
@@ -26,6 +26,7 @@ jobs:
           - fedora-43
           - freebsd-13
           - freebsd-14
+          - freebsd-15
           - opensuse-leap-15
           - opensuse-leap-16
           - oraclelinux-9

--- a/.github/workflows/pkr-bld-virtualbox-x64.yml
+++ b/.github/workflows/pkr-bld-virtualbox-x64.yml
@@ -27,6 +27,7 @@ jobs:
           - fedora-43
           - freebsd-13
           - freebsd-14
+          - freebsd-15
           - opensuse-leap-15
           - opensuse-leap-16
           - oraclelinux-8

--- a/.github/workflows/pkr-bld-vmware-arm64.yml
+++ b/.github/workflows/pkr-bld-vmware-arm64.yml
@@ -26,6 +26,7 @@ jobs:
           - fedora-43
           - freebsd-13
           - freebsd-14
+          - freebsd-15
           - opensuse-leap-15
           - opensuse-leap-16
           - oraclelinux-9

--- a/.github/workflows/pkr-bld-vmware-x64.yml
+++ b/.github/workflows/pkr-bld-vmware-x64.yml
@@ -27,6 +27,7 @@ jobs:
           - fedora-43
           - freebsd-13
           - freebsd-14
+          - freebsd-15
           - opensuse-leap-15
           - opensuse-leap-16
           - oraclelinux-8

--- a/.github/workflows/test-pkr-bld-parallels.yml
+++ b/.github/workflows/test-pkr-bld-parallels.yml
@@ -26,6 +26,7 @@ jobs:
           - fedora-43
           - freebsd-13
           - freebsd-14
+          - freebsd-15
           - opensuse-leap-15
           - opensuse-leap-16
           - oraclelinux-8
@@ -95,6 +96,7 @@ jobs:
           - fedora-41
           - freebsd-13
           - freebsd-14
+          - freebsd-15
           - opensuse-leap-15
           - oraclelinux-8
           - oraclelinux-9

--- a/builds.yml
+++ b/builds.yml
@@ -18,6 +18,7 @@ public:
   - fedora-43
   - freebsd-13
   - freebsd-14
+  - freebsd-15
   - opensuse-leap-15
   - opensuse-leap-16
   - oraclelinux-8
@@ -41,6 +42,7 @@ slugs:
   - fedora-latest
   - freebsd-13
   - freebsd-14
+  - freebsd-15
   - opensuse-leap-15
   - oraclelinux-8
   - oraclelinux-9

--- a/os_pkrvars/freebsd/freebsd-15-aarch64.pkrvars.hcl
+++ b/os_pkrvars/freebsd/freebsd-15-aarch64.pkrvars.hcl
@@ -1,0 +1,12 @@
+os_name                 = "freebsd"
+os_version              = "15.0"
+os_arch                 = "aarch64"
+iso_url                 = "https://download.freebsd.org/releases/arm64/aarch64/ISO-IMAGES/15.0/FreeBSD-15.0-RELEASE-arm64-aarch64-disc1.iso"
+iso_checksum            = "file:https://download.freebsd.org/releases/arm64/aarch64/ISO-IMAGES/15.0/CHECKSUM.SHA256-FreeBSD-15.0-RELEASE-arm64-aarch64"
+parallels_guest_os_type = "freebsd"
+vbox_guest_os_type      = "FreeBSD_arm64"
+vmware_guest_os_type    = "arm-freebsd15-64"
+utm_vm_icon             = "freebsd"
+default_boot_wait       = "60s"
+boot_command            = ["<wait>s<wait2>mdmfs -s 100m md1 /tmp<enter><wait>mdmfs -s 100m md2 /mnt<enter><wait>dhclient -p /tmp/dhclient.$(ifconfig -l | awk '{print $1}').pid -l /tmp/dhclient.lease.$(ifconfig -l | awk '{print $1}') $(ifconfig -l | awk '{print $1}')<enter><wait10>fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/freebsd/installerconfig && bsdinstall script /tmp/installerconfig<enter><wait>"]
+utm_boot_command        = ["<wait>s<wait2>mdmfs -s 100m md1 /tmp<enter><wait>mdmfs -s 100m md2 /mnt<enter><wait>dhclient -p /tmp/dhclient.$(ifconfig -l | awk '{print $1}').pid -l /tmp/dhclient.lease.$(ifconfig -l | awk '{print $1}') $(ifconfig -l | awk '{print $1}')<enter><wait10>dhclient -p /tmp/dhclient.$(ifconfig -l | awk '{print $2}').pid -l /tmp/dhclient.lease.$(ifconfig -l | awk '{print $2}') $(ifconfig -l | awk '{print $2}')<enter><wait10>fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/freebsd/installerconfig && bsdinstall script /tmp/installerconfig<enter><wait>"]

--- a/os_pkrvars/freebsd/freebsd-15-x86_64.pkrvars.hcl
+++ b/os_pkrvars/freebsd/freebsd-15-x86_64.pkrvars.hcl
@@ -1,0 +1,11 @@
+os_name                 = "freebsd"
+os_version              = "15.0"
+os_arch                 = "x86_64"
+iso_url                 = "https://download.freebsd.org/releases/amd64/amd64/ISO-IMAGES/15.0/FreeBSD-15.0-RELEASE-amd64-disc1.iso"
+iso_checksum            = "file:https://download.freebsd.org/releases/amd64/amd64/ISO-IMAGES/15.0/CHECKSUM.SHA256-FreeBSD-15.0-RELEASE-amd64"
+parallels_guest_os_type = "freebsd"
+vbox_guest_os_type      = "FreeBSD_64"
+vmware_guest_os_type    = "freebsd-64"
+utm_vm_icon             = "freebsd"
+default_boot_wait       = "60s"
+boot_command            = ["<wait>s<wait2>mdmfs -s 100m md1 /tmp<enter><wait>mdmfs -s 100m md2 /mnt<enter><wait>dhclient -p /tmp/dhclient.$(ifconfig -l | awk '{print $1}').pid -l /tmp/dhclient.lease.$(ifconfig -l | awk '{print $1}') $(ifconfig -l | awk '{print $1}')<enter><wait10>dhclient -p /tmp/dhclient.$(ifconfig -l | awk '{print $2}').pid -l /tmp/dhclient.lease.$(ifconfig -l | awk '{print $2}') $(ifconfig -l | awk '{print $2}')<enter><wait10>fetch -o /tmp/installerconfig http://{{ .HTTPIP }}:{{ .HTTPPort }}/freebsd/installerconfig && bsdinstall script /tmp/installerconfig<enter><wait>"]


### PR DESCRIPTION
FreeBSD 15.0 was recently released.  Copy the exisiting code related to
FreeBSD 14.3 and adjust the version number accordingly.

Signed-off-by: Romain Tartière <romain@blogreen.org>
