### PR TITLE
fix: sudo not preseving passed in environment variables

### DIFF
--- a/packer_templates/pkr-builder.pkr.hcl
+++ b/packer_templates/pkr-builder.pkr.hcl
@@ -84,7 +84,7 @@ locals {
     ]
   )
   nix_execute_command = var.os_name == "freebsd" ? "echo 'vagrant' | {{.Vars}} su -m root -c 'sh -eux {{.Path}}'" : (
-    var.os_name == "solaris" ? "echo 'vagrant'|sudo -S bash {{.Path}}" : "echo 'vagrant' | {{ .Vars }} sudo -S -E sh -eux '{{ .Path }}'"
+    var.os_name == "solaris" ? "echo 'vagrant'|sudo -S bash {{.Path}}" : "echo 'vagrant' | sudo -S {{ .Vars }} sh -eux '{{ .Path }}'"
   )
   elevated_user     = "vagrant"
   elevated_password = "vagrant"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

This mainly effects Ubuntu 26.04, but could affect any distribution that decides to disable `-E` on sudo in a similar manner.

Passing the environment variables through after the sudo guarantees they will be preserved in any executed script.

## Description
Ubuntu 26.04 currently fails on several scripts that use the `PACKER_` environment variables, or any other environment variable passed in via the shell provision's environment variables option.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

See: https://github.com/chef/bento/pull/1689#issuecomment-5011481482

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
