### PR TITLE
win11 arm64: make autologon persistent

### DIFF
--- a/packer_templates/win_answer_files/11/arm64/Autounattend.xml
+++ b/packer_templates/win_answer_files/11/arm64/Autounattend.xml
@@ -191,7 +191,6 @@
 			<AutoLogon>
 				<Username>vagrant</Username>
 				<Enabled>true</Enabled>
-				<LogonCount>1</LogonCount>
 				<Password>
 					<Value>vagrant</Value>
 					<PlainText>true</PlainText>
@@ -480,9 +479,6 @@ $scripts = @(
 		</File>
 		<File path="C:\Windows\Setup\Scripts\FirstLogon.ps1">
 $scripts = @(
-	{
-		Set-ItemProperty -LiteralPath 'Registry::HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' -Name 'AutoLogonCount' -Type 'DWord' -Force -Value 0;
-	};
 	{
 		Disable-ComputerRestore -Drive 'C:\';
 	};


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

Make auto logon persistent on Windows 11 ARM64
Aligns with x86_64 setup
Works around the reboot-loop with windows update KB5007651 which can only be applied while the user is logged in 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
