### PR TITLE
feat(ubuntu): Allocate all LVM available space to root volume on Ubuntu boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ Markdown table generated at <https://www.tablesgenerator.com/markdown_tables#>
 
 ## [unreleased] (2026-06-04)
 
+- Allocate all LVM available space to root volume on Ubuntu boxes
+
 ## [5.1.0] (2026-06-04)
 
 - Removed Ubuntu 25.04

--- a/packer_templates/http/ubuntu/user-data
+++ b/packer_templates/http/ubuntu/user-data
@@ -5,6 +5,10 @@ autoinstall:
     hostname: vagrant
     username: vagrant
     password: '$6$rounds=4096$5CU3LEj/MQvbkfPb$LmKEF9pCfU8R.dA.GemgE/8GT6r9blge3grJvdsVTMFKyLEQwzEF3SGWqAzjawY/XHRpWj4fOiLBrRyxJhIRJ1'
+  storage:
+    layout:
+      name: lvm
+      sizing-policy: all
   early-commands:
     # otherwise packer tries to connect and exceed max attempts:
     - systemctl stop ssh.service


### PR DESCRIPTION
## Description

Configure Ubuntu autoinstall LVM layouts with sizing-policy: all so the root logical volume uses all available volume-group space. This prevents the default scaled policy from leaving roughly half of a 64 GiB disk unallocated on Ubuntu 22.04, 24.04 and 26.04 boxes.

## Related Issue

Fix #1693 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist

- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

## Additional checks

- YAML parsing passed
- cloud-init schema passed
- Packer validate passed for Ubuntu 22, 24 and 26