### PR TITLE
feat(ubuntu): Add Ubuntu 26.04

### DIFF
--- a/.github/workflows/pkr-bld-hyperv-x64.yml
+++ b/.github/workflows/pkr-bld-hyperv-x64.yml
@@ -40,6 +40,7 @@ jobs:
           - ubuntu-24.04
           - ubuntu-25.04
           - ubuntu-25.10
+          - ubuntu-26.04
         provider:
           - hyperv-iso
     steps:

--- a/.github/workflows/pkr-bld-parallels-arm64.yml
+++ b/.github/workflows/pkr-bld-parallels-arm64.yml
@@ -37,6 +37,7 @@ jobs:
           - ubuntu-24.04
           - ubuntu-25.04
           - ubuntu-25.10
+          - ubuntu-26.04
         provider:
           - parallels-iso
     steps:

--- a/.github/workflows/pkr-bld-parallels-x64.yml
+++ b/.github/workflows/pkr-bld-parallels-x64.yml
@@ -40,6 +40,7 @@ jobs:
           - ubuntu-24.04
           - ubuntu-25.04
           - ubuntu-25.10
+          - ubuntu-26.04
         provider:
           - parallels-iso
     steps:

--- a/.github/workflows/pkr-bld-qemu-arm64.yml
+++ b/.github/workflows/pkr-bld-qemu-arm64.yml
@@ -37,6 +37,7 @@ jobs:
           - ubuntu-24.04
           - ubuntu-25.04
           - ubuntu-25.10
+          - ubuntu-26.04
         provider:
           - qemu
     steps:

--- a/.github/workflows/pkr-bld-qemu-x64.yml
+++ b/.github/workflows/pkr-bld-qemu-x64.yml
@@ -40,6 +40,7 @@ jobs:
           - ubuntu-24.04
           - ubuntu-25.04
           - ubuntu-25.10
+          - ubuntu-26.04
         provider:
           - qemu
     steps:

--- a/.github/workflows/pkr-bld-utm-arm64.yml
+++ b/.github/workflows/pkr-bld-utm-arm64.yml
@@ -36,6 +36,7 @@ jobs:
           - ubuntu-24.04
           - ubuntu-25.04
           - ubuntu-25.10
+          - ubuntu-26.04
         provider:
           - utm-iso
     steps:

--- a/.github/workflows/pkr-bld-utm-x64.yml
+++ b/.github/workflows/pkr-bld-utm-x64.yml
@@ -39,6 +39,7 @@ jobs:
           - ubuntu-24.04
           - ubuntu-25.04
           - ubuntu-25.10
+          - ubuntu-26.04
         provider:
           - utm-iso
     steps:

--- a/.github/workflows/pkr-bld-virtualbox-arm64.yml
+++ b/.github/workflows/pkr-bld-virtualbox-arm64.yml
@@ -37,6 +37,7 @@ jobs:
           - ubuntu-24.04
           - ubuntu-25.04
           - ubuntu-25.10
+          - ubuntu-26.04
         provider:
           - virtualbox-iso
     steps:

--- a/.github/workflows/pkr-bld-virtualbox-x64.yml
+++ b/.github/workflows/pkr-bld-virtualbox-x64.yml
@@ -40,6 +40,7 @@ jobs:
           - ubuntu-24.04
           - ubuntu-25.04
           - ubuntu-25.10
+          - ubuntu-26.04
         provider:
           - virtualbox-iso
     steps:

--- a/.github/workflows/pkr-bld-vmware-arm64.yml
+++ b/.github/workflows/pkr-bld-vmware-arm64.yml
@@ -37,6 +37,7 @@ jobs:
           - ubuntu-24.04
           - ubuntu-25.04
           - ubuntu-25.10
+          - ubuntu-26.04
         provider:
           - vmware-iso
     steps:

--- a/.github/workflows/pkr-bld-vmware-x64.yml
+++ b/.github/workflows/pkr-bld-vmware-x64.yml
@@ -40,6 +40,7 @@ jobs:
           - ubuntu-24.04
           - ubuntu-25.04
           - ubuntu-25.10
+          - ubuntu-26.04
         provider:
           - vmware-iso
     steps:

--- a/.github/workflows/test-pkr-bld-parallels.yml
+++ b/.github/workflows/test-pkr-bld-parallels.yml
@@ -37,6 +37,7 @@ jobs:
           - rockylinux-10
           - ubuntu-22.04
           - ubuntu-24.04
+          - ubuntu-26.04
         provider:
           - parallels-iso
     steps:
@@ -105,6 +106,7 @@ jobs:
           - ubuntu-20.04
           - ubuntu-22.04
           - ubuntu-24.04
+          - ubuntu-26.04
         provider:
           - parallels-iso
     steps:

--- a/builds.yml
+++ b/builds.yml
@@ -31,6 +31,7 @@ public:
   - ubuntu-24.04
   - ubuntu-25.04
   - ubuntu-25.10
+  - ubuntu-26.04
 
 # slug box name: text string from standard box name to match
 slugs:

--- a/os_pkrvars/ubuntu/ubuntu-26.04-aarch64.pkrvars.hcl
+++ b/os_pkrvars/ubuntu/ubuntu-26.04-aarch64.pkrvars.hcl
@@ -1,0 +1,10 @@
+os_name                 = "ubuntu"
+os_version              = "26.04"
+os_arch                 = "aarch64"
+iso_url                 = "https://cdimage.ubuntu.com/releases/resolute/release/ubuntu-26.04-live-server-arm64.iso"
+iso_checksum            = "file:https://cdimage.ubuntu.com/releases/resolute/release/SHA256SUMS"
+parallels_guest_os_type = "ubuntu"
+vbox_guest_os_type      = "Ubuntu_arm64"
+vmware_guest_os_type    = "ubuntu64Guest"
+utm_vm_icon             = "ubuntu"
+boot_command            = ["<wait>e<wait><down><down><down><end> autoinstall ds=nocloud-net\\;s=http://{{.HTTPIP}}:{{.HTTPPort}}/ubuntu/<wait><f10><wait>"]

--- a/os_pkrvars/ubuntu/ubuntu-26.04-x86_64.pkrvars.hcl
+++ b/os_pkrvars/ubuntu/ubuntu-26.04-x86_64.pkrvars.hcl
@@ -1,0 +1,10 @@
+os_name                 = "ubuntu"
+os_version              = "26.04"
+os_arch                 = "x86_64"
+iso_url                 = "https://releases.ubuntu.com/resolute/ubuntu-26.04-live-server-amd64.iso"
+iso_checksum            = "file:https://releases.ubuntu.com/resolute/SHA256SUMS"
+parallels_guest_os_type = "ubuntu"
+vbox_guest_os_type      = "Ubuntu_64"
+vmware_guest_os_type    = "ubuntu64Guest"
+utm_vm_icon             = "ubuntu"
+boot_command            = ["<wait>e<wait><down><down><down><end> autoinstall ds=nocloud-net\\;s=http://{{.HTTPIP}}:{{.HTTPPort}}/ubuntu/<wait><f10><wait>"]


### PR DESCRIPTION
## Description

This PR adds support for [Ubuntu 26.04 LTS (Resolute Raccoon)](https://documentation.ubuntu.com/release-notes/26.04/)

## Related Issue
Fix #1675 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
