### PR TITLE
Fix vmware-iso validation by explicitly setting tools_mode

### DIFF
--- a/packer_templates/pkr-plugins.pkr.hcl
+++ b/packer_templates/pkr-plugins.pkr.hcl
@@ -30,7 +30,7 @@ packer {
       source  = "github.com/hashicorp/virtualbox"
     }
     vmware = {
-      version = ">= 1.1.0"
+      version = ">= 2.1.3"
       source  = "github.com/hashicorp/vmware"
     }
     windows-update = {

--- a/packer_templates/pkr-sources.pkr.hcl
+++ b/packer_templates/pkr-sources.pkr.hcl
@@ -211,6 +211,9 @@ locals {
       var.os_name == "macos" ? "darwin" : null
     )
   ) : var.vmware_tools_upload_flavor
+  vmware_tools_mode = var.vmware_tools_mode == null ? (
+    local.vmware_tools_upload_flavor == null ? "disable" : "upload"
+  ) : var.vmware_tools_mode
   vmware_tools_upload_path = var.vmware_tools_upload_path == null ? (
     var.is_windows ? "c:\\vmware-tools.iso" : "/tmp/vmware-tools.iso"
   ) : var.vmware_tools_upload_path
@@ -553,6 +556,7 @@ source "vmware-iso" "vm" {
   guest_os_type                  = var.vmware_guest_os_type
   network                        = var.vmware_network
   network_adapter_type           = local.vmware_network_adapter_type
+  tools_mode                     = local.vmware_tools_mode
   tools_upload_flavor            = local.vmware_tools_upload_flavor
   tools_upload_path              = local.vmware_tools_upload_path
   usb                            = var.vmware_usb

--- a/packer_templates/pkr-sources.pkr.hcl
+++ b/packer_templates/pkr-sources.pkr.hcl
@@ -204,19 +204,50 @@ locals {
   vmware_network_adapter_type = var.vmware_network_adapter_type == null ? (
     var.is_windows && var.os_arch == "aarch64" ? "vmxnet3" : "e1000e"
   ) : var.vmware_network_adapter_type
-  vmware_tools_upload_flavor = var.vmware_tools_upload_flavor == null ? (
+  
+  # VMware Tools configuration
+  # tools_source_path and tools_upload_flavor are mutually exclusive
+  # - If tools_source_path is provided by user, use it
+  # - Otherwise, if tools_mode is "attach", auto-detect the ISO path on host
+  # - If tools_mode is "upload" and no tools_source_path, use tools_upload_flavor instead
+  
+  # Default source path based on host OS and guest type (for attach mode)
+  vmware_tools_source_path_default = local.host_os == "darwin" ? (
+    # macOS (VMware Fusion paths)
     var.is_windows ? (
-      var.os_arch == "x86_64" ? "windows" : null
-      ) : (
-      var.os_name == "macos" ? "darwin" : null
+      var.os_arch == "aarch64" ? "/Applications/VMware Fusion.app/Contents/Library/isoimages/arm64/windows.iso" : "/Applications/VMware Fusion.app/Contents/Library/isoimages/x86_64/windows.iso"
+    ) : (
+      var.os_name == "macos" ? "/Applications/VMware Fusion.app/Contents/Library/isoimages/darwin.iso" : "/Applications/VMware Fusion.app/Contents/Library/isoimages/linux.iso"
     )
-  ) : var.vmware_tools_upload_flavor
-  vmware_tools_mode = var.vmware_tools_mode == null ? (
-    local.vmware_tools_upload_flavor == null ? "disable" : "upload"
-  ) : var.vmware_tools_mode
-  vmware_tools_upload_path = var.vmware_tools_upload_path == null ? (
-    var.is_windows ? "c:\\vmware-tools.iso" : "/tmp/vmware-tools.iso"
-  ) : var.vmware_tools_upload_path
+  ) : (
+    # Linux (VMware Workstation paths)
+    var.is_windows ? "/usr/lib/vmware/isoimages/windows.iso" : (
+      var.os_name == "macos" ? "/usr/lib/vmware/isoimages/darwin.iso" : "/usr/lib/vmware/isoimages/linux.iso"
+    )
+  )
+  
+  # Set tools_source_path if user provided one, or if tools_mode is "attach" (auto-detect), otherwise null
+  vmware_tools_source_path = var.vmware_tools_source_path != null ? var.vmware_tools_source_path : (
+    var.vmware_tools_mode == "attach" ? local.vmware_tools_source_path_default : null
+  )
+  
+  # Only set tools_upload_flavor when tools_mode is "upload" AND tools_source_path is not being used
+  vmware_tools_upload_flavor = var.vmware_tools_mode == "upload" && var.vmware_tools_source_path == null ? (
+    var.vmware_tools_upload_flavor == null ? (
+      var.is_windows ? (
+        var.os_arch == "x86_64" ? "windows" : null
+      ) : (
+        var.os_name == "macos" ? "darwin" : null
+      )
+    ) : var.vmware_tools_upload_flavor
+  ) : null
+  
+  # Only set tools_upload_path when tools_mode is "upload"
+  vmware_tools_upload_path = var.vmware_tools_mode == "upload" ? (
+    var.vmware_tools_upload_path == null ? (
+      var.is_windows ? "c:\\vmware-tools.iso" : "/tmp/vmware-tools.iso"
+    ) : var.vmware_tools_upload_path
+  ) : null
   vmware_vmx_data = var.vmware_vmx_data == null ? (
     local.host_os == "darwin" ? (
       var.is_windows ? (
@@ -556,7 +587,8 @@ source "vmware-iso" "vm" {
   guest_os_type                  = var.vmware_guest_os_type
   network                        = var.vmware_network
   network_adapter_type           = local.vmware_network_adapter_type
-  tools_mode                     = local.vmware_tools_mode
+  tools_mode                     = var.vmware_tools_mode
+  tools_source_path              = local.vmware_tools_source_path
   tools_upload_flavor            = local.vmware_tools_upload_flavor
   tools_upload_path              = local.vmware_tools_upload_path
   usb                            = var.vmware_usb

--- a/packer_templates/pkr-sources.pkr.hcl
+++ b/packer_templates/pkr-sources.pkr.hcl
@@ -217,7 +217,7 @@ locals {
     ) : var.vmware_tools_upload_path
   ) : null
   vmware_tools_source_path = var.vmware_tools_mode == "disable" ? null : (
-    vmware_tools_source_path == null ? null : var.vmaware_tools_source_path
+    var.vmware_tools_source_path == null ? null : var.vmware_tools_source_path
   )
   vmware_vmx_data = var.vmware_vmx_data == null ? (
     {

--- a/packer_templates/pkr-sources.pkr.hcl
+++ b/packer_templates/pkr-sources.pkr.hcl
@@ -204,73 +204,23 @@ locals {
   vmware_network_adapter_type = var.vmware_network_adapter_type == null ? (
     var.is_windows && var.os_arch == "aarch64" ? "vmxnet3" : "e1000e"
   ) : var.vmware_network_adapter_type
-  
-  # VMware Tools configuration
-  # tools_source_path and tools_upload_flavor are mutually exclusive
-  # - If tools_source_path is provided by user, use it
-  # - Otherwise, if tools_mode is "attach", auto-detect the ISO path on host
-  # - If tools_mode is "upload" and no tools_source_path, use tools_upload_flavor instead
-  
-  # Default source path based on host OS and guest type (for attach mode)
-  vmware_tools_source_path_default = local.host_os == "darwin" ? (
-    # macOS (VMware Fusion paths)
-    var.is_windows ? (
-      var.os_arch == "aarch64" ? "/Applications/VMware Fusion.app/Contents/Library/isoimages/arm64/windows.iso" : "/Applications/VMware Fusion.app/Contents/Library/isoimages/x86_64/windows.iso"
-    ) : (
-      var.os_name == "macos" ? "/Applications/VMware Fusion.app/Contents/Library/isoimages/darwin.iso" : "/Applications/VMware Fusion.app/Contents/Library/isoimages/linux.iso"
-    )
-  ) : (
-    # Linux (VMware Workstation paths)
-    var.is_windows ? "/usr/lib/vmware/isoimages/windows.iso" : (
-      var.os_name == "macos" ? "/usr/lib/vmware/isoimages/darwin.iso" : "/usr/lib/vmware/isoimages/linux.iso"
-    )
-  )
-  
-  # Set tools_source_path if user provided one, or if tools_mode is "attach" (auto-detect), otherwise null
-  vmware_tools_source_path = var.vmware_tools_source_path != null ? var.vmware_tools_source_path : (
-    var.vmware_tools_mode == "attach" ? local.vmware_tools_source_path_default : null
-  )
-  
-  # Only set tools_upload_flavor when tools_mode is "upload" AND tools_source_path is not being used
   vmware_tools_upload_flavor = var.vmware_tools_mode == "upload" && var.vmware_tools_source_path == null ? (
     var.vmware_tools_upload_flavor == null ? (
-      var.is_windows ? (
-        var.os_arch == "x86_64" ? "windows" : null
-      ) : (
-        var.os_name == "macos" ? "darwin" : null
+      var.is_windows ? "windows" : (
+        var.os_name == "macos" ? "darwin" : "linux"
       )
     ) : var.vmware_tools_upload_flavor
   ) : null
-  
-  # Only set tools_upload_path when tools_mode is "upload"
   vmware_tools_upload_path = var.vmware_tools_mode == "upload" ? (
     var.vmware_tools_upload_path == null ? (
       var.is_windows ? "c:\\vmware-tools.iso" : "/tmp/vmware-tools.iso"
     ) : var.vmware_tools_upload_path
   ) : null
+  vmware_tools_source_path = var.vmware_tools_mode == "disable" ? null : (
+    vmware_tools_source_path == null ? null : var.vmaware_tools_source_path
+  )
   vmware_vmx_data = var.vmware_vmx_data == null ? (
-    local.host_os == "darwin" ? (
-      var.is_windows ? (
-        var.os_arch == "aarch64" ? {
-          "sata1.present"      = "TRUE"
-          "sata1:2.devicetype" = "cdrom-image"
-          "sata1:2.filename"   = "/Applications/VMware Fusion.app/Contents/Library/isoimages/arm64/windows.iso"
-          "sata1:2.present"    = "TRUE"
-          "svga.autodetect"    = "TRUE"
-          "usb_xhci.present"   = "TRUE"
-          } : {
-          "sata1.present"      = "TRUE"
-          "sata1:2.devicetype" = "cdrom-image"
-          "sata1:2.filename"   = "/Applications/VMware Fusion.app/Contents/Library/isoimages/x86_64/windows.iso"
-          "sata1:2.present"    = "TRUE"
-          "svga.autodetect"    = "TRUE"
-          "usb_xhci.present"   = "TRUE"
-        }
-        ) : {
-        "svga.autodetect"  = "TRUE"
-        "usb_xhci.present" = "TRUE"
-      }
-      ) : {
+    {
       "svga.autodetect"  = "TRUE"
       "usb_xhci.present" = "TRUE"
     }

--- a/packer_templates/pkr-variables.pkr.hcl
+++ b/packer_templates/pkr-variables.pkr.hcl
@@ -471,6 +471,10 @@ variable "vmware_tools_upload_flavor" {
   type    = string
   default = null
 }
+variable "vmware_tools_mode" {
+  type    = string
+  default = null
+}
 variable "vmware_tools_upload_path" {
   type    = string
   default = null

--- a/packer_templates/pkr-variables.pkr.hcl
+++ b/packer_templates/pkr-variables.pkr.hcl
@@ -478,13 +478,13 @@ variable "vmware_tools_source_path" {
   description = "Path to the VMware Tools ISO on the host. Can be used with 'attach' or 'upload' modes. When null and tools_mode is 'attach', auto-detects VMware installation path. Cannot be used with tools_upload_flavor"
 }
 variable "vmware_tools_upload_flavor" {
-  type    = string
-  default = null
+  type        = string
+  default     = null
   description = "The flavor of VMware Tools to upload (darwin, linux, windows). Only used when tools_mode is 'upload' and tools_source_path is null. Cannot be used with tools_source_path"
 }
 variable "vmware_tools_upload_path" {
-  type    = string
-  default = null
+  type        = string
+  default     = null
   description = "The path where VMware Tools will be uploaded in the guest. Only used when tools_mode is 'upload'"
 }
 variable "vmware_version" {

--- a/packer_templates/pkr-variables.pkr.hcl
+++ b/packer_templates/pkr-variables.pkr.hcl
@@ -467,17 +467,25 @@ variable "vmware_guest_os_type" {
   default     = null
   description = "OS type for virtualization optimization"
 }
+variable "vmware_tools_mode" {
+  type        = string
+  default     = "attach"
+  description = "How to handle VMware Tools. Options: 'attach' (default, best performance), 'upload', or 'disable'"
+}
+variable "vmware_tools_source_path" {
+  type        = string
+  default     = null
+  description = "Path to the VMware Tools ISO on the host. Can be used with 'attach' or 'upload' modes. When null and tools_mode is 'attach', auto-detects VMware installation path. Cannot be used with tools_upload_flavor"
+}
 variable "vmware_tools_upload_flavor" {
   type    = string
   default = null
-}
-variable "vmware_tools_mode" {
-  type    = string
-  default = null
+  description = "The flavor of VMware Tools to upload (darwin, linux, windows). Only used when tools_mode is 'upload' and tools_source_path is null. Cannot be used with tools_source_path"
 }
 variable "vmware_tools_upload_path" {
   type    = string
   default = null
+  description = "The path where VMware Tools will be uploaded in the guest. Only used when tools_mode is 'upload'"
 }
 variable "vmware_version" {
   type    = number

--- a/packer_templates/scripts/_common/guest_tools_vmware.sh
+++ b/packer_templates/scripts/_common/guest_tools_vmware.sh
@@ -17,26 +17,57 @@ vmware-iso|vmware-vmx)
     echo 'fuse_load="YES"' >>/boot/loader.conf
     echo 'ifconfig_vmx0="dhcp"' >>/etc/rc.conf
   elif [ "$OS_NAME" = "Darwin" ]; then
-    # Globbing here: VMware Fusion >= 8.5.4 includes a second
-    # 'darwinPre15.iso' for any OS X guests pre-10.11
-    TOOLS_PATH=$(find "/Users/vagrant/" -name '*darwin*.iso' -print)
-    if [ ! -e "$TOOLS_PATH" ]; then
-        echo "Couldn't locate uploaded tools iso at $TOOLS_PATH!"
+    INSTALLER_PKG=""
+    TMPMOUNT=""
+    TOOLS_ISO=""
+
+    # First, check for already-mounted VMware Tools volume (attach mode).
+    # VMware attaches the tools ISO as a CD-ROM which macOS auto-mounts under /Volumes/.
+    for vol_dir in /Volumes/*/; do
+      candidate="${vol_dir}Install VMware Tools.app/Contents/Resources/VMware Tools.pkg"
+      if [ -e "$candidate" ]; then
+        INSTALLER_PKG="$candidate"
+        break
+      fi
+    done
+
+    # If not found in mounted volumes, look for an uploaded ISO (upload mode).
+    # Check the default upload path (/tmp/vmware-tools.iso) first, then the legacy
+    # HOME_DIR location. VMware Fusion >= 8.5.4 may include 'darwinPre15.iso' for
+    # OS X guests pre-10.11, so glob for any *darwin*.iso as a fallback.
+    if [ -z "$INSTALLER_PKG" ]; then
+      if [ -f "/tmp/vmware-tools.iso" ]; then
+        TOOLS_ISO="/tmp/vmware-tools.iso"
+      else
+        TOOLS_ISO=$(find "$HOME_DIR" -name '*darwin*.iso' -print 2>/dev/null | head -1)
+      fi
+
+      if [ -z "$TOOLS_ISO" ] || [ ! -e "$TOOLS_ISO" ]; then
+        echo "Couldn't locate VMware Tools ISO in mounted volumes or at known upload paths!"
         exit 1
+      fi
+
+      TMPMOUNT=$(/usr/bin/mktemp -d /tmp/vmware-tools.XXXX)
+      hdiutil attach "$TOOLS_ISO" -mountpoint "$TMPMOUNT"
+      INSTALLER_PKG="$TMPMOUNT/Install VMware Tools.app/Contents/Resources/VMware Tools.pkg"
     fi
-    TMPMOUNT=$(/usr/bin/mktemp -d /tmp/vmware-tools.XXXX)
-    hdiutil attach "$TOOLS_PATH" -mountpoint "$TMPMOUNT"
-    INSTALLER_PKG="$TMPMOUNT/Install VMware Tools.app/Contents/Resources/VMware Tools.pkg"
+
     if [ ! -e "$INSTALLER_PKG" ]; then
-        echo "Couldn't locate VMware installer pkg at $INSTALLER_PKG!"
-        exit 1
+      echo "Couldn't locate VMware installer pkg at $INSTALLER_PKG!"
+      exit 1
     fi
+
     echo "Installing VMware tools.."
-    installer -pkg "$TMPMOUNT/Install VMware Tools.app/Contents/Resources/VMware Tools.pkg" -target /
-    # This usually fails
-    hdiutil detach "$TMPMOUNT" || echo "exit code $? is suppressed";
-    rm -rf "$TMPMOUNT"
-    rm -f "$TOOLS_PATH"
+    installer -pkg "$INSTALLER_PKG" -target /
+
+    # Clean up only if we mounted the ISO ourselves (upload mode).
+    if [ -n "$TMPMOUNT" ]; then
+      # This detach usually fails on macOS guests; suppress the error
+      hdiutil detach "$TMPMOUNT" || echo "exit code $? is suppressed"
+      rm -rf "$TMPMOUNT"
+      rm -f "$TOOLS_ISO"
+    fi
+
     # Point Linux shared folder root to that used by OS X guests,
     # useful for the Hashicorp vmware_fusion Vagrant provider plugin
     mkdir /mnt

--- a/packer_templates/scripts/windows/provision.ps1
+++ b/packer_templates/scripts/windows/provision.ps1
@@ -125,13 +125,33 @@ switch ($env:PACKER_BUILDER_TYPE) {
     {$_ -in "vmware-iso", "vmware-vmx"} {
         # Actions for VMware ISO builder
         $installed = $false
-        # Check if vmware-tools.iso exists and mount it
-        $iso_exists = Test-Path -LiteralPath "C:\vmware-tools.iso"
-        if ( $iso_exists ) {
-            Write-Host "Found C:\vmware-tools.iso, mounting it..."
-            Mount-DiskImage -ImagePath C:\vmware-tools.iso -PassThru | Get-Volume
-        }
+        $iso_mounted = $false
+
+        # First, scan for the VMware Tools volume on an attached CD-ROM (attach mode, the default).
+        # Searching by label handles multiple CD-ROMs (e.g. an autounattend disc) without ambiguity.
         $volList = Get-Volume | Where-Object {$_.FileSystemLabel -eq 'VMware Tools' -and $_.DriveLetter}
+
+        # If the volume wasn't found via label, fall back to mounting an uploaded ISO (upload mode).
+        # Check paths in priority order:
+        #   1. C:\vmware-tools.iso  — our template's explicit default (tools_upload_path)
+        #   2. C:\windows.iso       — Packer plugin default when tools_upload_flavor="windows"
+        #                             and tools_upload_path is not set (resolves to {{.Flavor}}.iso)
+        if (-not $volList) {
+            $iso_path = $null
+            if (Test-Path -LiteralPath "C:\vmware-tools.iso") {
+                $iso_path = "C:\vmware-tools.iso"
+            } elseif (Test-Path -LiteralPath "C:\windows.iso") {
+                $iso_path = "C:\windows.iso"
+            }
+            if ($iso_path) {
+                Write-Host "VMware Tools not on an attached CD-ROM; mounting uploaded ISO at $iso_path..."
+                Mount-DiskImage -ImagePath $iso_path -PassThru | Get-Volume
+                $iso_mounted = $true
+                # Refresh list after mounting
+                $volList = Get-Volume | Where-Object {$_.FileSystemLabel -eq 'VMware Tools' -and $_.DriveLetter}
+            }
+        }
+
         foreach( $vol in $volList ) {
             $letter = $vol.DriveLetter
             $exe = "${letter}:\setup.exe"
@@ -150,14 +170,17 @@ switch ($env:PACKER_BUILDER_TYPE) {
                 Write-Host "Guest Tools NOT FOUND at $exe"
             }
         }
-        if ( $iso_exists ) {
-            Dismount-DiskImage -ImagePath C:\vmware-tools.iso
-            Remove-Item C:\vmware-tools.iso
+
+        # Only dismount and remove if we mounted the ISO ourselves (upload mode)
+        if ($iso_mounted) {
+            Dismount-DiskImage -ImagePath $iso_path
+            Remove-Item $iso_path
         }
+
         if ( $installed ) {
             Write-Host "Done installing the guest tools."
         } else {
-            throw "Guest Tools not found. Skipping installation."
+            throw "Guest Tools not found."
         }
         break
     }


### PR DESCRIPTION
## Description

This change fixes `vmware-iso` validation when VMware tools upload settings are configured.

Bento already sets `tools_upload_flavor` and `tools_upload_path` for VMware builds, but does not set `tools_mode`. With current VMware builder validation, `tools_mode` must be explicitly specified whenever tools configuration is present.

Without this change, validation fails with the following error:

```text
Error: 1 error(s) occurred:

* 'tools_mode' must be explicitly specified when using any tools configuration

  on packer_templates\pkr-sources.pkr.hcl line 547:
  (source code not available)
```

This PR adds a `vmware_tools_mode` variable, derives a default value from the existing upload configuration, and passes `tools_mode` to the `vmware-iso` source.

The default behavior remains the same:
- use `upload` when a VMware tools upload flavor is configured
- use `disable` when no upload flavor is available
- allow explicit override through `vmware_tools_mode`

## Related Issue

No related issue.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
