### PR TITLE
fix grub-install for debian 13

### DIFF
--- a/packer_templates/scripts/debian/cleanup_debian.sh
+++ b/packer_templates/scripts/debian/cleanup_debian.sh
@@ -2,6 +2,7 @@
 
 if [ -d /sys/firmware/efi ]; then
   # Ensure the system can boot by adding the bootloader at the fallback path
+  ln -s -r /usr/lib/grub/x86_64-efi /usr/lib/grub/amd64-efi
   grub-install --target="$(dpkg --print-architecture)"-efi --efi-directory=/boot/efi --bootloader-id=debian --removable
 fi
 

--- a/packer_templates/scripts/debian/cleanup_debian.sh
+++ b/packer_templates/scripts/debian/cleanup_debian.sh
@@ -2,7 +2,7 @@
 
 if [ -d /sys/firmware/efi ]; then
   # Ensure the system can boot by adding the bootloader at the fallback path
-  [[ "$(uname -m)" == "x86_64" ]] && ln -sfn /usr/lib/grub/x86_64-efi /usr/lib/grub/amd64-efi
+  [ "$(uname -m)" == "x86_64" ] && ln -sfn /usr/lib/grub/x86_64-efi /usr/lib/grub/amd64-efi
   grub-install --target="$(dpkg --print-architecture)"-efi --efi-directory=/boot/efi --bootloader-id=debian --removable
 fi
 

--- a/packer_templates/scripts/debian/cleanup_debian.sh
+++ b/packer_templates/scripts/debian/cleanup_debian.sh
@@ -2,7 +2,7 @@
 
 if [ -d /sys/firmware/efi ]; then
   # Ensure the system can boot by adding the bootloader at the fallback path
-  [ "$(uname -m)" == "x86_64" ] && ln -sfn /usr/lib/grub/x86_64-efi /usr/lib/grub/amd64-efi
+  [ "$(uname -m)" = "x86_64" ] && ln -sfn /usr/lib/grub/x86_64-efi /usr/lib/grub/amd64-efi
   grub-install --target="$(dpkg --print-architecture)"-efi --efi-directory=/boot/efi --bootloader-id=debian --removable
 fi
 

--- a/packer_templates/scripts/debian/cleanup_debian.sh
+++ b/packer_templates/scripts/debian/cleanup_debian.sh
@@ -2,7 +2,7 @@
 
 if [ -d /sys/firmware/efi ]; then
   # Ensure the system can boot by adding the bootloader at the fallback path
-  ln -s -r /usr/lib/grub/x86_64-efi /usr/lib/grub/amd64-efi
+  [[ "$(uname -m)" == "x86_64" ]] && ln -sfn /usr/lib/grub/x86_64-efi /usr/lib/grub/amd64-efi
   grub-install --target="$(dpkg --print-architecture)"-efi --efi-directory=/boot/efi --bootloader-id=debian --removable
 fi
 


### PR DESCRIPTION
## Description
During a qemu build of Debian 13:

```
...
==> qemu.vm: grub-install: error: /usr/lib/grub/amd64-efi/modinfo.sh doesn't exist. Please specify --target or --directory.
...
Build 'qemu.vm' errored after 12 minutes 26 seconds: Script exited with non-zero exit status: 1. Allowed exit codes are: [0]
```

Examining the filesystem, the file in question is now actually in `/usr/lib/grub/x86_64-efi`, not `/usr/lib/grub/amd64-efi`. 

This PR adds a single line prior to `grub-install`:

```bash
ln -s -r /usr/lib/grub/x86_64-efi /usr/lib/grub/amd64-efi
```

which fixes the build:

```
==> qemu.vm: Provisioning with shell script: ./packer_templates/scripts/debian/cleanup_debian.sh
==> qemu.vm: + [ -d /sys/firmware/efi ]
==> qemu.vm: + ln -s -r /usr/lib/grub/x86_64-efi /usr/lib/grub/amd64-efi
==> qemu.vm: + dpkg --print-architecture
==> qemu.vm: + grub-install --target=amd64-efi --efi-directory=/boot/efi --bootloader-id=debian --removable
==> qemu.vm: Installing for x86_64-efi platform.
==> qemu.vm: Installation finished. No error reported.
...
Build 'qemu.vm' finished after 16 minutes 16 seconds.
```


## Related Issue
chef/bento#1667

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
](https://github.com/chef/bento/issues/1667)