### PR TITLE
change windows 11 x86_64 virtualbox boot wait and command

### DIFF
--- a/os_pkrvars/windows/windows-11-x86_64.pkrvars.hcl
+++ b/os_pkrvars/windows/windows-11-x86_64.pkrvars.hcl
@@ -10,5 +10,5 @@ vbox_guest_os_type      = "Windows11_64"
 vmware_guest_os_type    = "windows11-64"
 utm_vm_icon             = "windows-11"
 default_boot_wait       = "1s"
-vbox_boot_wait          = "10s"
+vbox_boot_command       = ["<ctrl><wait><ctrl><wait><ctrl><wait><ctrl><wait><ctrl><wait><ctrl><wait><ctrl><wait><ctrl><wait><ctrl><wait><ctrl><wait><ctrl>"]
 boot_command            = ["<up><wait><up>"]


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The Windows 11 VirtualBox boot wait is too long on my macBook 2020.
Replace the 10s wait with 10 times <ctrl><wait> to trigger boot as soon as possible within the 10s time frame.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
