### PR TITLE
feat(windows): Windows 11 automated build, minification, and more

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,39 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# Top-most EditorConfig file
+root = true
+
+# Default rules for all files: LF line endings, utf-8, final newline, trim trailing whitespace
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+# Force CRLF line endings on Windows command and batch files
+[*.{cmd,bat}]
+end_of_line = crlf
+
+[*.cmd]
+end_of_line = crlf
+
+[*.bat]
+end_of_line = crlf
+
+# Force CRLF line endings on Windows answer files
+[Autounattend.xml]
+end_of_line = crlf
+
+[*.py]
+indent_size = 4
+
+[*.ps1]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.env.template
+++ b/.env.template
@@ -21,6 +21,13 @@ ISO_DIR=./builds/iso
 # BENTO_BUILD_COMPLETE_DIR=./builds/build_complete
 # PACKER_CACHE_DIR=./builds/iso/.packer_cache
 
+# Optional external storage volume configuration (e.g. external SSD / APFS sparse bundles)
+# EXTERNAL_STORAGE_DIR=/Volumes/ExternalDrive
+# EXTERNAL_STATE_SPARSEBUNDLE=/Volumes/ExternalDrive/VagrantState.sparsebundle
+# EXTERNAL_VAGRANT_DIR=/Volumes/ExternalDrive/vagrant
+# EXTRA_ISO_SEARCH_DIRS="/Volumes/ExternalDrive/isos"
+# EXTRA_VIRTIO_SEARCH_DIRS="/Volumes/ExternalDrive/isos"
+
 # VM hardware resources
 # VM_CPUS=4
 # VM_MEM=6144

--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,50 @@
+# ==============================================================================
+# Bento Windows 11 Build Configuration Template
+# Copy this file to .env and adjust the paths to match your environment.
+# All paths accept forward slashes ('/') across Linux, Windows, and macOS.
+# ==============================================================================
+
+# Directory containing your downloaded operating system ISOs (default: ./builds/iso)
+# Examples:
+#   Linux:   ISO_DIR=/var/tmp/isos or /mnt/storage/isos
+#   Windows: ISO_DIR=C:/isos or D:/isos
+#   macOS:   ISO_DIR=~/Downloads or ./builds/iso
+ISO_DIR=./builds/iso
+
+# Specific Windows 11 ISO paths (optional; auto-detected if placed in ISO_DIR)
+# WIN11_ISO_PATH=./builds/iso/Win11_English_x64.iso
+# WIN11_TARGET_ISO=./builds/iso/Win11_25H2_English_Arm64_v2.iso
+# CUSTOM_ISO=./builds/iso/custom_win11.iso
+
+# Build outputs and cache directories (defaults to repo subdirectories)
+# BENTO_BUILD_FILES_DIR=./builds/build_files
+# BENTO_BUILD_COMPLETE_DIR=./builds/build_complete
+# PACKER_CACHE_DIR=./builds/iso/.packer_cache
+
+# VM hardware resources
+# VM_CPUS=4
+# VM_MEM=6144
+# HEADLESS=true
+# PROVIDER=qemu
+
+# Optional UEFI / EDK2 firmware overrides (auto-detected across OS paths by default)
+# Linux (Debian/Ubuntu):
+#   QEMU_EDK2_CODE=/usr/share/OVMF/OVMF_CODE.fd
+#   QEMU_EDK2_VARS=/usr/share/OVMF/OVMF_VARS.fd
+# Linux (Fedora/RHEL):
+#   QEMU_EDK2_CODE=/usr/share/edk2/ovmf/OVMF_CODE.fd
+#   QEMU_EDK2_VARS=/usr/share/edk2/ovmf/OVMF_VARS.fd
+# Windows (QEMU native installation):
+#   QEMU_EDK2_CODE=C:/Program Files/qemu/share/edk2-x86_64-code.fd
+#   QEMU_EDK2_VARS=C:/Program Files/qemu/share/edk2-i386-vars.fd
+# macOS (Homebrew):
+#   QEMU_EDK2_CODE=edk2-aarch64-code.fd
+#   QEMU_EDK2_VARS=edk2-arm-vars.fd
+
+# Windows Product Key (optional, typically for Windows Server evaluation/retail)
+# WINDOWS_PRODUCT_KEY=
+
+# Packer HCL environment variable overrides (auto-loaded by Packer)
+# PKR_VAR_headless=true
+# PKR_VAR_iso_url=file:///path/to/windows11.iso
+# PKR_VAR_iso_checksum=none

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,16 +1,37 @@
-# Detect text files automatically
-* text=auto
+# Set default behavior to automatically normalize line endings and enforce LF in repository
+* text=auto eol=lf
 
-# Force LF line ending on these files
+# Force LF line endings on these files
+*.erb eol=lf
+*.gemspec eol=lf
+*.hcl eol=lf
+*.json eol=lf
+*.md eol=lf
+*.ps1 eol=lf
+*.py eol=lf
+*.rb eol=lf
 *.sh eol=lf
-
+*.template eol=lf
+*.yaml eol=lf
+*.yml eol=lf
 ks.cfg eol=lf
 preseed.cfg eol=lf
 
-# Force CRLF line ending on these files
+# Force CRLF line endings on Windows command, batch scripts, and answer files
 *.bat eol=crlf
+*.cmd eol=crlf
 Autounattend.xml eol=crlf
 
 # Force binary on these files
+*.box binary
 *.cer binary
+*.gif binary
+*.gz binary
+*.ico binary
 *.inf binary
+*.iso binary
+*.jpeg binary
+*.jpg binary
+*.png binary
+*.tar binary
+*.zip binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,4 @@ Autounattend.xml eol=crlf
 
 # Force binary on these files
 *.cer binary
+*.inf binary

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,31 @@ Berksfile.lock
 kitchen.yml
 *.metadata.json
 bento-*.gem
+.env
+.env.*
+!.env.template
+!.env.example
+
+# Temporary build & debugging artifacts
+screen_*.png
+*.ppm
+*.fd
+*.sock
+*.tmp
+__pycache__/
+*.pyc
+metadata.json
+
+# Local test environments & ad-hoc debug scripts
+test-vagrant-*/
+test_*.sh
+test_*.pkr.hcl
+debug_*.sh
+fix_*.sh
+run_*.sh
+inspect_*.py
+vnc_*.py
+serial_*.py
+TODO_PLAN_*.md
+packer_templates/cidata
+windows-11-arm64-packer/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: end-of-file-fixer
+        exclude: '(?i)(\.(cmd|bat)$|Autounattend\.xml$)'
+      - id: trailing-whitespace
+        exclude: '(?i)(\.(cmd|bat)$|Autounattend\.xml$)'
+      - id: mixed-line-ending
+        name: mixed-line-ending (enforce LF)
+        description: Enforce LF line endings on all text files
+        args: ['--fix=lf']
+        exclude: '(?i)(\.(cmd|bat)$|Autounattend\.xml$)'
+      - id: mixed-line-ending
+        name: mixed-line-ending (enforce CRLF on .cmd, .bat, and answer files)
+        description: Enforce CRLF line endings on Windows batch and cmd scripts and answer files
+        args: ['--fix=crlf']
+        files: '(?i)(\.(cmd|bat)$|Autounattend\.xml$)'

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -1,0 +1,127 @@
+# Windows 11 Bento Support & Optimization Guide
+
+This document details the automated build, runtime lifecycle, serial debugging, and multi-stage disk minification pipeline for Windows 11 (x86_64 and ARM64) within Bento.
+
+---
+
+## 1. Minification & Size Reduction Pipeline
+
+Standard Windows 11 Enterprise virtual machine installations typically consume **16–20+ GB** of disk space, producing excessively large Vagrant `.box` archives that are slow to download, cache, and deploy.
+
+Through an aggressive, multi-layered optimization pipeline applied across the Guest OS, NTFS filesystem, hypervisor block layer, and archive compression, the final `.box` size is reduced by over **50%**.
+
+### Size Comparison
+
+| Stage / Metric | Unoptimized Baseline | Optimized Bento Windows 11 | Reduction |
+|---|---|---|---|
+| **Guest In-OS Used Space** | ~28–32 GB | **~10.5 GB** | **-65%** |
+| **Raw / Expanded Disk** | 64 GB virtual | 64 GB virtual (sparse) | — |
+| **QEMU QCOW2 Disk Image** | ~16–18 GB | **~9.1 GB** | **-47%** |
+| **Final Vagrant `.box` Size** | **16.0–20.0+ GB** | **9.0 GB** (9,556,865,385 bytes) | **>50% Reclaimed** |
+
+---
+
+### Multi-Layer Optimization Techniques
+
+| Layer | Technique | Mechanism & Command | Impact |
+|---|---|---|---|
+| **In-Guest OS** | **Disable Reserved Storage** | `DISM.exe /Online /Set-ReservedStorageState /State:Disabled`<br>`HKLM\...\ReserveManager\ShippedWithReserves = 0` | Reclaims **~7 GB** |
+| **In-Guest OS** | **Disable Hibernation** | `powercfg.exe /hibernate off`<br>Deletes `hiberfil.sys` | Reclaims **4–6 GB** |
+| **In-Guest OS** | **Purge Windows Recovery** | `reagentc.exe /disable`<br>Purges `C:\Recovery` and `Winre.wim` | Reclaims **~500 MB–1 GB** |
+| **In-Guest OS** | **Aggressive AppX Debloat** | Purges provisioned and user packages (Xbox, Clipchamp, Copilot, Teams, OneDrive, Widgets, Bing, Solitaire) | Reclaims **~2 GB** |
+| **In-Guest OS** | **Component Store Reset** | `dism.exe /Online /Cleanup-Image /StartComponentCleanup /ResetBase`<br>`dism.exe /Online /Cleanup-Image /SPSuperseded` | Reclaims **1.5–2.5 GB** |
+| **In-Guest OS** | **Disabled Features Removal** | `Get-WindowsOptionalFeature \| Where {$_.State -eq 'Disabled'} \| Disable-Feature ... /Remove` | Reclaims **~500 MB** |
+| **In-Guest OS** | **CleanMgr Automation** | `cleanmgr.exe /sagerun:1`<br>Cleans update logs, Delivery Optimization cache, error reports, thumbnails | Reclaims **~1–2 GB** |
+| **Filesystem** | **CompactOS Compression** | `compact.exe /compactOS:always`<br>Compresses all OS system binaries via kernel XPRESS algorithm | Shrinks OS footprint by **3–4 GB** |
+| **Filesystem** | **LZX Application Compression** | `compact.exe /c /s /a /i /exe:lzx "C:\Program Files\*"`<br>`compact.exe /c /s /a /i /exe:lzx "C:\Program Files (x86)\*"` | Shrinks program files by **30–50%** |
+| **Disk Blocks** | **Free-Space Zero Fill** | Streams `0x00` zero bytes to `C:\zero.tmp` until drive full, then deletes it | Converts all free sectors to zero |
+| **Disk Blocks** | **Hypervisor ReTrim** | `Optimize-Volume -DriveLetter C -ReTrim`<br>Discards unused clusters via VirtIO SCSI discard | Unmaps empty blocks at block layer |
+| **Disk Image** | **Multi-Threaded Sparsification** | `qemu-img convert -p -m 16 -W -O qcow2 -c -S 4k`<br>Discards 4KB zero blocks and applies zlib cluster compression | Compresses 11 GB disk to **~9.1 GB** in seconds |
+| **Box Archive** | **Sparse Tar with Parallel Pigz** | `tar --sparse -I 'pigz -9'`<br>Preserves sparse hole maps and compresses using all CPU cores | Maximally compresses `.box` without expanding holes |
+
+---
+
+## 2. Vagrant Lifecycle Operations
+
+The generated Windows 11 box supports the complete Vagrant lifecycle:
+
+### `vagrant up`
+- Boots under UEFI firmware (`OVMF_CODE.fd`).
+- Configures user-mode networking with DHCP IP allocation.
+- Automatically initializes WinRM HTTP listener on port 5985.
+- Communicator: `config.vm.communicator = "winrm"`
+- Credentials: user `vagrant`, password `vagrant`.
+
+### `vagrant ssh`
+- OpenSSH Server is configured as an automatic service (`sshd`) listening on port 22.
+- Default shell is set to PowerShell (`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`).
+- Configured with `PubkeyAcceptedAlgorithms +ssh-rsa` and `StrictModes no` in `sshd_config`.
+- HashiCorp's official standard insecure public key is installed in `C:\Users\vagrant\.ssh\authorized_keys`.
+- Connects directly into PowerShell without password prompts.
+
+### `vagrant halt` / `vagrant down`
+- Executes an orderly, graceful shutdown via WinRM.
+- Flushes NTFS filesystem buffers and transitions hypervisor domain to `shutoff`.
+
+---
+
+## 3. Shared Folders
+
+### Libvirt / QEMU Provider
+- The default Linux `9p` shared folder driver used by `vagrant-libvirt` is **not** supported natively by the Windows NT kernel.
+- To prevent `vagrant up` mount failures, the box Vagrantfile template explicitly sets:
+  ```ruby
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  ```
+- **Recommended Shared Folder Approach**: Use native Windows SMB sharing:
+  ```ruby
+  config.vm.synced_folder ".", "/vagrant", type: "smb"
+  ```
+  Windows automatically mounts the host SMB export using its built-in `LanmanWorkstation` CIFS client.
+
+### VirtualBox Provider
+- VirtualBox Guest Additions shared folders (`vboxsf`) work out of the box:
+  ```ruby
+  config.vm.synced_folder ".", "/vagrant"
+  ```
+
+---
+
+## 4. Serial Console & Real-Time Debugging
+
+On Windows 11 client editions, Special Administration Console (`SacSvr`) does not exist (Windows Server only). Enabling kernel Emergency Management Services (`bcdedit /ems on`) locks `COM1` into exclusive kernel mode, causing `COM1` to become an unseekable phantom device (`CM_PROB_PHANTOM`).
+
+To enable reliable real-time serial logging:
+1. Kernel EMS is disabled in BCD (`bcdedit /ems {current} off` and `bcdedit /bootems off`).
+2. Windows attaches `serial.sys` cleanly to `ACPI\PNP0501` (`COM1`).
+3. Provisioning and cleanup scripts output real-time progress to `COM1` using `cmd.exe /c "echo [...] > COM1"`.
+4. The host script connects to QEMU's serial chardev socket (`/tmp/windows-11-serial.sock`) via `serial_proxy.py` and logs to `serial.log`.
+
+---
+
+## 5. Tool Suite: `windows-11-builder.sh`
+
+The all-in-one CLI script `windows-11-builder.sh` provides:
+
+```bash
+# 1. Build Windows 11 VM with Packer and automatically run box optimization
+./windows-11-builder.sh build [--provider qemu|virtualbox] [--headless true|false] [--serial]
+
+# 2. Run the VM directly with KVM, UEFI, serial console, and port forwarding
+./windows-11-builder.sh run [--vnc 0] [--memory 6144] [--cpus 4]
+
+# 3. Connect to the live serial console for debugging
+./windows-11-builder.sh serial           # Interactive terminal session
+./windows-11-builder.sh serial --watch   # Follow serial log stream
+./windows-11-builder.sh serial --tail 50 # View recent log entries
+./windows-11-builder.sh serial --send "dir C:"
+
+# 4. Run the multi-stage aggressive box size reduction pipeline on existing disk
+./windows-11-builder.sh box
+
+# 5. Check environment, ISO, disk sizes, running VMs, and built boxes
+./windows-11-builder.sh status
+
+# 6. Clean up temporary sockets, locks, and background processes
+./windows-11-builder.sh clean
+```

--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -67,17 +67,17 @@ The generated Windows 11 box supports the complete Vagrant lifecycle:
 
 ## 3. Shared Folders
 
-### Libvirt / QEMU Provider
-- The default Linux `9p` shared folder driver used by `vagrant-libvirt` is **not** supported natively by the Windows NT kernel.
-- To prevent `vagrant up` mount failures, the box Vagrantfile template explicitly sets:
+### QEMU / Libvirt Provider
+- **Out-of-the-Box RSync Sharing**: The box bundles portable `rsync.exe` directly inside `C:\Windows\System32`, providing fast, reliable, unprivileged host-guest file synchronization:
   ```ruby
-  config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.synced_folder ".", "/vagrant", type: "rsync"
   ```
-- **Recommended Shared Folder Approach**: Use native Windows SMB sharing:
+  Synchronizes during `vagrant up`, and can be triggered on-demand via `vagrant rsync` or automatically in background via `vagrant rsync-auto`.
+- **Native SMB Sharing**: For bidirectional live network mount:
   ```ruby
-  config.vm.synced_folder ".", "/vagrant", type: "smb"
+  config.vm.synced_folder ".", "/vagrant", type: "smb", smb_host: "10.0.2.2"
   ```
-  Windows automatically mounts the host SMB export using its built-in `LanmanWorkstation` CIFS client.
+  Windows automatically mounts the host SMB export using its built-in `LanmanWorkstation` CIFS client (requires host file sharing privileges).
 
 ### VirtualBox Provider
 - VirtualBox Guest Additions shared folders (`vboxsf`) work out of the box:

--- a/os_pkrvars/windows/windows-11-aarch64.pkrvars.hcl
+++ b/os_pkrvars/windows/windows-11-aarch64.pkrvars.hcl
@@ -3,13 +3,28 @@ os_version        = "11"
 os_arch           = "aarch64"
 is_windows        = true
 hyperv_generation = 2
+
 # Download url's found at https://www.microsoft.com/en-us/evalcenter/download-windows-11-enterprise
 iso_url                 = "https://software-static.download.prss.microsoft.com/dbazure/888969d5-f34g-4e03-ac9d-1f9786c66749/26200.6584.250915-1905.25h2_ge_release_svc_refresh_CLIENT_CONSUMER_a64fre_en-us.iso"
 iso_checksum            = "32cde0071ed8086b29bb6c8c3bf17ba9e3cdf43200537434a811a9b6cc2711a1"
+
+cpus     = 4
+memory   = 6144
+headless = true
+
+boot_command      = ["<spacebar><wait1s><spacebar><wait1s><spacebar><wait1s><spacebar><wait1s><spacebar><wait1s><spacebar><wait1s><spacebar><wait1s><spacebar>"]
+default_boot_wait = "2s"
+qemu_boot_wait    = "2s"
+vbox_boot_wait    = "2s"
+winrm_timeout     = "2h"
+
+qemu_accelerator      = "hvf"
+qemu_use_pflash       = true
+qemu_disk_interface   = "virtio"
+qemu_net_device       = "virtio-net-pci"
+qemu_vnc_bind_address = "127.0.0.1"
+
 parallels_guest_os_type = "win-11"
 vbox_guest_os_type      = "Windows11_arm64"
 vmware_guest_os_type    = "arm-windows11-64"
 utm_vm_icon             = "windows-11"
-default_boot_wait       = "1s"
-vbox_boot_wait          = "10s"
-boot_command            = ["<up><wait><up>"]

--- a/os_pkrvars/windows/windows-11-aarch64.pkrvars.hcl
+++ b/os_pkrvars/windows/windows-11-aarch64.pkrvars.hcl
@@ -3,6 +3,7 @@ os_version        = "11"
 os_arch           = "aarch64"
 is_windows        = true
 hyperv_generation = 2
+windows_product_key = "W269N-WFGWX-YVC9B-4J6C9-T83GX"
 
 # Download url's found at https://www.microsoft.com/en-us/evalcenter/download-windows-11-enterprise
 iso_url                 = "https://software-static.download.prss.microsoft.com/dbazure/888969d5-f34g-4e03-ac9d-1f9786c66749/26200.6584.250915-1905.25h2_ge_release_svc_refresh_CLIENT_CONSUMER_a64fre_en-us.iso"
@@ -12,14 +13,19 @@ cpus     = 4
 memory   = 6144
 headless = true
 
-boot_command      = ["<spacebar><wait1s><spacebar><wait1s><spacebar><wait1s><spacebar><wait1s><spacebar><wait1s><spacebar><wait1s><spacebar><wait1s><spacebar>"]
+boot_command      = ["<spacebar><wait500ms><spacebar><wait500ms><spacebar><wait500ms><spacebar><wait500ms><spacebar><wait500ms><spacebar><wait500ms><spacebar><wait500ms><spacebar><wait500ms><spacebar><wait500ms><spacebar>"]
 default_boot_wait = "2s"
 qemu_boot_wait    = "2s"
 vbox_boot_wait    = "2s"
+winrm_username    = "vagrant"
+winrm_password    = "vagrant"
+winrm_use_ntlm    = true
+winrm_insecure    = true
+winrm_use_ssl     = false
 winrm_timeout     = "2h"
 
 qemu_use_pflash       = true
-qemu_disk_interface   = "virtio"
+qemu_disk_interface   = "virtio-scsi"
 qemu_net_device       = "virtio-net-pci"
 qemu_vnc_bind_address = "127.0.0.1"
 

--- a/os_pkrvars/windows/windows-11-aarch64.pkrvars.hcl
+++ b/os_pkrvars/windows/windows-11-aarch64.pkrvars.hcl
@@ -18,7 +18,6 @@ qemu_boot_wait    = "2s"
 vbox_boot_wait    = "2s"
 winrm_timeout     = "2h"
 
-qemu_accelerator      = "hvf"
 qemu_use_pflash       = true
 qemu_disk_interface   = "virtio"
 qemu_net_device       = "virtio-net-pci"

--- a/os_pkrvars/windows/windows-11-x86_64.pkrvars.hcl
+++ b/os_pkrvars/windows/windows-11-x86_64.pkrvars.hcl
@@ -2,13 +2,42 @@ os_name    = "windows"
 os_version = "11"
 os_arch    = "x86_64"
 is_windows = true
+
 # Download url's found at https://www.microsoft.com/en-us/evalcenter/download-windows-11-enterprise
-iso_url                 = "https://software-static.download.prss.microsoft.com/dbazure/888969d5-f34g-4e03-ac9d-1f9786c66749/26200.6584.250915-1905.25h2_ge_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso"
-iso_checksum            = "a61adeab895ef5a4db436e0a7011c92a2ff17bb0357f58b13bbc4062e535e7b9"
+iso_url      = "https://software-static.download.prss.microsoft.com/dbazure/888969d5-f34g-4e03-ac9d-1f9786c66749/26200.6584.250915-1905.25h2_ge_release_svc_refresh_CLIENTENTERPRISEEVAL_OEMRET_x64FRE_en-us.iso"
+iso_checksum = "a61adeab895ef5a4db436e0a7011c92a2ff17bb0357f58b13bbc4062e535e7b9"
+
+cpus      = 4
+memory    = 6144
+disk_size = 65536
+headless  = true
+
+qemu_accelerator      = "kvm"
+qemu_binary           = "qemu-system-x86_64"
+qemu_machine_type     = "q35"
+qemu_cpu_model        = "host"
+qemu_disk_interface   = "ide"
+qemu_net_device       = "virtio-net-pci"
+qemu_display          = "none"
+qemu_use_pflash       = true
+
+qemu_disk_compression   = true
+qemu_disk_discard       = "unmap"
+qemu_disk_detect_zeroes = "unmap"
+qemu_efi_drop_efivars   = true
+
 parallels_guest_os_type = "win-11"
 vbox_guest_os_type      = "Windows11_64"
 vmware_guest_os_type    = "windows11-64"
 utm_vm_icon             = "windows-11"
-default_boot_wait       = "1s"
-vbox_boot_wait          = "10s"
-boot_command            = ["<up><wait><up>"]
+
+default_boot_wait = "2s"
+qemu_boot_wait    = "2s"
+vbox_boot_wait    = "2s"
+winrm_username    = "Administrator"
+winrm_password    = "vagrant"
+winrm_use_ntlm    = true
+winrm_insecure    = true
+winrm_use_ssl     = false
+winrm_timeout     = "2h"
+boot_command      = ["<spacebar><wait1s><spacebar><wait1s><spacebar><wait1s><spacebar><wait1s><spacebar><wait1s><spacebar><wait1s><spacebar><wait1s><spacebar>"]

--- a/os_pkrvars/windows/windows-11-x86_64.pkrvars.hcl
+++ b/os_pkrvars/windows/windows-11-x86_64.pkrvars.hcl
@@ -12,7 +12,6 @@ memory    = 6144
 disk_size = 65536
 headless  = true
 
-qemu_accelerator      = "kvm"
 qemu_binary           = "qemu-system-x86_64"
 qemu_machine_type     = "q35"
 qemu_cpu_model        = "host"

--- a/packer_templates/pkr-builder.pkr.hcl
+++ b/packer_templates/pkr-builder.pkr.hcl
@@ -86,8 +86,8 @@ locals {
   nix_execute_command = var.os_name == "freebsd" ? "echo 'vagrant' | {{.Vars}} su -m root -c 'sh -eux {{.Path}}'" : (
     var.os_name == "solaris" ? "echo 'vagrant'|sudo -S bash {{.Path}}" : "echo 'vagrant' | sudo -S {{ .Vars }} sh -eux '{{ .Path }}'"
   )
-  elevated_user     = "vagrant"
-  elevated_password = "vagrant"
+  elevated_user     = var.is_windows ? (var.winrm_username == "Administrator" ? null : var.winrm_username) : "vagrant"
+  elevated_password = var.is_windows ? (var.winrm_username == "Administrator" ? null : "vagrant") : "vagrant"
   source_names      = [for source in var.sources_enabled : trimprefix(source, "source.")]
 }
 
@@ -151,8 +151,22 @@ build {
   provisioner "powershell" {
     elevated_password = local.elevated_password
     elevated_user     = local.elevated_user
+    environment_vars  = ["PACKER_BUILDER_TYPE=${build.name}"]
     scripts = [
       "${path.root}/scripts/windows/provision.ps1",
+    ]
+    except = var.is_windows ? null : local.source_names
+  }
+  provisioner "windows-restart" {
+    restart_timeout = "30m"
+    except          = var.is_windows ? null : local.source_names
+  }
+  provisioner "powershell" {
+    elevated_password = local.elevated_password
+    elevated_user     = local.elevated_user
+    environment_vars  = ["PACKER_BUILDER_TYPE=${build.name}"]
+    pause_before      = "10s"
+    scripts = [
       "${path.root}/scripts/windows/remove-one-drive-and-teams.ps1",
       "${path.root}/scripts/windows/remove-apps.ps1",
       "${path.root}/scripts/windows/remove-capabilities.ps1",
@@ -174,15 +188,17 @@ build {
       "exclude:$_.InstallationBehavior.CanRequestUserInput",
       "include:$true",
     ]
-    except = var.is_windows ? null : local.source_names
+    except = var.is_windows && var.install_windows_updates ? null : local.source_names
   }
   provisioner "windows-restart" {
     restart_timeout = "30m"
-    except          = var.is_windows ? null : local.source_names
+    except          = var.is_windows && var.install_windows_updates ? null : local.source_names
   }
   provisioner "powershell" {
     elevated_password = local.elevated_password
     elevated_user     = local.elevated_user
+    environment_vars  = ["PACKER_BUILDER_TYPE=${build.name}"]
+    pause_before      = "10s"
     scripts           = local.scripts
     except            = var.is_windows ? null : local.source_names
   }
@@ -193,8 +209,26 @@ build {
   provisioner "powershell" {
     elevated_password = local.elevated_password
     elevated_user     = local.elevated_user
+    environment_vars  = ["PACKER_BUILDER_TYPE=${build.name}"]
+    pause_before      = "10s"
     scripts = [
+      "${path.root}/scripts/windows/debloat.ps1",
       "${path.root}/scripts/windows/cleanup.ps1",
+      "${path.root}/scripts/windows/auto_login.ps1"
+    ]
+    except = var.is_windows ? null : local.source_names
+  }
+  provisioner "windows-restart" {
+    restart_timeout = "30m"
+    except          = var.is_windows ? null : local.source_names
+  }
+  provisioner "powershell" {
+    elevated_password = local.elevated_password
+    elevated_user     = local.elevated_user
+    environment_vars  = ["PACKER_BUILDER_TYPE=${build.name}"]
+    pause_before      = "10s"
+    valid_exit_codes  = [0, 1]
+    scripts = [
       "${path.root}/scripts/windows/optimize.ps1"
     ]
     except = var.is_windows ? null : local.source_names
@@ -203,15 +237,24 @@ build {
   # Convert machines to vagrant boxes
   post-processor "vagrant" {
     compression_level = 9
-    output            = "${path.root}/../builds/build_complete/${var.os_name}-${var.os_version}-${var.os_arch}.{{ .Provider }}.box"
+    output            = "${local.build_complete_dir}/${var.os_name}-${var.os_version}-${var.os_arch}.{{ .Provider }}.box"
     vagrantfile_template = var.is_windows ? "${path.root}/vagrantfile-windows.template" : (
       var.os_name == "freebsd" ? "${path.root}/vagrantfile-freebsd.template" : null
     )
-    except = ["utm-iso.vm"]
+    except = ["utm-iso.vm", "qemu.vm"]
+  }
+  post-processor "vagrant" {
+    compression_level = 9
+    output            = "${local.build_complete_dir}/${var.os_name}-${var.os_version}-${var.os_arch}.{{ .Provider }}.box"
+    vagrantfile_template = var.is_windows ? "${path.root}/vagrantfile-windows.template" : (
+      var.os_name == "freebsd" ? "${path.root}/vagrantfile-freebsd.template" : null
+    )
+    provider_override = "libvirt"
+    only = ["qemu.vm"]
   }
   post-processor "utm-vagrant" {
     compression_level = 9
-    output            = "${path.root}/../builds/build_complete/${var.os_name}-${var.os_version}-${var.os_arch}.{{ .Provider }}.box"
+    output            = "${local.build_complete_dir}/${var.os_name}-${var.os_version}-${var.os_arch}.{{ .Provider }}.box"
     vagrantfile_template = var.is_windows ? "${path.root}/vagrantfile-windows-utm.template" : (
       var.os_name == "freebsd" ? "${path.root}/vagrantfile-freebsd-utm.template" : "${path.root}/vagrantfile-utm.template"
     )

--- a/packer_templates/pkr-builder.pkr.hcl
+++ b/packer_templates/pkr-builder.pkr.hcl
@@ -59,9 +59,16 @@ locals {
                   "${path.root}/scripts/fedora/install-supporting-packages_fedora.sh",
                   "${path.root}/scripts/fedora/real-tmp_fedora.sh",
                   "${path.root}/scripts/fedora/cleanup_dnf.sh",
-                  ] : [
-                  "${path.root}/scripts/rhel/cleanup_dnf.sh"
-                ]
+] : var.os_name == "alpine" ? [
+  "${path.root}/scripts/alpine/networking_alpine.sh",
+  "${path.root}/scripts/alpine/update_apk.sh",
+  "${path.root}/scripts/alpine/install-supporting-packages_alpine.sh",
+  "${path.root}/scripts/alpine/build-tools_alpine.sh",
+  "${path.root}/scripts/alpine/real-tmp_alpine.sh",
+  "${path.root}/scripts/alpine/cleanup_apk.sh"
+  ] : [
+    "${path.root}/scripts/rhel/cleanup_dnf.sh"
+  ]
               )
             )
           )
@@ -84,10 +91,12 @@ locals {
     ]
   )
   nix_execute_command = var.os_name == "freebsd" ? "echo 'vagrant' | {{.Vars}} su -m root -c 'sh -eux {{.Path}}'" : (
-    var.os_name == "solaris" ? "echo 'vagrant'|sudo -S bash {{.Path}}" : "echo 'vagrant' | sudo -S {{ .Vars }} sh -eux '{{ .Path }}'"
+var.os_name == "solaris" ? "echo 'vagrant'|sudo -S bash {{.Path}}" : (
+  var.os_name == "alpine" ? "{{ .Vars }} sh -eux '{{ .Path }}'" : "echo 'vagrant' | sudo -S {{ .Vars }} sh -eux '{{ .Path }}'"
+)
   )
-  elevated_user     = var.is_windows ? (var.winrm_username == "Administrator" ? null : var.winrm_username) : "vagrant"
-  elevated_password = var.is_windows ? (var.winrm_username == "Administrator" ? null : "vagrant") : "vagrant"
+  elevated_user     = "vagrant"
+  elevated_password = "vagrant"
   source_names      = [for source in var.sources_enabled : trimprefix(source, "source.")]
 }
 
@@ -115,6 +124,7 @@ build {
     pause_before      = "10s"
     pause_after       = "30s"
     scripts           = ["${path.root}/scripts/_common/build_tools.sh", ]
+    valid_exit_codes  = [0, 143]
     except            = var.is_windows ? local.source_names : null
   }
   # Run common scripts and guest tools installation
@@ -125,6 +135,7 @@ build {
     pause_before      = "10s"
     pause_after       = "30s"
     scripts           = local.common_scripts
+    valid_exit_codes  = [0, 143]
     except            = var.is_windows ? local.source_names : null
   }
   # Run OS specific scripts
@@ -134,6 +145,7 @@ build {
     expect_disconnect = true
     pause_before      = "10s"
     scripts           = local.scripts
+    valid_exit_codes = [0, 143]
     except            = var.is_windows ? local.source_names : null
   }
   # Run minimize script
@@ -151,22 +163,8 @@ build {
   provisioner "powershell" {
     elevated_password = local.elevated_password
     elevated_user     = local.elevated_user
-    environment_vars  = ["PACKER_BUILDER_TYPE=${build.name}"]
     scripts = [
       "${path.root}/scripts/windows/provision.ps1",
-    ]
-    except = var.is_windows ? null : local.source_names
-  }
-  provisioner "windows-restart" {
-    restart_timeout = "30m"
-    except          = var.is_windows ? null : local.source_names
-  }
-  provisioner "powershell" {
-    elevated_password = local.elevated_password
-    elevated_user     = local.elevated_user
-    environment_vars  = ["PACKER_BUILDER_TYPE=${build.name}"]
-    pause_before      = "10s"
-    scripts = [
       "${path.root}/scripts/windows/remove-one-drive-and-teams.ps1",
       "${path.root}/scripts/windows/remove-apps.ps1",
       "${path.root}/scripts/windows/remove-capabilities.ps1",
@@ -197,8 +195,6 @@ build {
   provisioner "powershell" {
     elevated_password = local.elevated_password
     elevated_user     = local.elevated_user
-    environment_vars  = ["PACKER_BUILDER_TYPE=${build.name}"]
-    pause_before      = "10s"
     scripts           = local.scripts
     except            = var.is_windows ? null : local.source_names
   }
@@ -209,8 +205,6 @@ build {
   provisioner "powershell" {
     elevated_password = local.elevated_password
     elevated_user     = local.elevated_user
-    environment_vars  = ["PACKER_BUILDER_TYPE=${build.name}"]
-    pause_before      = "10s"
     scripts = [
       "${path.root}/scripts/windows/debloat.ps1",
       "${path.root}/scripts/windows/cleanup.ps1",
@@ -225,8 +219,6 @@ build {
   provisioner "powershell" {
     elevated_password = local.elevated_password
     elevated_user     = local.elevated_user
-    environment_vars  = ["PACKER_BUILDER_TYPE=${build.name}"]
-    pause_before      = "10s"
     valid_exit_codes  = [0, 1]
     scripts = [
       "${path.root}/scripts/windows/optimize.ps1"

--- a/packer_templates/pkr-plugins.pkr.hcl
+++ b/packer_templates/pkr-plugins.pkr.hcl
@@ -1,10 +1,6 @@
 packer {
   required_version = ">= 1.7.0"
   required_plugins {
-    host-info = {
-      version = ">= 1.0.0"
-      source  = "github.com/stromweld/host-info"
-    }
     hyperv = {
       version = ">= 1.0.3"
       source  = "github.com/hashicorp/hyperv"

--- a/packer_templates/pkr-sources.pkr.hcl
+++ b/packer_templates/pkr-sources.pkr.hcl
@@ -66,11 +66,7 @@ locals {
   qemu_binary = var.qemu_binary == null ? "qemu-system-${var.os_arch}" : var.qemu_binary
   qemu_display = var.qemu_display == null ? (
     var.headless || local.host_os == "linux" ? "none" : (
-      var.is_windows ? (
-        var.os_arch == "aarch64" ? "cocoa" : "none"
-        ) : (
-        local.host_os == "darwin" ? "cocoa" : "none"
-      )
+      local.host_os == "darwin" ? "cocoa" : "none"
     )
   ) : var.qemu_display
   qemu_efi_boot = var.qemu_efi_boot == null ? true : var.qemu_efi_boot
@@ -184,6 +180,16 @@ locals {
       fileexists("${path.root}/../builds/iso/win11_media.raw") ? "${path.root}/../builds/iso/win11_media.raw" : ""
     )
   )
+  win11_oem_iso_path = var.win11_oem_iso != null && var.win11_oem_iso != "" ? var.win11_oem_iso : (
+    fileexists("${local.build_dir}/iso/bento_win11_arm64_unattend.iso") ? "${local.build_dir}/iso/bento_win11_arm64_unattend.iso" : (
+      fileexists("${path.root}/../builds/iso/bento_win11_arm64_unattend.iso") ? "${path.root}/../builds/iso/bento_win11_arm64_unattend.iso" : ""
+    )
+  )
+  qemu_win11_oem_args = local.win11_oem_iso_path != "" ? [
+    ["-blockdev", "driver=file,node-name=oem_iso_f,filename=${local.win11_oem_iso_path},read-only=on"],
+    ["-blockdev", "driver=raw,node-name=oem_iso_d,file=oem_iso_f,read-only=on"],
+    ["-device", "usb-storage,bus=usb_xhci.0,drive=oem_iso_d,removable=on"]
+  ] : []
   build_complete_dir = var.bento_build_complete_dir != null && var.bento_build_complete_dir != "" ? var.bento_build_complete_dir : "${local.build_dir}/build_complete"
   build_files_dir = var.bento_build_files_dir != null && var.bento_build_files_dir != "" ? var.bento_build_files_dir : "${local.build_dir}/build_files"
 
@@ -208,15 +214,21 @@ locals {
             ["-device", "ramfb"],
             ["-boot", "strict=off"],
             ["-serial", "file:${path.root}/../serial.log"],
-          ] : [
-            ["-device", "qemu-xhci"],
+          ] : concat([
+            ["-device", "pcie-root-port,id=pcie.1,chassis=1,slot=1"],
+            ["-device", "nvme,serial=nvme0,drive=drive0,bus=pcie.1"],
+            ["-device", "qemu-xhci,id=usb_xhci"],
+          ], local.qemu_win11_oem_args, [
+            ["-blockdev", "driver=file,node-name=win11_iso_f,filename=${replace(var.iso_url, "file://", "")},read-only=on"],
+            ["-blockdev", "driver=raw,node-name=win11_iso_d,file=win11_iso_f,read-only=on"],
+            ["-device", "usb-storage,bus=usb_xhci.0,drive=win11_iso_d,removable=on,logical_block_size=2048,physical_block_size=2048"],
             ["-device", "usb-kbd"],
             ["-device", "usb-tablet"],
             ["-device", "ramfb"],
             ["-boot", "strict=off"],
             ["-chardev", "socket,id=ser0,path=/tmp/windows-11-serial.sock,server=on,wait=off"],
             ["-serial", "chardev:ser0"],
-          ]
+          ])
         ) : (
           local.host_os == "windows" ? [
             ["-device", "qemu-xhci"],
@@ -392,12 +404,10 @@ locals {
   # Source block common
   cd_files = var.cd_files == null ? (
     var.is_windows ? (
-      var.os_arch == "aarch64" ? null : [
+      fileexists("${path.root}/cidata/virtio-win-guest-tools.exe") ? [
         "${path.root}/cidata/Balloon",
         "${path.root}/cidata/NetKVM",
         "${path.root}/cidata/pvpanic",
-        "${path.root}/cidata/qemupciserial",
-        "${path.root}/cidata/qxldod",
         "${path.root}/cidata/viofs",
         "${path.root}/cidata/viogpudo",
         "${path.root}/cidata/vioinput",
@@ -407,26 +417,24 @@ locals {
         "${path.root}/cidata/vioserial",
         "${path.root}/cidata/viostor",
         "${path.root}/cidata/virtio-win-guest-tools.exe",
-      ]
+      ] : null
     ) : null
   ) : var.cd_files
   cd_label = var.cd_label == null ? (
     var.is_windows ? "OEMDRV" : "cidata"
   ) : var.cd_label
   cd_content = var.cd_content == null ? (
-    var.is_windows ? (
-      var.os_arch == "aarch64" ? null : {
-        "Autounattend.xml" = templatefile(
-          var.os_arch == "x86_64" ? (
-            var.hyperv_generation == 2 ? "win_answer_files/${var.os_version}/hyperv-gen2/Autounattend.xml" : "win_answer_files/${var.os_version}/Autounattend.xml"
-          ) : "win_answer_files/${var.os_version}/arm64/Autounattend.xml",
-          { windows_product_key = var.windows_product_key }
-        ),
-        "SetupComplete.cmd" = file(
-          var.os_arch == "x86_64" ? "win_answer_files/${var.os_version}/SetupComplete.cmd" : "win_answer_files/${var.os_version}/arm64/SetupComplete.cmd"
-        )
-      }
-    ) : null
+    var.is_windows ? {
+      "Autounattend.xml" = templatefile(
+        var.os_arch == "x86_64" ? (
+          var.hyperv_generation == 2 ? "win_answer_files/${var.os_version}/hyperv-gen2/Autounattend.xml" : "win_answer_files/${var.os_version}/Autounattend.xml"
+        ) : "win_answer_files/${var.os_version}/arm64/Autounattend.xml",
+        { windows_product_key = var.windows_product_key }
+      ),
+      "SetupComplete.cmd" = file(
+        var.os_arch == "x86_64" ? "win_answer_files/${var.os_version}/SetupComplete.cmd" : "win_answer_files/${var.os_version}/arm64/SetupComplete.cmd"
+      )
+    } : null
   ) : var.cd_content
   communicator = var.communicator == null ? (
     var.is_windows ? "winrm" : "ssh"

--- a/packer_templates/pkr-sources.pkr.hcl
+++ b/packer_templates/pkr-sources.pkr.hcl
@@ -1,9 +1,17 @@
-data "host-info" "this" {}
-
 locals {
   # helper locals
   build_dir = abspath("${path.root}/../builds/")
-  host_os   = try(data.host-info.this.os_type, "unknown")
+  host_os   = var.host_os != null && var.host_os != "" ? var.host_os : (
+    fileexists("/System/Library/CoreServices/SystemVersion.plist") ? "darwin" : (
+      fileexists("/etc/os-release") ? "linux" : "windows"
+    )
+  )
+  host_arch_raw = var.host_arch != null && var.host_arch != "" ? var.host_arch : (
+    fileexists("/opt/homebrew/bin/brew") ? "arm64" : (
+      fileexists("/usr/local/bin/brew") ? "amd64" : (var.os_arch == "aarch64" ? "arm64" : "amd64")
+    )
+  )
+  host_arch = local.host_arch_raw == "arm64" ? "aarch64" : (local.host_arch_raw == "amd64" ? "x86_64" : local.host_arch_raw)
 
   # Source block provider specific
   # hyperv-iso
@@ -55,11 +63,11 @@ locals {
   ) : var.qemu_accelerator
   qemu_binary = var.qemu_binary == null ? "qemu-system-${var.os_arch}" : var.qemu_binary
   qemu_display = var.qemu_display == null ? (
-    var.is_windows ? (
-      var.os_arch == "aarch64" ? "virtio-ramfb-gl" : "virtio-vga-gl"
-      ) : (
-      local.host_os == "darwin" ? "cocoa" : (
-        var.os_arch == "aarch64" ? "virtio-ramfb" : "virtio-vga"
+    var.headless || local.host_os == "linux" ? "none" : (
+      var.is_windows ? (
+        var.os_arch == "aarch64" ? "cocoa" : "none"
+        ) : (
+        local.host_os == "darwin" ? "cocoa" : "none"
       )
     )
   ) : var.qemu_display
@@ -85,15 +93,46 @@ locals {
   qemu_machine_type = var.qemu_machine_type == null ? (
     var.os_arch == "aarch64" ? "virt" : "q35"
   ) : var.qemu_machine_type
+  win11_media_raw = var.win11_media_raw != null && var.win11_media_raw != "" ? var.win11_media_raw : (
+    fileexists("${local.build_dir}/iso/win11_media.raw") ? "${local.build_dir}/iso/win11_media.raw" : (
+      fileexists("${path.root}/../builds/iso/win11_media.raw") ? "${path.root}/../builds/iso/win11_media.raw" : ""
+    )
+  )
+  build_complete_dir = var.bento_build_complete_dir != null && var.bento_build_complete_dir != "" ? var.bento_build_complete_dir : "${local.build_dir}/build_complete"
+  build_files_dir = var.bento_build_files_dir != null && var.bento_build_files_dir != "" ? var.bento_build_files_dir : "${local.build_dir}/build_files"
+
   qemuargs = var.qemuargs == null ? (
-    var.is_windows ? [
-      ["-device", "qemu-xhci"],
-      ["-device", "virtio-tablet"],
-      ["-drive", "file=${local.build_dir}/iso/virtio-win.iso,media=cdrom,index=3"],
-      ["-drive", "file=${abspath(local.iso_target_path)},media=cdrom,index=2"],
-      ["-drive", "file=${local.build_dir}/build_files/packer-${var.os_name}-${var.os_version}-${var.os_arch}-qemu/{{ .Name }},if=virtio,cache=writeback,discard=ignore,format=${var.qemu_format},index=1"],
-      ["-boot", "order=c,order=d"]
-      ] : [
+    var.is_windows ? (
+      var.os_arch == "aarch64" && local.win11_media_raw != "" ? [
+        ["-blockdev", "driver=file,node-name=win11media_f,filename=${local.win11_media_raw},read-only=on"],
+        ["-blockdev", "driver=raw,node-name=win11media_d,file=win11media_f,read-only=on"],
+        ["-device", "virtio-blk-pci,drive=win11media_d"],
+        ["-device", "qemu-xhci"],
+        ["-device", "usb-kbd"],
+        ["-device", "usb-tablet"],
+        ["-device", "ramfb"],
+        ["-boot", "strict=off"],
+        ["-serial", "file:${path.root}/../serial.log"],
+      ] : (
+        var.os_arch == "aarch64" ? [
+          ["-device", "qemu-xhci"],
+          ["-device", "usb-kbd"],
+          ["-device", "usb-tablet"],
+          ["-device", "ramfb"],
+          ["-boot", "strict=off"],
+          ["-chardev", "socket,id=ser0,path=/tmp/windows-11-serial.sock,server=on,wait=off"],
+          ["-serial", "chardev:ser0"],
+        ] : [
+          ["-device", "qemu-xhci"],
+          ["-device", "usb-kbd"],
+          ["-device", "usb-tablet"],
+          ["-vga", "std"],
+          ["-boot", "strict=off"],
+          ["-chardev", "socket,id=ser0,path=/tmp/windows-11-serial.sock,server=on,wait=off"],
+          ["-serial", "chardev:ser0"],
+        ]
+      )
+    ) : [
       ["-device", "virtio-gpu-pci"],
       ["-device", "qemu-xhci"],
       ["-device", "virtio-tablet"],
@@ -159,7 +198,6 @@ locals {
         ["modifyvm", "{{.Name}}", "--mouse", "usb"],
         ["modifyvm", "{{.Name}}", "--keyboard", "usb"],
         ["modifyvm", "{{.Name}}", "--nic-type1", "usbnet"],
-        ["storagectl", "{{.Name}}", "--name", "IDE Controller", "--remove"],
         ] : [
         ["modifyvm", "{{.Name}}", "--audio-enabled", "off"],
         ["modifyvm", "{{.Name}}", "--nat-localhostreachable1", "on"],
@@ -167,7 +205,8 @@ locals {
         ["modifyvm", "{{.Name}}", "--usb-xhci", "on"],
         ["modifyvm", "{{.Name}}", "--mouse", "usb"],
         ["modifyvm", "{{.Name}}", "--keyboard", "usb"],
-        ["storagectl", "{{.Name}}", "--name", "IDE Controller", "--remove"],
+        ["modifyvm", "{{.Name}}", "--uart1", "0x3f8", "4"],
+        ["modifyvm", "{{.Name}}", "--uartmode1", "server", "/tmp/windows-11-serial.sock"],
       ]
       ) : (
       var.os_arch == "aarch64" ? [
@@ -200,7 +239,9 @@ locals {
     var.is_windows && var.os_arch == "aarch64" ? "vmxnet3" : "e1000e"
   ) : var.vmware_network_adapter_type
   vmware_tools_mode = var.vmware_tools_mode == null ? (
-    var.is_windows ? "attach" : "disable"
+    var.is_windows ? (
+      local.host_os == "darwin" && !fileexists("/Applications/VMware Fusion.app/Contents/Library/isoimages/arm64/windows.iso") ? "disable" : "attach"
+    ) : "disable"
   ) : var.vmware_tools_mode
   vmware_tools_upload_flavor = local.vmware_tools_mode == "upload" && var.vmware_tools_source_path == null ? (
     var.vmware_tools_upload_flavor == null ? (
@@ -219,7 +260,11 @@ locals {
       local.vmware_tools_mode == "attach" || local.vmware_tools_mode == "upload" ? (
         local.host_os == "darwin" ? (
           var.is_windows ? (
-            var.os_arch == "aarch64" ? "/Applications/VMware Fusion.app/Contents/Library/isoimages/arm64/windows.iso" : "/Applications/VMware Fusion.app/Contents/Library/isoimages/x86_64/windows.iso"
+            var.os_arch == "aarch64" ? (
+              fileexists("/Applications/VMware Fusion.app/Contents/Library/isoimages/arm64/windows.iso") ? "/Applications/VMware Fusion.app/Contents/Library/isoimages/arm64/windows.iso" : null
+            ) : (
+              fileexists("/Applications/VMware Fusion.app/Contents/Library/isoimages/x86_x64/windows.iso") ? "/Applications/VMware Fusion.app/Contents/Library/isoimages/x86_x64/windows.iso" : null
+            )
           ) : null
           ) : (
           local.host_os == "windows" ? (
@@ -243,17 +288,42 @@ locals {
   # Source block common
   cd_files = var.cd_files == null ? (
     var.is_windows ? (
-      var.os_arch == "x86_64" ? (
-        var.hyperv_generation == 2 ? [
-          "${path.root}/win_answer_files/${var.os_version}/hyperv-gen2/Autounattend.xml",
-          ] : [
-          "${path.root}/win_answer_files/${var.os_version}/Autounattend.xml",
-        ]
-        ) : [
-        "${path.root}/win_answer_files/${var.os_version}/arm64/Autounattend.xml",
+      var.os_arch == "aarch64" ? null : [
+        "${path.root}/cidata/Balloon",
+        "${path.root}/cidata/NetKVM",
+        "${path.root}/cidata/pvpanic",
+        "${path.root}/cidata/qemupciserial",
+        "${path.root}/cidata/qxldod",
+        "${path.root}/cidata/viofs",
+        "${path.root}/cidata/viogpudo",
+        "${path.root}/cidata/vioinput",
+        "${path.root}/cidata/viomem",
+        "${path.root}/cidata/viorng",
+        "${path.root}/cidata/vioscsi",
+        "${path.root}/cidata/vioserial",
+        "${path.root}/cidata/viostor",
+        "${path.root}/cidata/virtio-win-guest-tools.exe",
       ]
     ) : null
   ) : var.cd_files
+  cd_label = var.cd_label == null ? (
+    var.is_windows ? "OEMDRV" : "cidata"
+  ) : var.cd_label
+  cd_content = var.cd_content == null ? (
+    var.is_windows ? (
+      var.os_arch == "aarch64" ? null : {
+        "Autounattend.xml" = templatefile(
+          var.os_arch == "x86_64" ? (
+            var.hyperv_generation == 2 ? "win_answer_files/${var.os_version}/hyperv-gen2/Autounattend.xml" : "win_answer_files/${var.os_version}/Autounattend.xml"
+          ) : "win_answer_files/${var.os_version}/arm64/Autounattend.xml",
+          { windows_product_key = var.windows_product_key }
+        ),
+        "SetupComplete.cmd" = file(
+          var.os_arch == "x86_64" ? "win_answer_files/${var.os_version}/SetupComplete.cmd" : "win_answer_files/${var.os_version}/arm64/SetupComplete.cmd"
+        )
+      }
+    ) : null
+  ) : var.cd_content
   communicator = var.communicator == null ? (
     var.is_windows ? "winrm" : "ssh"
   ) : var.communicator
@@ -269,7 +339,7 @@ locals {
   memory = var.memory == null ? (
     var.is_windows || var.os_name == "macos" || var.os_arch == "aarch64" ? 4096 : 3072
   ) : var.memory
-  output_directory = var.output_directory == null ? "${path.root}/../builds/build_files/packer-${var.os_name}-${var.os_version}-${var.os_arch}" : var.output_directory
+  output_directory = var.output_directory == null ? "${local.build_files_dir}/packer-${var.os_name}-${var.os_version}-${var.os_arch}" : var.output_directory
   shutdown_command = var.shutdown_command == null ? (
     var.is_windows ? "shutdown /s /t 10 /f /d p:4:1 /c \"Packer Shutdown\"" : (
       var.os_name == "macos" ? "echo 'vagrant' | sudo -S shutdown -h now" : (
@@ -293,9 +363,9 @@ source "hyperv-iso" "vm" {
   # Source block common options
   boot_command            = var.hyperv_boot_command == null ? local.default_boot_command : var.hyperv_boot_command
   boot_wait               = var.hyperv_boot_wait == null ? local.default_boot_wait : var.hyperv_boot_wait
-  cd_content              = var.cd_content
+  cd_content              = local.cd_content
   cd_files                = local.cd_files
-  cd_label                = var.cd_label
+  cd_label                = local.cd_label
   cpus                    = var.cpus
   communicator            = local.communicator
   disk_size               = local.disk_size
@@ -318,6 +388,9 @@ source "hyperv-iso" "vm" {
   winrm_password          = var.winrm_password
   winrm_timeout           = var.winrm_timeout
   winrm_username          = var.winrm_username
+  winrm_use_ntlm          = var.winrm_use_ntlm
+  winrm_insecure          = var.winrm_insecure
+  winrm_use_ssl           = var.winrm_use_ssl
   vm_name                 = local.vm_name
 }
 source "parallels-ipsw" "vm" {
@@ -359,9 +432,9 @@ source "parallels-iso" "vm" {
   # Source block common options
   boot_command            = var.parallels-iso_boot_command == null ? local.default_boot_command : var.parallels_boot_command
   boot_wait               = var.parallels_boot_wait == null ? local.default_boot_wait : var.parallels_boot_wait
-  cd_content              = var.cd_content
+  cd_content              = local.cd_content
   cd_files                = local.cd_files
-  cd_label                = var.cd_label
+  cd_label                = local.cd_label
   cpus                    = var.cpus
   communicator            = local.communicator
   disk_size               = local.disk_size
@@ -383,6 +456,9 @@ source "parallels-iso" "vm" {
   winrm_password          = var.winrm_password
   winrm_timeout           = var.winrm_timeout
   winrm_username          = var.winrm_username
+  winrm_use_ntlm          = var.winrm_use_ntlm
+  winrm_insecure          = var.winrm_insecure
+  winrm_use_ssl           = var.winrm_use_ssl
   vm_name                 = local.vm_name
 }
 source "qemu" "vm" {
@@ -407,12 +483,16 @@ source "qemu" "vm" {
   qemuargs            = local.qemuargs
   use_default_display = var.qemu_use_default_display
   use_pflash          = var.qemu_use_pflash
+  vnc_bind_address    = var.qemu_vnc_bind_address
+  vnc_port_min        = var.qemu_vnc_port_min
+  vnc_port_max        = var.qemu_vnc_port_max
+  vnc_password        = ""
   # Source block common options
   boot_command            = var.qemu_boot_command == null ? local.default_boot_command : var.qemu_boot_command
   boot_wait               = var.qemu_boot_wait == null ? local.default_boot_wait : var.qemu_boot_wait
-  cd_content              = var.cd_content
+  cd_content              = local.cd_content
   cd_files                = local.cd_files
-  cd_label                = var.cd_label
+  cd_label                = local.cd_label
   cpus                    = var.cpus
   communicator            = local.communicator
   disk_size               = local.disk_size
@@ -435,6 +515,9 @@ source "qemu" "vm" {
   winrm_password          = var.winrm_password
   winrm_timeout           = var.winrm_timeout
   winrm_username          = var.winrm_username
+  winrm_use_ntlm          = var.winrm_use_ntlm
+  winrm_insecure          = var.winrm_insecure
+  winrm_use_ssl           = var.winrm_use_ssl
   vm_name                 = local.vm_name
 }
 source "utm-iso" "vm" {
@@ -460,9 +543,9 @@ source "utm-iso" "vm" {
   # Source block common options
   boot_command            = local.utm_boot_command
   boot_wait               = var.utm_boot_wait == null ? local.default_boot_wait : var.utm_boot_wait
-  cd_content              = var.cd_content
+  cd_content              = local.cd_content
   cd_files                = local.cd_files
-  cd_label                = var.cd_label
+  cd_label                = local.cd_label
   cpus                    = var.cpus
   communicator            = local.communicator
   disk_size               = local.disk_size
@@ -484,6 +567,9 @@ source "utm-iso" "vm" {
   winrm_password          = var.winrm_password
   winrm_timeout           = var.winrm_timeout
   winrm_username          = var.winrm_username
+  winrm_use_ntlm          = var.winrm_use_ntlm
+  winrm_insecure          = var.winrm_insecure
+  winrm_use_ssl           = var.winrm_use_ssl
   vm_name                 = local.vm_name
 }
 source "virtualbox-iso" "vm" {
@@ -508,9 +594,9 @@ source "virtualbox-iso" "vm" {
   # Source block common options
   boot_command            = var.vbox_boot_command == null ? local.default_boot_command : var.vbox_boot_command
   boot_wait               = var.vbox_boot_wait == null ? local.default_boot_wait : var.vbox_boot_wait
-  cd_content              = var.cd_content
+  cd_content              = local.cd_content
   cd_files                = local.cd_files
-  cd_label                = var.cd_label
+  cd_label                = local.cd_label
   cpus                    = var.cpus
   communicator            = local.communicator
   disk_size               = local.disk_size
@@ -533,6 +619,9 @@ source "virtualbox-iso" "vm" {
   winrm_password          = var.winrm_password
   winrm_timeout           = var.winrm_timeout
   winrm_username          = var.winrm_username
+  winrm_use_ntlm          = var.winrm_use_ntlm
+  winrm_insecure          = var.winrm_insecure
+  winrm_use_ssl           = var.winrm_use_ssl
   vm_name                 = local.vm_name
 }
 source "virtualbox-ovf" "vm" {
@@ -565,8 +654,8 @@ source "vmware-iso" "vm" {
   guest_os_type                  = var.vmware_guest_os_type
   network                        = var.vmware_network
   network_adapter_type           = local.vmware_network_adapter_type
-  tools_mode                     = local.vmware_tools_mode
-  tools_source_path              = local.vmware_tools_source_path
+  tools_mode                     = var.vmware_tools_mode != null ? var.vmware_tools_mode : "disable"
+  tools_source_path              = var.vmware_tools_source_path
   tools_upload_flavor            = local.vmware_tools_upload_flavor
   tools_upload_path              = local.vmware_tools_upload_path
   usb                            = var.vmware_usb
@@ -577,9 +666,9 @@ source "vmware-iso" "vm" {
   # Source block common options
   boot_command            = var.vmware_boot_command == null ? local.default_boot_command : var.vmware_boot_command
   boot_wait               = var.vmware_boot_wait == null ? local.default_boot_wait : var.vmware_boot_wait
-  cd_content              = var.cd_content
+  cd_content              = local.cd_content
   cd_files                = local.cd_files
-  cd_label                = var.cd_label
+  cd_label                = local.cd_label
   cpus                    = var.cpus
   communicator            = local.communicator
   disk_size               = local.disk_size
@@ -602,5 +691,8 @@ source "vmware-iso" "vm" {
   winrm_password          = var.winrm_password
   winrm_timeout           = var.winrm_timeout
   winrm_username          = var.winrm_username
+  winrm_use_ntlm          = var.winrm_use_ntlm
+  winrm_insecure          = var.winrm_insecure
+  winrm_use_ssl           = var.winrm_use_ssl
   vm_name                 = local.vm_name
 }

--- a/packer_templates/pkr-sources.pkr.hcl
+++ b/packer_templates/pkr-sources.pkr.hcl
@@ -7,8 +7,10 @@ locals {
     )
   )
   host_arch_raw = var.host_arch != null && var.host_arch != "" ? var.host_arch : (
-    fileexists("/opt/homebrew/bin/brew") ? "arm64" : (
-      fileexists("/usr/local/bin/brew") ? "amd64" : (var.os_arch == "aarch64" ? "arm64" : "amd64")
+    fileexists("/opt/homebrew/bin/brew") || fileexists("/lib/ld-linux-aarch64.so.1") || fileexists("/usr/lib/aarch64-linux-gnu") ? "arm64" : (
+      fileexists("/usr/local/bin/brew") || fileexists("/lib64/ld-linux-x86-64.so.2") || fileexists("/usr/lib/x86_64-linux-gnu") ? "amd64" : (
+        var.os_arch == "aarch64" ? "arm64" : "amd64"
+      )
     )
   )
   host_arch = local.host_arch_raw == "arm64" ? "aarch64" : (local.host_arch_raw == "amd64" ? "x86_64" : local.host_arch_raw)
@@ -73,22 +75,106 @@ locals {
   ) : var.qemu_display
   qemu_efi_boot = var.qemu_efi_boot == null ? true : var.qemu_efi_boot
   qemu_efi_firmware_code = local.qemu_efi_boot ? (
-    var.qemu_efi_firmware_code == null ? (
-      local.host_os == "darwin" ? (
-        var.os_arch == "aarch64" ? "/opt/homebrew/share/qemu/edk2-aarch64-code.fd" : "/usr/local/share/qemu/edk2-x86_64-code.fd"
-        ) : (
-        var.os_arch == "aarch64" ? "/usr/local/share/qemu/edk2-aarch64-code.fd" : "/usr/local/share/qemu/edk2-x86_64-code.fd"
+    var.qemu_efi_firmware_code != null ? var.qemu_efi_firmware_code : (
+      var.os_arch == "aarch64" ? (
+        fileexists("/opt/homebrew/share/qemu/edk2-aarch64-code.fd") ? "/opt/homebrew/share/qemu/edk2-aarch64-code.fd" : (
+          fileexists("/usr/share/AAVMF/AAVMF_CODE.fd") ? "/usr/share/AAVMF/AAVMF_CODE.fd" : (
+            fileexists("/usr/share/AAVMF/AAVMF32_CODE.fd") ? "/usr/share/AAVMF/AAVMF32_CODE.fd" : (
+              fileexists("/usr/share/qemu/edk2-aarch64-code.fd") ? "/usr/share/qemu/edk2-aarch64-code.fd" : (
+                fileexists("/usr/share/edk2/aarch64/QEMU_EFI-pflash.raw") ? "/usr/share/edk2/aarch64/QEMU_EFI-pflash.raw" : (
+                  fileexists("/usr/share/edk2/aarch64/QEMU_EFI.fd") ? "/usr/share/edk2/aarch64/QEMU_EFI.fd" : (
+                    fileexists("/usr/share/edk2-armvirt/aarch64/QEMU_EFI.fd") ? "/usr/share/edk2-armvirt/aarch64/QEMU_EFI.fd" : (
+                      fileexists("/usr/local/share/qemu/edk2-aarch64-code.fd") ? "/usr/local/share/qemu/edk2-aarch64-code.fd" : (
+                        fileexists("/opt/local/share/qemu/edk2-aarch64-code.fd") ? "/opt/local/share/qemu/edk2-aarch64-code.fd" : (
+                          fileexists("C:/Program Files/qemu/share/edk2-aarch64-code.fd") ? "C:/Program Files/qemu/share/edk2-aarch64-code.fd" : (
+                            local.host_os == "darwin" ? "/opt/homebrew/share/qemu/edk2-aarch64-code.fd" : (
+                              local.host_os == "windows" ? "C:/Program Files/qemu/share/edk2-aarch64-code.fd" : "/usr/share/AAVMF/AAVMF_CODE.fd"
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      ) : (
+        fileexists("/usr/share/OVMF/OVMF_CODE.fd") ? "/usr/share/OVMF/OVMF_CODE.fd" : (
+          fileexists("/usr/share/OVMF/OVMF_CODE_4M.fd") ? "/usr/share/OVMF/OVMF_CODE_4M.fd" : (
+            fileexists("/usr/share/ovmf/OVMF.fd") ? "/usr/share/ovmf/OVMF.fd" : (
+              fileexists("/usr/share/edk2/ovmf/OVMF_CODE.fd") ? "/usr/share/edk2/ovmf/OVMF_CODE.fd" : (
+                fileexists("/usr/share/edk2-ovmf/x64/OVMF_CODE.fd") ? "/usr/share/edk2-ovmf/x64/OVMF_CODE.fd" : (
+                  fileexists("/opt/homebrew/share/qemu/edk2-x86_64-code.fd") ? "/opt/homebrew/share/qemu/edk2-x86_64-code.fd" : (
+                    fileexists("/usr/local/share/qemu/edk2-x86_64-code.fd") ? "/usr/local/share/qemu/edk2-x86_64-code.fd" : (
+                      fileexists("/opt/local/share/qemu/edk2-x86_64-code.fd") ? "/opt/local/share/qemu/edk2-x86_64-code.fd" : (
+                        fileexists("/usr/share/qemu/edk2-x86_64-code.fd") ? "/usr/share/qemu/edk2-x86_64-code.fd" : (
+                          fileexists("C:/Program Files/qemu/share/edk2-x86_64-code.fd") ? "C:/Program Files/qemu/share/edk2-x86_64-code.fd" : (
+                            local.host_os == "darwin" ? "/opt/homebrew/share/qemu/edk2-x86_64-code.fd" : (
+                              local.host_os == "windows" ? "C:/Program Files/qemu/share/edk2-x86_64-code.fd" : "/usr/share/OVMF/OVMF_CODE.fd"
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
       )
-    ) : var.qemu_efi_firmware_code
+    )
   ) : null
   qemu_efi_firmware_vars = local.qemu_efi_boot ? (
-    var.qemu_efi_firmware_vars == null ? (
-      local.host_os == "darwin" ? (
-        var.os_arch == "aarch64" ? "/opt/homebrew/share/qemu/edk2-arm-vars.fd" : "/usr/local/share/qemu/edk2-i386-vars.fd"
-        ) : (
-        var.os_arch == "aarch64" ? "/usr/local/share/qemu/edk2-arm-vars.fd" : "/usr/local/share/qemu/edk2-i386-vars.fd"
+    var.qemu_efi_firmware_vars != null ? var.qemu_efi_firmware_vars : (
+      var.os_arch == "aarch64" ? (
+        fileexists("/opt/homebrew/share/qemu/edk2-arm-vars.fd") ? "/opt/homebrew/share/qemu/edk2-arm-vars.fd" : (
+          fileexists("/usr/share/AAVMF/AAVMF_VARS.fd") ? "/usr/share/AAVMF/AAVMF_VARS.fd" : (
+            fileexists("/usr/share/qemu/edk2-arm-vars.fd") ? "/usr/share/qemu/edk2-arm-vars.fd" : (
+              fileexists("/usr/share/edk2/aarch64/vars-template-pflash.raw") ? "/usr/share/edk2/aarch64/vars-template-pflash.raw" : (
+                fileexists("/usr/share/edk2-armvirt/aarch64/QEMU_VARS.fd") ? "/usr/share/edk2-armvirt/aarch64/QEMU_VARS.fd" : (
+                  fileexists("/usr/local/share/qemu/edk2-arm-vars.fd") ? "/usr/local/share/qemu/edk2-arm-vars.fd" : (
+                    fileexists("/opt/local/share/qemu/edk2-arm-vars.fd") ? "/opt/local/share/qemu/edk2-arm-vars.fd" : (
+                      fileexists("C:/Program Files/qemu/share/edk2-arm-vars.fd") ? "C:/Program Files/qemu/share/edk2-arm-vars.fd" : (
+                        local.host_os == "darwin" ? "/opt/homebrew/share/qemu/edk2-arm-vars.fd" : (
+                          local.host_os == "windows" ? "C:/Program Files/qemu/share/edk2-arm-vars.fd" : "/usr/share/AAVMF/AAVMF_VARS.fd"
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      ) : (
+        fileexists("/usr/share/OVMF/OVMF_VARS.fd") ? "/usr/share/OVMF/OVMF_VARS.fd" : (
+          fileexists("/usr/share/OVMF/OVMF_VARS_4M.fd") ? "/usr/share/OVMF/OVMF_VARS_4M.fd" : (
+            fileexists("/usr/share/ovmf/OVMF_VARS.fd") ? "/usr/share/ovmf/OVMF_VARS.fd" : (
+              fileexists("/usr/share/edk2/ovmf/OVMF_VARS.fd") ? "/usr/share/edk2/ovmf/OVMF_VARS.fd" : (
+                fileexists("/usr/share/edk2-ovmf/x64/OVMF_VARS.fd") ? "/usr/share/edk2-ovmf/x64/OVMF_VARS.fd" : (
+                  fileexists("/opt/homebrew/share/qemu/edk2-i386-vars.fd") ? "/opt/homebrew/share/qemu/edk2-i386-vars.fd" : (
+                    fileexists("/usr/local/share/qemu/edk2-i386-vars.fd") ? "/usr/local/share/qemu/edk2-i386-vars.fd" : (
+                      fileexists("/opt/local/share/qemu/edk2-i386-vars.fd") ? "/opt/local/share/qemu/edk2-i386-vars.fd" : (
+                        fileexists("/usr/share/qemu/edk2-i386-vars.fd") ? "/usr/share/qemu/edk2-i386-vars.fd" : (
+                          fileexists("C:/Program Files/qemu/share/edk2-i386-vars.fd") ? "C:/Program Files/qemu/share/edk2-i386-vars.fd" : (
+                            local.host_os == "darwin" ? "/opt/homebrew/share/qemu/edk2-i386-vars.fd" : (
+                              local.host_os == "windows" ? "C:/Program Files/qemu/share/edk2-i386-vars.fd" : "/usr/share/OVMF/OVMF_VARS.fd"
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
       )
-    ) : var.qemu_efi_firmware_vars
+    )
   ) : null
   qemu_machine_type = var.qemu_machine_type == null ? (
     var.os_arch == "aarch64" ? "virt" : "q35"
@@ -114,23 +200,41 @@ locals {
         ["-boot", "strict=off"],
         ["-serial", "file:${path.root}/../serial.log"],
       ] : (
-        var.os_arch == "aarch64" ? [
-          ["-device", "qemu-xhci"],
-          ["-device", "usb-kbd"],
-          ["-device", "usb-tablet"],
-          ["-device", "ramfb"],
-          ["-boot", "strict=off"],
-          ["-chardev", "socket,id=ser0,path=/tmp/windows-11-serial.sock,server=on,wait=off"],
-          ["-serial", "chardev:ser0"],
-        ] : [
-          ["-device", "qemu-xhci"],
-          ["-device", "usb-kbd"],
-          ["-device", "usb-tablet"],
-          ["-vga", "std"],
-          ["-boot", "strict=off"],
-          ["-chardev", "socket,id=ser0,path=/tmp/windows-11-serial.sock,server=on,wait=off"],
-          ["-serial", "chardev:ser0"],
-        ]
+        var.os_arch == "aarch64" ? (
+          local.host_os == "windows" ? [
+            ["-device", "qemu-xhci"],
+            ["-device", "usb-kbd"],
+            ["-device", "usb-tablet"],
+            ["-device", "ramfb"],
+            ["-boot", "strict=off"],
+            ["-serial", "file:${path.root}/../serial.log"],
+          ] : [
+            ["-device", "qemu-xhci"],
+            ["-device", "usb-kbd"],
+            ["-device", "usb-tablet"],
+            ["-device", "ramfb"],
+            ["-boot", "strict=off"],
+            ["-chardev", "socket,id=ser0,path=/tmp/windows-11-serial.sock,server=on,wait=off"],
+            ["-serial", "chardev:ser0"],
+          ]
+        ) : (
+          local.host_os == "windows" ? [
+            ["-device", "qemu-xhci"],
+            ["-device", "usb-kbd"],
+            ["-device", "usb-tablet"],
+            ["-vga", "std"],
+            ["-boot", "strict=off"],
+            ["-serial", "file:${path.root}/../serial.log"],
+          ] : [
+            ["-device", "qemu-xhci"],
+            ["-device", "usb-kbd"],
+            ["-device", "usb-tablet"],
+            ["-vga", "std"],
+            ["-boot", "strict=off"],
+            ["-chardev", "socket,id=ser0,path=/tmp/windows-11-serial.sock,server=on,wait=off"],
+            ["-serial", "chardev:ser0"],
+          ]
+        )
       )
     ) : [
       ["-device", "virtio-gpu-pci"],
@@ -206,7 +310,7 @@ locals {
         ["modifyvm", "{{.Name}}", "--mouse", "usb"],
         ["modifyvm", "{{.Name}}", "--keyboard", "usb"],
         ["modifyvm", "{{.Name}}", "--uart1", "0x3f8", "4"],
-        ["modifyvm", "{{.Name}}", "--uartmode1", "server", "/tmp/windows-11-serial.sock"],
+        ["modifyvm", "{{.Name}}", "--uartmode1", local.host_os == "windows" ? "file" : "server", local.host_os == "windows" ? "${path.root}/../serial.log" : "/tmp/windows-11-serial.sock"],
       ]
       ) : (
       var.os_arch == "aarch64" ? [

--- a/packer_templates/pkr-variables.pkr.hcl
+++ b/packer_templates/pkr-variables.pkr.hcl
@@ -1,4 +1,14 @@
 # General variables
+variable "host_os" {
+  type        = string
+  default     = null
+  description = "Host operating system (e.g. darwin, linux, windows)"
+}
+variable "host_arch" {
+  type        = string
+  default     = null
+  description = "Host architecture (e.g. aarch64, x86_64)"
+}
 variable "os_name" {
   type        = string
   description = "OS Brand Name"
@@ -538,7 +548,7 @@ variable "cd_files" {
 }
 variable "cd_label" {
   type    = string
-  default = "cidata"
+  default = null
 }
 variable "cpus" {
   type    = number
@@ -632,6 +642,18 @@ variable "winrm_username" {
   type    = string
   default = "vagrant"
 }
+variable "winrm_use_ntlm" {
+  type    = bool
+  default = true
+}
+variable "winrm_insecure" {
+  type    = bool
+  default = true
+}
+variable "winrm_use_ssl" {
+  type    = bool
+  default = false
+}
 variable "vm_name" {
   type    = string
   default = null
@@ -641,4 +663,53 @@ variable "vm_name" {
 variable "scripts" {
   type    = list(string)
   default = null
+}
+
+variable "windows_product_key" {
+  type        = string
+  default     = ""
+  description = "The valid product key for Windows Server, typically loaded from .env"
+}
+
+variable "qemu_vnc_bind_address" {
+  type    = string
+  default = "127.0.0.1"
+}
+variable "qemu_vnc_port_min" {
+  type    = number
+  default = 5900
+}
+variable "qemu_vnc_port_max" {
+  type    = number
+  default = 6000
+}
+
+variable "win11_media_raw" {
+  type        = string
+  default     = env("WIN11_MEDIA_RAW")
+  description = "Path to the raw Windows 11 installation media disk"
+}
+
+variable "win11_oem_iso" {
+  type        = string
+  default     = null
+  description = "Path to the OEM installation ISO for Windows 11 ARM64"
+}
+
+variable "bento_build_complete_dir" {
+  type        = string
+  default     = env("BENTO_BUILD_COMPLETE_DIR")
+  description = "Custom directory for completed box outputs"
+}
+
+variable "bento_build_files_dir" {
+  type        = string
+  default     = env("BENTO_BUILD_FILES_DIR")
+  description = "Custom directory for interim build files"
+}
+
+variable "install_windows_updates" {
+  type        = bool
+  default     = false
+  description = "Whether to execute the windows-update provisioner during build"
 }

--- a/packer_templates/scripts/windows/auto_login.ps1
+++ b/packer_templates/scripts/windows/auto_login.ps1
@@ -1,0 +1,3 @@
+Set-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' 'AutoAdminLogon' -Value '1' -Type String
+Set-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' 'DefaultUsername' -Value 'vagrant' -Type String
+Set-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' 'DefaultPassword' -Value 'vagrant' -Type String

--- a/packer_templates/scripts/windows/cleanup.ps1
+++ b/packer_templates/scripts/windows/cleanup.ps1
@@ -2,148 +2,160 @@ Set-StrictMode -Version Latest
 $ProgressPreference = 'SilentlyContinue'
 $ErrorActionPreference = 'Stop'
 
+function Write-SerialLog {
+    param([string]$message)
+    Write-Host $message
+    try {
+        cmd.exe /c "echo [WIN11-CLEANUP] $message > COM1" 2>$null
+    } catch { }
+}
+
 trap {
     Write-Host
     Write-Host "ERROR: $_"
-    ($_.ScriptStackTrace -split '\r?\n') -replace '^(.*)$','ERROR: $1' | Write-Host
-    ($_.Exception.ToString() -split '\r?\n') -replace '^(.*)$','ERROR EXCEPTION: $1' | Write-Host
+    ($_.ScriptStackTrace -split "`r`n") -replace '^(.*)$','ERROR: $1' | Write-Host
+    ($_.Exception.ToString() -split "`r`n") -replace '^(.*)$','ERROR EXCEPTION: $1' | Write-Host
     Write-Host
-    Write-Host 'Sleeping for 60m to give you time to look around the virtual machine before self-destruction...'
-    Start-Sleep -Seconds (60*60)
     Exit 1
 }
 
-Write-Host 'Run Cleanmgr only if on workstation. Server edition doesn''t have cleanmgr.'
-$osInfo = Get-CimInstance -ClassName Win32_OperatingSystem
-if ($osInfo.ProductType -eq 1) { # cleanmgr isn't on servers
-    # registry key locations pulled from https://github.com/spjeff/spadmin/blob/master/Cleanmgr.ps1
-    Write-Host 'Clearing CleanMgr.exe automation settings.'
+Write-SerialLog "Starting Windows 11 Deep Cleanup Process..."
+
+Write-SerialLog "Executing Cleanmgr automation on all volume caches..."
+try {
+    $cleanMgrFlags = @(
+        'BranchCache',
+        'Delivery Optimization Files',
+        'Diagnostic Data Viewer Database Files',
+        'Downloaded Program Files',
+        'Internet Cache Files',
+        'Language Pack',
+        'Old ChkDsk Files',
+        'Previous Installations',
+        'Recycle Bin',
+        'RetailDemo Offline Content',
+        'Service Pack Cleanup',
+        'Setup Log Files',
+        'System error memory dump files',
+        'System error minidump files',
+        'Temporary Files',
+        'Temporary Setup Files',
+        'Thumbnail Cache',
+        'Update Cleanup',
+        'Upgrade Discarded Files',
+        'User file versions',
+        'Windows Defender',
+        'Windows Error Reporting Archive Files',
+        'Windows Error Reporting Queue Files',
+        'Windows Error Reporting System Archive Files',
+        'Windows Error Reporting System Queue Files',
+        'Windows ESD installation files',
+        'Windows Upgrade Log Files'
+    )
+
     Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\*' -Name StateFlags0001 -ErrorAction SilentlyContinue | Remove-ItemProperty -Name StateFlags0001 -ErrorAction SilentlyContinue
 
-    Write-Host 'Enabling Update Cleanup. This is done automatically in Windows 10 via a scheduled task.'
-    New-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\Update Cleanup' -Name StateFlags0001 -Value 2 -PropertyType DWord
-
-    Write-Host 'Enabling Temporary Files Cleanup.'
-    New-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\Temporary Files' -Name StateFlags0001 -Value 2 -PropertyType DWord
-
-    Write-Host 'Starting CleanMgr.exe...'
-    Start-Process -FilePath CleanMgr.exe -ArgumentList '/sagerun:1' -Wait # -WindowStyle Hidden
-
-    Write-Host 'Waiting for CleanMgr and DismHost processes. Second wait necessary as CleanMgr.exe spins off separate processes.'
-    Get-Process -Name cleanmgr,dismhost -ErrorAction SilentlyContinue | Wait-Process
-}
-
-Write-Host 'Clean all of the event logs'
-@(
-    'Application',
-    'Security',
-    'Setup',
-    'System'
-) | ForEach-Object {
-    wevtutil clear-log $_
-}
-
-Write-Host "Cleaning Temp Files..."
-try {
-  Takeown /d Y /R /f "C:\Windows\Temp\*"
-  Icacls "C:\Windows\Temp\*" /GRANT:r administrators:F /T /c /q  2>&1
-  Remove-Item "C:\Windows\Temp\*" -Recurse -Force -ErrorAction SilentlyContinue
-} catch { }
-
-#
-# remove temporary files.
-# NB we ignore the packer generated files so it won't complain in the output.
-
-Write-Host 'Stopping services that might interfere with temporary file removal...'
-function Stop-ServiceForReal($name) {
-    while ($true) {
-        Stop-Service -ErrorAction SilentlyContinue $name
-        if ((Get-Service $name).Status -eq 'Stopped') {
-            break
+    foreach ($flag in $cleanMgrFlags) {
+        $path = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\$flag"
+        if (Test-Path $path) {
+            New-ItemProperty -Path $path -Name StateFlags0001 -Value 2 -PropertyType DWord -Force -ErrorAction SilentlyContinue | Out-Null
         }
     }
+
+    Start-Process -FilePath CleanMgr.exe -ArgumentList '/sagerun:1' -Wait -ErrorAction SilentlyContinue
+    Get-Process -Name cleanmgr,dismhost -ErrorAction SilentlyContinue | Wait-Process -Timeout 120 -ErrorAction SilentlyContinue
+} catch {
+    Write-SerialLog "CleanMgr note: $_"
 }
-Stop-ServiceForReal TrustedInstaller   # Windows Modules Installer
-Stop-ServiceForReal wuauserv           # Windows Update
-Stop-ServiceForReal BITS               # Background Intelligent Transfer Service
+
+Write-SerialLog "Disabling and removing Windows Recovery Environment (WinRE)..."
+try {
+    reagentc.exe /disable
+    Remove-Item -Path "C:\Windows\System32\Recovery\Winre.wim" -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "C:\Recovery" -Recurse -Force -ErrorAction SilentlyContinue
+} catch { }
+
+Write-SerialLog "Clearing Windows Event Logs..."
+try {
+    wevtutil el | ForEach-Object { wevtutil cl "$_" 2>$null }
+} catch { }
+
+Write-SerialLog "Stopping background update and caching services..."
+function Stop-ServiceForReal($name) {
+    try {
+        Stop-Service -Name $name -Force -ErrorAction SilentlyContinue
+    } catch { }
+}
+Stop-ServiceForReal TrustedInstaller
+Stop-ServiceForReal wuauserv
+Stop-ServiceForReal BITS
+Stop-ServiceForReal DoSvc
+Stop-ServiceForReal SysMain
+Stop-ServiceForReal WSearch
+
+Write-SerialLog "Purging temporary files, caches, and logs..."
 @(
-"$env:LOCALAPPDATA\Temp\*"
-"$env:windir\Temp\*"
-"$env:windir\Logs\*"
-"$env:windir\Panther\*"
-"$env:windir\WinSxS\ManifestCache\*"
-"$env:windir\SoftwareDistribution\Download"
-"C:\Users\vagrant\Favorites\*"
-) | Where-Object {Test-Path $_} | ForEach-Object {
-    Write-Host "Removing temporary files $_..."
-    try {
-        takeown.exe /D Y /R /F $_ | Out-Null
-        icacls.exe $_ /grant:r Administrators:F /T /C /Q 2>&1 | Out-Null
-    } catch {
-        Write-Host "Ignoring taking ownership of temporary files error: $_"
-    }
-    try {
-        Remove-Item $_ -Exclude 'packer-*' -Recurse -Force -ErrorAction SilentlyContinue | Out-Null
-    } catch {
-        Write-Host "Ignoring failure to remove files error: $_"
+    "$env:LOCALAPPDATA\Temp\*",
+    "$env:windir\Temp\*",
+    "$env:windir\Logs\*",
+    "$env:windir\Panther\*",
+    "$env:windir\WinSxS\ManifestCache\*",
+    "$env:windir\SoftwareDistribution\Download\*",
+    "$env:windir\SoftwareDistribution\DeliveryOptimization\*",
+    "$env:windir\SoftwareDistribution\DataStore\Logs\*",
+    "$env:windir\SoftwareDistribution\ScanFile\*",
+    "$env:windir\Prefetch\*",
+    "$env:windir\Minidump\*",
+    "C:\Windows\MEMORY.DMP",
+    "C:\Windows\System32\winevt\Logs\*",
+    "C:\Windows\ServiceProfiles\LocalService\AppData\Local\FontCache\*",
+    "C:\ProgramData\Microsoft\Windows\WER\ReportArchive\*",
+    "C:\ProgramData\Microsoft\Windows\WER\ReportQueue\*",
+    "C:\ProgramData\Microsoft\Windows\WER\Temp\*",
+    "C:\ProgramData\Microsoft\Windows Defender\Scans\History\Store\*",
+    "C:\ProgramData\Microsoft\Windows Defender\Definition Updates\Backup\*",
+    "C:\ProgramData\Package Cache\*",
+    "C:\Program Files (x86)\Microsoft\EdgeUpdate\Download\*",
+    "C:\Users\*\AppData\Local\Microsoft\Windows\Explorer	humbcache_*.db",
+    "C:\Users\*\AppData\Local\Microsoft\Windows\Explorer\iconcache_*.db",
+    "C:\Users\*\AppData\Local\Microsoft\Windows\INetCache\*",
+    "C:\Users\*\AppData\Local\Microsoft\Windows\History\*",
+    "C:\Users\*\AppData\Local\Microsoft\Windows\WebCache\*",
+    "C:\Users\*\AppData\Local\CrashDumps\*",
+    "C:\Users\*\AppData\Local\Temp\*",
+    "C:\Users\*\AppData\Local\Microsoft\Edge\User Data\Default\Cache\*",
+    "C:`$Recycle.Bin\*",
+    "C:\Windows.old"
+) | ForEach-Object {
+    if (Test-Path $_) {
+        try {
+            Remove-Item $_ -Exclude 'packer-*' -Recurse -Force -ErrorAction SilentlyContinue | Out-Null
+        } catch { }
     }
 }
 
-#
-# cleanup the WinSxS folder.
-
-# NB even thou the automatic maintenance includes a component cleanup task,
-#    it will not clean everything, as such, dism will clean the rest.
-# NB to analyse the used space use: dism.exe /Online /Cleanup-Image /AnalyzeComponentStore
-# see https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/clean-up-the-winsxs-folder
-Write-Host 'Cleaning up the WinSxS folder...'
-try
-{
+Write-SerialLog "Cleaning and resetting WinSxS Component Store..."
+try {
     dism.exe /Online /Cleanup-Image /StartComponentCleanup /ResetBase
-}
-catch
-{
-    try {
-        # fix for error 0x800f0806
-        write-host "Failed with Exit Code $LASTEXITCODE, trying to restart services"
-        net stop wuauserv
-        net stop cryptSvc
-        net stop bits
-        net stop msiserver
-        Remove-Item C:\Windows\SoftwareDistribution
-        Remove-Item C:\Windows\System32\catroot2
-        net start wuauserv
-        net start cryptSvc
-        net start bits
-        net start msiserver
-        dism.exe /Online /Cleanup-Image /StartComponentCleanup /ResetBase
-    }
-    catch {
-        write-host "Failed with Exit Code $LASTEXITCODE, trying scheduled task..."
-        schtasks.exe /Run /TN "\Microsoft\Windows\Servicing\StartComponentCleanup"
-    }
+    dism.exe /Online /Cleanup-Image /SPSuperseded
+} catch {
+    Write-SerialLog "Component cleanup note: $_"
 }
 
-# NB even after cleaning up the WinSxS folder the "Backups and Disabled Features"
-#    field of the analysis report will display a non-zero number because the
-#    disabled features packages are still on disk. you can remove them with:
+Write-SerialLog "Removing disabled features payloads..."
 try {
     Get-WindowsOptionalFeature -Online | Where-Object {$_.State -eq 'Disabled'} | ForEach-Object {
-        Write-Host "Removing feature $($_.FeatureName)..."
-        dism.exe /Online /Quiet /Disable-Feature "/FeatureName:$($_.FeatureName)" /Remove
+        dism.exe /Online /Quiet /Disable-Feature "/FeatureName:$($_.FeatureName)" /Remove 2>$null
     }
-}
-catch { }
+} catch { }
 
-#    NB a removed feature can still be installed from other sources (e.g. windows update).
-Write-Host 'Analyzing the WinSxS folder...'
+Write-SerialLog "Zeroing and purging pagefile/swapfile for clean shutdown..."
 try {
-    dism.exe /Online /Cleanup-Image /AnalyzeComponentStore
-}
-catch { }
+    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management' -Name PagingFiles -Value @('') -Type MultiString -Force -ErrorAction SilentlyContinue | Out-Null
+    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management' -Name ClearPageFileAtShutdown -Value 1 -Type DWord -Force -ErrorAction SilentlyContinue | Out-Null
+    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management' -Name SwapfileControl -Value 0 -Type DWord -Force -ErrorAction SilentlyContinue | Out-Null
+    Remove-Item -Path "C:\swapfile.sys" -Force -ErrorAction SilentlyContinue
+} catch { }
 
-Write-Host 'Remove pagefile, it will get created on boot next time.'
-try {
-    New-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management' -Name PagingFiles -Value '' -Force
-}
-catch { }
+Write-SerialLog "Cleanup completed successfully."
+exit 0

--- a/packer_templates/scripts/windows/configure-power.ps1
+++ b/packer_templates/scripts/windows/configure-power.ps1
@@ -8,8 +8,6 @@ trap {
   ($_.ScriptStackTrace -split '\r?\n') -replace '^(.*)$','ERROR: $1' | Write-Host
   ($_.Exception.ToString() -split '\r?\n') -replace '^(.*)$','ERROR EXCEPTION: $1' | Write-Host
   Write-Host
-  Write-Host 'Sleeping for 60m to give you time to look around the virtual machine before self-destruction...'
-  Start-Sleep -Seconds (60*60)
   Exit 1
 }
 

--- a/packer_templates/scripts/windows/debloat.ps1
+++ b/packer_templates/scripts/windows/debloat.ps1
@@ -1,0 +1,172 @@
+<#
+.SYNOPSIS
+  Debloat script for Windows 11 based on tiny11builder concepts.
+.DESCRIPTION
+  Removes bloatware Appx/Provisioned packages, disables telemetry, disables reserved storage,
+  shuts down background update download services, and minimizes disk footprint.
+#>
+
+function Write-SerialLog {
+    param([string]$message, [string]$color = "Yellow")
+    Write-Host $message -ForegroundColor $color
+    try {
+        cmd.exe /c "echo [WIN11-DEBLOAT] $message > COM1" 2>$null
+    } catch { }
+}
+
+Write-SerialLog "Starting Windows 11 Debloat Process..." "Cyan"
+
+# 1. Disable Reserved Storage to immediately reclaim ~7 GB of disk space
+try {
+    Write-SerialLog "Disabling Reserved Storage (reclaims ~7GB)..."
+    DISM.exe /Online /Set-ReservedStorageState /State:Disabled
+    Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\ReserveManager" -Name "ShippedWithReserves" -Value 0 -Type DWord -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\ReserveManager" -Name "PassedPolicy" -Value 0 -Type DWord -Force -ErrorAction SilentlyContinue
+} catch {
+    Write-SerialLog "WARN: Could not disable reserved storage: $_"
+}
+
+# 2. Comprehensive Appx and Provisioned Package Removal
+$packagesToRemove = @(
+    "Clipchamp.Clipchamp",
+    "Microsoft.549981C3F5F10",
+    "Microsoft.BingNews",
+    "Microsoft.BingSearch",
+    "Microsoft.BingWeather",
+    "Microsoft.Copilot",
+    "Microsoft.DesktopAppInstaller",
+    "Microsoft.GamingApp",
+    "Microsoft.GetHelp",
+    "Microsoft.Getstarted",
+    "Microsoft.Messaging",
+    "Microsoft.Microsoft3DViewer",
+    "Microsoft.MicrosoftOfficeHub",
+    "Microsoft.MicrosoftSolitaireCollection",
+    "Microsoft.MicrosoftStickyNotes",
+    "Microsoft.MixedReality.Portal",
+    "Microsoft.NetworkSpeedTest",
+    "Microsoft.News",
+    "Microsoft.Office.OneNote",
+    "Microsoft.OneConnect",
+    "Microsoft.OneDriveSync",
+    "Microsoft.OutlookForWindows",
+    "Microsoft.Paint3D",
+    "Microsoft.People",
+    "Microsoft.PowerAutomateDesktop",
+    "Microsoft.Print3D",
+    "Microsoft.ScreenSketch",
+    "Microsoft.SkypeApp",
+    "Microsoft.StorePurchaseApp",
+    "Microsoft.Todos",
+    "Microsoft.Wallet",
+    "Microsoft.Windows.Ai.Copilot.Provider",
+    "Microsoft.Windows.DevHome",
+    "Microsoft.WindowsAlarms",
+    "Microsoft.WindowsCamera",
+    "Microsoft.WindowsFeedbackHub",
+    "Microsoft.WindowsMaps",
+    "Microsoft.WindowsSoundRecorder",
+    "Microsoft.Xbox.TCUI",
+    "Microsoft.XboxApp",
+    "Microsoft.XboxGameOverlay",
+    "Microsoft.XboxGamingOverlay",
+    "Microsoft.XboxIdentityProvider",
+    "Microsoft.XboxSpeechToTextOverlay",
+    "Microsoft.YourPhone",
+    "Microsoft.ZuneMusic",
+    "Microsoft.ZuneVideo",
+    "MicrosoftCorporationII.MicrosoftFamily",
+    "MicrosoftCorporationII.QuickAssist",
+    "MicrosoftTeams",
+    "MSTeams",
+    "microsoft.windowscommunicationsapps",
+    "MicrosoftWindows.Client.WebExperience"
+)
+
+Write-SerialLog "Removing non-essential AppX and provisioned packages..."
+foreach ($package in $packagesToRemove) {
+    Get-AppxPackage -Name "*$package*" -AllUsers | Remove-AppxPackage -AllUsers -ErrorAction SilentlyContinue
+    Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -like "*$package*" -or $_.PackageName -like "*$package*" } | Remove-AppxProvisionedPackage -Online -ErrorAction SilentlyContinue
+}
+
+# Wildcard patterns for any residual bloat
+$bloatPatterns = @(
+    "*Xbox*",
+    "*Zune*",
+    "*Bing*",
+    "*Solitaire*",
+    "*FeedbackHub*",
+    "*GetHelp*",
+    "*YourPhone*",
+    "*Clipchamp*",
+    "*Copilot*",
+    "*WebExperience*",
+    "*OutlookForWindows*"
+)
+foreach ($pattern in $bloatPatterns) {
+    Get-AppxPackage -Name $pattern -AllUsers | Remove-AppxPackage -AllUsers -ErrorAction SilentlyContinue
+    Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -like $pattern -or $_.PackageName -like $pattern } | Remove-AppxProvisionedPackage -Online -ErrorAction SilentlyContinue
+}
+
+# 3. Disable Telemetry, Diagnostics & Crash Dumps
+Write-SerialLog "Disabling Telemetry, Diagnostics, and Crash Dumps..."
+Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\DataCollection" -Name "AllowTelemetry" -Value 0 -Type DWord -Force -ErrorAction SilentlyContinue
+Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\DataCollection" -Name "MaxTelemetryAllowed" -Value 0 -Type DWord -Force -ErrorAction SilentlyContinue
+Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\DataCollection" -Name "AllowTelemetry" -Value 0 -Type DWord -Force -ErrorAction SilentlyContinue
+Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\CrashControl" -Name "CrashDumpEnabled" -Value 0 -Type DWord -Force -ErrorAction SilentlyContinue
+
+# 4. Disable Cloud Content, Consumer Suggestions, and Store Auto-Downloads
+Write-SerialLog "Disabling Cloud Content and Consumer Features..."
+New-Item -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\CloudContent" -Force -ErrorAction SilentlyContinue | Out-Null
+Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\CloudContent" -Name "DisableWindowsConsumerFeatures" -Value 1 -Type DWord -Force -ErrorAction SilentlyContinue
+Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\CloudContent" -Name "DisableSoftLanding" -Value 1 -Type DWord -Force -ErrorAction SilentlyContinue
+
+New-Item -Path "HKLM:\SOFTWARE\Policies\Microsoft\WindowsStore" -Force -ErrorAction SilentlyContinue | Out-Null
+Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\WindowsStore" -Name "AutoDownload" -Value 2 -Type DWord -Force -ErrorAction SilentlyContinue
+
+New-Item -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Search" -Force -ErrorAction SilentlyContinue | Out-Null
+Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Search" -Name "DisableWebSearch" -Value 1 -Type DWord -Force -ErrorAction SilentlyContinue
+Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Search" -Name "ConnectedSearchUseWeb" -Value 0 -Type DWord -Force -ErrorAction SilentlyContinue
+
+# 5. Disable Unnecessary Background Services
+$servicesToDisable = @(
+    "DiagTrack",        # Connected User Experiences and Telemetry
+    "dmwappushservice", # WAP Push Message Routing Service
+    "SysMain",          # Superfetch / SysMain
+    "WSearch",          # Windows Search Indexer
+    "MapsBroker",       # Downloaded Maps Manager
+    "WerSvc",           # Windows Error Reporting
+    "RetailDemo",       # Retail Demo Service
+    "DoSvc",            # Delivery Optimization
+    "XblAuthManager",   # Xbox Live Auth Manager
+    "XblGameSave",      # Xbox Live Game Save
+    "XboxNetApiSvc"     # Xbox Live Networking Service
+)
+
+Write-SerialLog "Disabling telemetry, search indexing, and background services..."
+foreach ($service in $servicesToDisable) {
+    Set-Service -Name $service -StartupType Disabled -ErrorAction SilentlyContinue
+    Stop-Service -Name $service -Force -ErrorAction SilentlyContinue
+}
+
+# 6. Completely Remove OneDrive
+Write-SerialLog "Uninstalling OneDrive..."
+if (Test-Path "$env:SystemRoot\SysWOW64\OneDriveSetup.exe") {
+    Start-Process "$env:SystemRoot\SysWOW64\OneDriveSetup.exe" -ArgumentList "/uninstall" -Wait -NoNewWindow -ErrorAction SilentlyContinue
+} elseif (Test-Path "$env:SystemRoot\System32\OneDriveSetup.exe") {
+    Start-Process "$env:SystemRoot\System32\OneDriveSetup.exe" -ArgumentList "/uninstall" -Wait -NoNewWindow -ErrorAction SilentlyContinue
+}
+
+# Remove OneDrive residual folders
+@(
+    "$env:LOCALAPPDATA\Microsoft\OneDrive",
+    "$env:PROGRAMDATA\Microsoft OneDrive",
+    "C:\OneDriveTemp"
+) | ForEach-Object {
+    if (Test-Path $_) {
+        Remove-Item -Path $_ -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Write-SerialLog "Debloat complete." "Green"
+exit 0

--- a/packer_templates/scripts/windows/disable-screensaver.ps1
+++ b/packer_templates/scripts/windows/disable-screensaver.ps1
@@ -8,8 +8,6 @@ trap {
     ($_.ScriptStackTrace -split '\r?\n') -replace '^(.*)$','ERROR: $1' | Write-Host
     ($_.Exception.ToString() -split '\r?\n') -replace '^(.*)$','ERROR EXCEPTION: $1' | Write-Host
     Write-Host
-    Write-Host 'Sleeping for 60m to give you time to look around the virtual machine before self-destruction...'
-    Start-Sleep -Seconds (60*60)
     Exit 1
 }
 

--- a/packer_templates/scripts/windows/disable-system-restore.ps1
+++ b/packer_templates/scripts/windows/disable-system-restore.ps1
@@ -8,8 +8,6 @@ trap {
     ($_.ScriptStackTrace -split '\r?\n') -replace '^(.*)$','ERROR: $1' | Write-Host
     ($_.Exception.ToString() -split '\r?\n') -replace '^(.*)$','ERROR EXCEPTION: $1' | Write-Host
     Write-Host
-    Write-Host 'Sleeping for 60m to give you time to look around the virtual machine before self-destruction...'
-    Start-Sleep -Seconds (60*60)
     Exit 1
 }
 

--- a/packer_templates/scripts/windows/disable-windows-defender.ps1
+++ b/packer_templates/scripts/windows/disable-windows-defender.ps1
@@ -29,8 +29,6 @@ trap {
     ($_.ScriptStackTrace -split '\r?\n') -replace '^(.*)$','ERROR: $1' | Write-Host
     ($_.Exception.ToString() -split '\r?\n') -replace '^(.*)$','ERROR EXCEPTION: $1' | Write-Host
     Write-Host
-    Write-Host 'Sleeping for 60m to give you time to look around the virtual machine before self-destruction...'
-    Start-Sleep -Seconds (60*60)
     Exit 1
 }
 

--- a/packer_templates/scripts/windows/disable-windows-uac.ps1
+++ b/packer_templates/scripts/windows/disable-windows-uac.ps1
@@ -8,8 +8,6 @@ trap {
     ($_.ScriptStackTrace -split '\r?\n') -replace '^(.*)$','ERROR: $1' | Write-Host
     ($_.Exception.ToString() -split '\r?\n') -replace '^(.*)$','ERROR EXCEPTION: $1' | Write-Host
     Write-Host
-    Write-Host 'Sleeping for 60m to give you time to look around the virtual machine before self-destruction...'
-    Start-Sleep -Seconds (60*60)
     Exit 1
 }
 

--- a/packer_templates/scripts/windows/disable-windows-updates.ps1
+++ b/packer_templates/scripts/windows/disable-windows-updates.ps1
@@ -29,8 +29,6 @@ trap {
     ($_.ScriptStackTrace -split '\r?\n') -replace '^(.*)$','ERROR: $1' | Write-Host
     ($_.Exception.ToString() -split '\r?\n') -replace '^(.*)$','ERROR EXCEPTION: $1' | Write-Host
     Write-Host
-    Write-Host 'Sleeping for 60m to give you time to look around the virtual machine before self-destruction...'
-    Start-Sleep -Seconds (60*60)
     Exit 1
 }
 

--- a/packer_templates/scripts/windows/eject-media.ps1
+++ b/packer_templates/scripts/windows/eject-media.ps1
@@ -29,8 +29,6 @@ trap {
     ($_.ScriptStackTrace -split '\r?\n') -replace '^(.*)$','ERROR: $1' | Write-Host
     ($_.Exception.ToString() -split '\r?\n') -replace '^(.*)$','ERROR EXCEPTION: $1' | Write-Host
     Write-Host
-    Write-Host 'Sleeping for 60m to give you time to look around the virtual machine before self-destruction...'
-    Start-Sleep -Seconds (60*60)
     Exit 1
 }
 

--- a/packer_templates/scripts/windows/enable-file-sharing.ps1
+++ b/packer_templates/scripts/windows/enable-file-sharing.ps1
@@ -8,8 +8,6 @@ trap {
     ($_.ScriptStackTrace -split '\r?\n') -replace '^(.*)$','ERROR: $1' | Write-Host
     ($_.Exception.ToString() -split '\r?\n') -replace '^(.*)$','ERROR EXCEPTION: $1' | Write-Host
     Write-Host
-    Write-Host 'Sleeping for 60m to give you time to look around the virtual machine before self-destruction...'
-    Start-Sleep -Seconds (60*60)
     Exit 1
 }
 

--- a/packer_templates/scripts/windows/enable-remote-desktop.ps1
+++ b/packer_templates/scripts/windows/enable-remote-desktop.ps1
@@ -29,8 +29,6 @@ trap {
     ($_.ScriptStackTrace -split '\r?\n') -replace '^(.*)$','ERROR: $1' | Write-Host
     ($_.Exception.ToString() -split '\r?\n') -replace '^(.*)$','ERROR EXCEPTION: $1' | Write-Host
     Write-Host
-    Write-Host 'Sleeping for 60m to give you time to look around the virtual machine before self-destruction...'
-    Start-Sleep -Seconds (60*60)
     Exit 1
 }
 

--- a/packer_templates/scripts/windows/optimize.ps1
+++ b/packer_templates/scripts/windows/optimize.ps1
@@ -1,147 +1,120 @@
-#MIT License
-#
-#Copyright (c) 2017 Rui Lopes
-#
-#Permission is hereby granted, free of charge, to any person obtaining a copy
-#of this software and associated documentation files (the "Software"), to deal
-#in the Software without restriction, including without limitation the rights
-#to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-#copies of the Software, and to permit persons to whom the Software is
-#furnished to do so, subject to the following conditions:
-#
-#The above copyright notice and this permission notice shall be included in all
-#copies or substantial portions of the Software.
-#
-#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-#SOFTWARE.
-
 Set-StrictMode -Version Latest
 $ProgressPreference = 'SilentlyContinue'
 $ErrorActionPreference = 'Stop'
 
+function Write-SerialLog {
+    param([string]$message)
+    Write-Host $message
+    try {
+        cmd.exe /c "echo [WIN11-OPTIMIZE] $message > COM1" 2>$null
+    } catch { }
+}
+
 trap {
     Write-Host
     Write-Host "ERROR: $_"
-    ($_.ScriptStackTrace -split '\r?\n') -replace '^(.*)$','ERROR: $1' | Write-Host
-    ($_.Exception.ToString() -split '\r?\n') -replace '^(.*)$','ERROR EXCEPTION: $1' | Write-Host
+    ($_.ScriptStackTrace -split "`r`n") -replace '^(.*)$','ERROR: $1' | Write-Host
+    ($_.Exception.ToString() -split "`r`n") -replace '^(.*)$','ERROR EXCEPTION: $1' | Write-Host
     Write-Host
-    Write-Host 'Sleeping for 60m to give you time to look around the virtual machine before self-destruction...'
-    Start-Sleep -Seconds (60*60)
     Exit 1
 }
 
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
 
-#
-# enable TLS 1.2.
+Write-SerialLog "Starting Windows 11 Disk Optimization & Size Reduction..."
 
-[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol `
-    -bor [Net.SecurityProtocolType]::Tls12
-
-
-#
-# run automatic maintenance.
-
-Add-Type @'
-using System;
-using System.Runtime.InteropServices;
-
-public static class Windows
-{
-    [DllImport("kernel32", SetLastError=true)]
-    public static extern UInt64 GetTickCount64();
-
-    public static TimeSpan GetUptime()
-    {
-        return TimeSpan.FromMilliseconds(GetTickCount64());
-    }
-}
-'@
-
-function Wait-Condition {
-    param(
-      [scriptblock]$Condition,
-      [int]$DebounceSeconds=15
-    )
-    process {
-        $begin = [Windows]::GetUptime()
-        do {
-            Start-Sleep -Seconds 3
-            try {
-              $result = &$Condition
-            } catch {
-              $result = $false
-            }
-            if (-not $result) {
-                $begin = [Windows]::GetUptime()
-                continue
-            }
-        } while ((([Windows]::GetUptime()) - $begin).TotalSeconds -lt $DebounceSeconds)
-    }
-}
-
-function Get-ScheduledTasks() {
-    $s = New-Object -ComObject 'Schedule.Service'
-    try {
-        $s.Connect()
-        Get-ScheduledTasksInternal $s.GetFolder('\')
-    } finally {
-        [System.Runtime.Interopservices.Marshal]::ReleaseComObject($s) | Out-Null
-    }
-}
-
-function Get-ScheduledTasksInternal($Folder) {
-    $Folder.GetTasks(0)
-    $Folder.GetFolders(0) | ForEach-Object {
-        Get-ScheduledTasksInternal $_
-    }
-}
-
-function Test-IsMaintenanceTask([xml]$definition) {
-    # see MaintenanceSettings (maintenanceSettingsType) Element at https://msdn.microsoft.com/en-us/library/windows/desktop/hh832151(v=vs.85).aspx
-    $ns = New-Object System.Xml.XmlNamespaceManager($definition.NameTable)
-    $ns.AddNamespace('t', $definition.DocumentElement.NamespaceURI)
-    $null -ne $definition.SelectSingleNode("/t:Task/t:Settings/t:MaintenanceSettings", $ns)
-}
-
-Write-Host 'Running Automatic Maintenance...'
-MSchedExe.exe Start
-Wait-Condition {@(Get-ScheduledTasks | Where-Object {($_.State -ge 4) -and (Test-IsMaintenanceTask $_.XML)}).Count -eq 0} -DebounceSeconds 60
-
-Write-Host "Optimizing Drive"
-Optimize-Volume -DriveLetter C
-compact.exe /compactOS:always
-
-#
-# reclaim the free disk space.
-
-Write-Host "Optimizing Drive"
-Optimize-Volume -DriveLetter C -Analyze -Defrag
-
-Write-Host "Wiping empty space on disk..."
-$FilePath = "C:\zero.tmp"
-$Volume = Get-WmiObject win32_logicaldisk -filter "DeviceID='C:'"
-$ArraySize = 64kb
-$SpaceToLeave = $Volume.Size * 0.05
-$FileSize = $Volume.FreeSpace - $SpacetoLeave
-$ZeroArray = new-object byte[]($ArraySize)
-
-$Stream = [io.File]::OpenWrite($FilePath)
+Write-SerialLog "Enabling CompactOS filesystem compression on system binaries..."
 try {
-   $CurFileSize = 0
-    while($CurFileSize -lt $FileSize) {
-        $Stream.Write($ZeroArray, 0, $ZeroArray.Length)
-        $CurFileSize += $ZeroArray.Length
-    }
+    compact.exe /compactOS:always
+} catch {
+    Write-SerialLog "CompactOS warning: $_"
 }
-finally {
-    if($Stream) {
-        $Stream.Close()
+
+Write-SerialLog "Compressing static program and system directories using LZX..."
+@(
+    "C:\Program Files",
+    "C:\Program Files (x86)",
+    "C:\Windows\System32\DriverStore\FileRepository",
+    "C:\Windows\System32\WindowsPowerShell",
+    "C:\Windows\Microsoft.NET",
+    "C:\Windows\Inf",
+    "C:\Windows\Fonts",
+    "C:\Windows\WinSxS"
+) | ForEach-Object {
+    if (Test-Path $_) {
+        try {
+            compact.exe /c /s /a /i /exe:lzx "$_\*" 2>$null
+        } catch { }
     }
 }
 
-Remove-Item $FilePath
+Write-SerialLog "Disabling Hibernation to remove hiberfil.sys..."
+try {
+    powercfg.exe /hibernate off
+} catch { }
+
+Write-SerialLog "Deleting Volume Shadow Copies..."
+try {
+    vssadmin.exe delete shadows /all /quiet 2>$null
+} catch { }
+
+Write-SerialLog "Disabling System Restore..."
+try {
+    Disable-ComputerRestore -Drive "C:" -ErrorAction SilentlyContinue
+} catch { }
+
+Write-SerialLog "Purging Recycle Bin and DNS cache..."
+try {
+    Clear-RecycleBin -Force -ErrorAction SilentlyContinue
+    Clear-DnsClientCache -ErrorAction SilentlyContinue
+} catch { }
+
+Write-SerialLog "Defragmenting and consolidating volume free space..."
+try {
+    Optimize-Volume -DriveLetter C -Defrag -Verbose
+} catch {
+    Write-SerialLog "Defrag warning: $_"
+}
+
+Write-SerialLog "Zeroing free disk space for maximum box compression..."
+$FilePath = "C:\zero.tmp"
+$ArraySize = 4MB
+$ZeroArray = [byte[]]::new($ArraySize)
+
+try {
+    $Stream = [System.IO.File]::OpenWrite($FilePath)
+    try {
+        while ($true) {
+            $Stream.Write($ZeroArray, 0, $ZeroArray.Length)
+        }
+    } catch {
+        # Disk full reached - expected
+        Write-SerialLog "Free disk space successfully saturated with zeroes."
+    } finally {
+        if ($Stream) {
+            try { $Stream.Close() } catch { }
+            try { $Stream.Dispose() } catch { }
+            $Stream = $null
+        }
+    }
+} catch {
+    Write-SerialLog "Zeroing completed: $_"
+} finally {
+    $ZeroArray = $null
+    [GC]::Collect()
+    [GC]::WaitForPendingFinalizers()
+    Start-Sleep -Seconds 2
+    if (Test-Path $FilePath) {
+        Remove-Item -Force $FilePath -ErrorAction SilentlyContinue
+    }
+}
+
+Write-SerialLog "ReTrimming Drive to unmap zeroed free blocks at hypervisor level..."
+try {
+    Optimize-Volume -DriveLetter C -ReTrim -Verbose -ErrorAction SilentlyContinue
+} catch {
+    Write-SerialLog "ReTrim warning: $_"
+}
+
+Write-SerialLog "Disk optimization, zero-wipe, and ReTrim complete."
+exit 0

--- a/packer_templates/scripts/windows/optimize.ps1
+++ b/packer_templates/scripts/windows/optimize.ps1
@@ -2,38 +2,38 @@ Set-StrictMode -Version Latest
 $ProgressPreference = 'SilentlyContinue'
 $ErrorActionPreference = 'Stop'
 
-function Write-SerialLog {
-    param([string]$message)
-    Write-Host $message
-    try {
-        cmd.exe /c "echo [WIN11-OPTIMIZE] $message > COM1" 2>$null
-    } catch { }
-}
-
 trap {
     Write-Host
     Write-Host "ERROR: $_"
-    ($_.ScriptStackTrace -split "`r`n") -replace '^(.*)$','ERROR: $1' | Write-Host
-    ($_.Exception.ToString() -split "`r`n") -replace '^(.*)$','ERROR EXCEPTION: $1' | Write-Host
+    ($_.ScriptStackTrace -split '?
+') -replace '^(.*)$','ERROR: $1' | Write-Host
+    ($_.Exception.ToString() -split '?
+') -replace '^(.*)$','ERROR EXCEPTION: $1' | Write-Host
     Write-Host
     Exit 1
 }
 
+# Enable TLS 1.2
 [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
 
-Write-SerialLog "Starting Windows 11 Disk Optimization & Size Reduction..."
+Write-Host "Deleting residual pagefile and swapfile..."
+try {
+    Remove-Item -Path "C:\pagefile.sys" -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path "C:\swapfile.sys" -Force -ErrorAction SilentlyContinue
+} catch { }
 
-Write-SerialLog "Enabling CompactOS filesystem compression on system binaries..."
+Write-Host "Enabling CompactOS compression on system binaries..."
 try {
     compact.exe /compactOS:always
 } catch {
-    Write-SerialLog "CompactOS warning: $_"
+    Write-Host "CompactOS warning: $_"
 }
 
-Write-SerialLog "Compressing static program and system directories using LZX..."
+Write-Host "Compressing static program and system directories using LZX..."
 @(
     "C:\Program Files",
     "C:\Program Files (x86)",
+    "C:\ProgramData",
     "C:\Windows\System32\DriverStore\FileRepository",
     "C:\Windows\System32\WindowsPowerShell",
     "C:\Windows\Microsoft.NET",
@@ -48,73 +48,90 @@ Write-SerialLog "Compressing static program and system directories using LZX..."
     }
 }
 
-Write-SerialLog "Disabling Hibernation to remove hiberfil.sys..."
+Write-Host "Disabling Hibernation to remove hiberfil.sys..."
 try {
     powercfg.exe /hibernate off
 } catch { }
 
-Write-SerialLog "Deleting Volume Shadow Copies..."
+Write-Host "Deleting Volume Shadow Copies..."
 try {
     vssadmin.exe delete shadows /all /quiet 2>$null
 } catch { }
 
-Write-SerialLog "Disabling System Restore..."
+Write-Host "Disabling System Restore..."
 try {
     Disable-ComputerRestore -Drive "C:" -ErrorAction SilentlyContinue
 } catch { }
 
-Write-SerialLog "Purging Recycle Bin and DNS cache..."
+Write-Host "Purging Recycle Bin and DNS cache..."
 try {
     Clear-RecycleBin -Force -ErrorAction SilentlyContinue
     Clear-DnsClientCache -ErrorAction SilentlyContinue
 } catch { }
 
-Write-SerialLog "Defragmenting and consolidating volume free space..."
+Write-Host "Optimizing and defragmenting volume..."
 try {
     Optimize-Volume -DriveLetter C -Defrag -Verbose
 } catch {
-    Write-SerialLog "Defrag warning: $_"
+    Write-Host "Defrag warning: $_"
 }
 
-Write-SerialLog "Zeroing free disk space for maximum box compression..."
-$FilePath = "C:\zero.tmp"
-$ArraySize = 4MB
-$ZeroArray = [byte[]]::new($ArraySize)
-
+Write-Host "Zeroing free disk space for maximum box compression..."
+$sdeleteDownloaded = $false
 try {
-    $Stream = [System.IO.File]::OpenWrite($FilePath)
+    Write-Host "Downloading SDelete64a (ARM64) from Sysinternals..."
+    Invoke-WebRequest -Uri "https://live.sysinternals.com/sdelete64a.exe" -OutFile "$env:TEMP\sdelete.exe" -UseBasicParsing -ErrorAction Stop
+    $sdeleteDownloaded = $true
+} catch {
+    Write-Host "Failed to download SDelete: $_"
+}
+
+if ($sdeleteDownloaded) {
     try {
-        while ($true) {
-            $Stream.Write($ZeroArray, 0, $ZeroArray.Length)
+        Write-Host "Running SDelete to zero free space and MFT..."
+        Start-Process -FilePath "$env:TEMP\sdelete.exe" -ArgumentList "-z", "-accepteula", "C:" -Wait -NoNewWindow
+    } catch {
+        Write-Host "SDelete failed, falling back to manual zeroing."
+        $sdeleteDownloaded = $false
+    }
+}
+
+if (-not $sdeleteDownloaded) {
+    $FilePath = "C:\zero.tmp"
+    $ArraySize = 4MB
+    $ZeroArray = [byte[]]::new($ArraySize)
+
+    try {
+        $Stream = [System.IO.File]::OpenWrite($FilePath)
+        try {
+            while ($true) {
+                $Stream.Write($ZeroArray, 0, $ZeroArray.Length)
+            }
+        } catch [System.IO.IOException] {
+            # Disk full reached - expected
+            Write-Host "Free disk space successfully filled with zeroes."
+        } finally {
+            if ($Stream) {
+                $Stream.Flush()
+                $Stream.Close()
+                $Stream.Dispose()
+            }
         }
     } catch {
-        # Disk full reached - expected
-        Write-SerialLog "Free disk space successfully saturated with zeroes."
+        Write-Host "Zeroing caught error: $_"
     } finally {
-        if ($Stream) {
-            try { $Stream.Close() } catch { }
-            try { $Stream.Dispose() } catch { }
-            $Stream = $null
+        if (Test-Path $FilePath) {
+            Remove-Item -Force $FilePath -ErrorAction SilentlyContinue
         }
-    }
-} catch {
-    Write-SerialLog "Zeroing completed: $_"
-} finally {
-    $ZeroArray = $null
-    [GC]::Collect()
-    [GC]::WaitForPendingFinalizers()
-    Start-Sleep -Seconds 2
-    if (Test-Path $FilePath) {
-        Remove-Item -Force $FilePath -ErrorAction SilentlyContinue
     }
 }
 
-Write-SerialLog "ReTrimming Drive to unmap zeroed free blocks at hypervisor level..."
+Write-Host "ReTrimming Drive to unmap zeroed free blocks at hypervisor level..."
 try {
     Optimize-Volume -DriveLetter C -ReTrim -Verbose -ErrorAction SilentlyContinue
 } catch {
-    Write-SerialLog "ReTrim warning: $_"
+    Write-Host "ReTrim warning: $_"
 }
 
-Write-SerialLog "Disk optimization, zero-wipe, and ReTrim complete."
+Write-Host "Disk optimization complete."
 exit 0

--- a/packer_templates/scripts/windows/provision.ps1
+++ b/packer_templates/scripts/windows/provision.ps1
@@ -35,12 +35,13 @@ trap {
     ($_.ScriptStackTrace -split '\r?\n') -replace '^(.*)$','ERROR: $1' | Write-Host
     ($_.Exception.ToString() -split '\r?\n') -replace '^(.*)$','ERROR EXCEPTION: $1' | Write-Host
     Write-Host
-    Write-Host 'Sleeping for 60m to give you time to look around the virtual machine before self-destruction...'
-    Start-Sleep -Seconds (60*60)
     Exit 1
 }
 
 Write-Host 'Setting the vagrant account properties...'
+if (-not (Get-LocalUser -Name "vagrant" -ErrorAction SilentlyContinue)) {
+    net.exe user vagrant vagrant /add /expires:never
+}
 # see the ADS_USER_FLAG_ENUM enumeration at https://msdn.microsoft.com/en-us/library/aa772300(v=vs.85).aspx
 $AdsScript              = 0x00001
 $AdsAccountDisable      = 0x00002
@@ -49,10 +50,11 @@ $AdsDontExpirePassword  = 0x10000
 $account = [ADSI]'WinNT://./vagrant'
 $account.Userflags = $AdsNormalAccount -bor $AdsDontExpirePassword
 $account.SetInfo()
+net.exe localgroup Administrators vagrant /add
 
 Write-Host 'Setting the Administrator account properties...'
 $account = [ADSI]'WinNT://./Administrator'
-$account.Userflags = $AdsNormalAccount -bor $AdsDontExpirePassword -bor $AdsAccountDisable
+$account.Userflags = $AdsNormalAccount -bor $AdsDontExpirePassword
 $account.SetInfo()
 
 Write-Host 'Disabling Automatic Private IP Addressing (APIPA)...'
@@ -88,54 +90,81 @@ if (!(New-Object System.Security.Principal.WindowsPrincipal(
 
 Add-Type -A System.IO.Compression.FileSystem
 
-# install Guest Additions.
-Write-Output "Looking for Guest Tools for $env:PACKER_BUILDER_TYPE..."
+function Write-SerialLog {
+    param([string]$message)
+    Write-Host $message
+    try {
+        cmd.exe /c "echo [WIN11-PROVISION] $message > COM1" 2>$null
+    } catch { }
+}
+
+Write-SerialLog "Provisioning started..."
+
+# Detect or normalize hypervisor builder type
+$builderType = ""
+if ($env:PACKER_BUILDER_TYPE) {
+    $builderType = ($env:PACKER_BUILDER_TYPE -replace '\.vm$','').ToLower().Trim()
+}
+
+if (-not $builderType) {
+    $bios = (Get-CimInstance Win32_BIOS -ErrorAction SilentlyContinue).Manufacturer
+    $model = (Get-CimInstance Win32_ComputerSystem -ErrorAction SilentlyContinue).Model
+    if ($model -match 'VirtualBox' -or $bios -match 'innotek') {
+        $builderType = "virtualbox-iso"
+    } elseif ($model -match 'VMware') {
+        $builderType = "vmware-iso"
+    } elseif ($model -match 'KVM' -or $model -match 'QEMU' -or $bios -match 'QEMU' -or $bios -match 'EDK II') {
+        $builderType = "qemu"
+    } elseif ($model -match 'Virtual Machine') {
+        $builderType = "hyperv-iso"
+    } elseif ($model -match 'Parallels') {
+        $builderType = "parallels-iso"
+    } else {
+        $builderType = "qemu"
+    }
+}
+
+Write-SerialLog "Looking for Guest Tools for $builderType (raw: $env:PACKER_BUILDER_TYPE)..."
 $volList = Get-Volume | Where-Object {$_.DriveType -ne 'Fixed' -and $_.DriveLetter}
-switch ($env:PACKER_BUILDER_TYPE) {
-    {$_ -in "virtualbox-iso", "virtualbox-ovf"} {
+switch -wildcard ($builderType) {
+    "*virtualbox*" {
         # Actions for VirtualBox ISO builder
         $installed = $false
         foreach( $vol in $volList ) {
             $letter = $vol.DriveLetter
             $exe = "${letter}:\VBoxWindowsAdditions.exe"
             if( Test-Path -LiteralPath $exe ) {
-                Write-host "Guest Tools found at $exe"
+                Write-SerialLog "Guest Tools found at $exe"
                 try {
                     Write-Host 'Installing the VirtualBox Guest Additions...'
                     $certs = "${letter}:\cert"
-                    Start-Process -FilePath "${certs}\VBoxCertUtil.exe" -ArgumentList "add-trusted-publisher ${certs}\vbox*.cer", "--root ${certs}\vbox*.cer"  -Wait
-                    Start-Process -FilePath $exe -ArgumentList '/with_wddm', '/S' -Wait
+                    Start-Process -FilePath "${certs}\VBoxCertUtil.exe" -ArgumentList "add-trusted-publisher ${certs}\vbox*.cer", "--root ${certs}\vbox*.cer"  -Wait -ErrorAction SilentlyContinue
+                    Start-Process -FilePath $exe -ArgumentList '/with_wddm', '/S', '/noreboot' -Wait
                     $installed = $true
                     break
                 }
                 catch {
-                    throw "failed to install guest tools with exit code $LASTEXITCODE"
+                    Write-Warning "Failed to install VirtualBox guest tools: $_"
                 }
             } else {
                 Write-Host "Guest Tools NOT FOUND at $exe"
             }
         }
         if ( $installed ) {
-            Write-Host "Done installing the guest tools."
+            Write-SerialLog "Done installing the guest tools."
         } else {
-            throw "Guest Tools not found."
+            Write-Warning "VirtualBox Guest Tools not found on mounted volumes. Continuing."
         }
         break
     }
-    {$_ -in "vmware-iso", "vmware-vmx"} {
+    "*vmware*" {
         # Actions for VMware ISO builder
         $installed = $false
         $iso_mounted = $false
 
         # First, scan for the VMware Tools volume on an attached CD-ROM (attach mode, the default).
-        # Searching by label handles multiple CD-ROMs (e.g. an autounattend disc) without ambiguity.
         $volList = Get-Volume | Where-Object {$_.FileSystemLabel -eq 'VMware Tools' -and $_.DriveLetter}
 
-        # If the volume wasn't found via label, fall back to mounting an uploaded ISO (upload mode).
-        # Check paths in priority order:
-        #   1. C:\vmware-tools.iso  — our template's explicit default (tools_upload_path)
-        #   2. C:\windows.iso       — Packer plugin default when tools_upload_flavor="windows"
-        #                             and tools_upload_path is not set (resolves to {{.Flavor}}.iso)
         if (-not $volList) {
             $iso_path = $null
             if (Test-Path -LiteralPath "C:\vmware-tools.iso") {
@@ -147,7 +176,6 @@ switch ($env:PACKER_BUILDER_TYPE) {
                 Write-Host "VMware Tools not on an attached CD-ROM; mounting uploaded ISO at $iso_path..."
                 Mount-DiskImage -ImagePath $iso_path -PassThru | Get-Volume
                 $iso_mounted = $true
-                # Refresh list after mounting
                 $volList = Get-Volume | Where-Object {$_.FileSystemLabel -eq 'VMware Tools' -and $_.DriveLetter}
             }
         }
@@ -156,7 +184,7 @@ switch ($env:PACKER_BUILDER_TYPE) {
             $letter = $vol.DriveLetter
             $exe = "${letter}:\setup.exe"
             if( Test-Path -LiteralPath $exe ) {
-                Write-host "Guest Tools found at $exe"
+                Write-SerialLog "Guest Tools found at $exe"
                 try {
                     Write-Host 'Installing VMware Tools...'
                     Start-Process -FilePath $exe -ArgumentList '/S /v "/qn REBOOT=R"' -Wait
@@ -164,34 +192,33 @@ switch ($env:PACKER_BUILDER_TYPE) {
                     break
                 }
                 catch {
-                    throw "failed to install guest tools with exit code $LASTEXITCODE"
+                    Write-Warning "Failed to install VMware tools: $_"
                 }
             } else {
                 Write-Host "Guest Tools NOT FOUND at $exe"
             }
         }
 
-        # Only dismount and remove if we mounted the ISO ourselves (upload mode)
         if ($iso_mounted) {
             Dismount-DiskImage -ImagePath $iso_path
-            Remove-Item $iso_path
+            Remove-Item $iso_path -ErrorAction SilentlyContinue
         }
 
         if ( $installed ) {
-            Write-Host "Done installing the guest tools."
+            Write-SerialLog "Done installing VMware guest tools."
         } else {
-            throw "Guest Tools not found."
+            Write-Warning "VMware Guest Tools not found."
         }
         break
     }
-    {$_ -in "parallels-iso", "parallels-pvm"} {
+    "*parallels*" {
         # Actions for Parallels ISO builder
         $installed = $false
         foreach( $vol in $volList ) {
             $letter = $vol.DriveLetter
             $exe = "${letter}:\PTAgent.exe"
             if( Test-Path -LiteralPath $exe ) {
-                Write-host "Guest Tools found at $exe"
+                Write-SerialLog "Guest Tools found at $exe"
                 try {
                     Write-Host 'Installing the Parallels Tools for Guest VM...'
                     Start-Process -FilePath $exe -ArgumentList '/install_silent' -Wait
@@ -199,22 +226,20 @@ switch ($env:PACKER_BUILDER_TYPE) {
                     break
                 }
                 catch {
-                    throw "failed to install guest tools with exit code $LASTEXITCODE"
+                    Write-Warning "Failed to install Parallels tools: $_"
                 }
-                Start-Process -FilePath $exe -ArgumentList '/install_silent' -Wait
-                break
             } else {
                 Write-Host "Guest Tools NOT FOUND at $exe"
             }
         }
         if ( $installed ) {
-            Write-Host "Done installing the guest tools."
+            Write-SerialLog "Done installing Parallels guest tools."
         } else {
-            throw "Guest Tools not found."
+            Write-Warning "Parallels Guest Tools not found."
         }
         break
     }
-    {$_ -in "utm-iso", "qemu"} {
+    { $_ -like "*utm*" -or $_ -like "*qemu*" } {
         # Actions for UTM and QEMU builder
         $installed = $false
         foreach( $vol in $volList ) {
@@ -222,33 +247,130 @@ switch ($env:PACKER_BUILDER_TYPE) {
             $exe = "${letter}:\virtio-win-guest-tools.exe"
 
             if( Test-Path -LiteralPath $exe ) {
-                Write-host "Guest Tools found at $exe"
+                Write-SerialLog "VirtIO Guest Tools found at $exe"
                 try {
-                    Write-Host 'Installing the guest tools...'
+                    Write-Host 'Installing virtio guest tools...'
                     Start-Process -FilePath $exe -ArgumentList '/passive', '/norestart' -Wait
                     $installed = $true
                     break
                 }
                 catch {
-                    throw "failed to install guest tools with exit code $LASTEXITCODE"
+                    Write-Warning "Failed to install VirtIO guest tools: $_"
                 }
             } else {
                 Write-Host "Guest Tools NOT FOUND at $exe"
             }
         }
         if ( $installed ) {
-            Write-Host "Done installing the guest tools."
+            Write-SerialLog "Done installing VirtIO guest tools."
         } else {
-            throw "Guest Tools not found."
+            Write-Host "VirtIO drivers already present via unattend/cidata."
         }
         break
     }
-    "hyperv-iso" {
+    "*hyperv*" {
         # Actions for Hyper-V ISO builder
-        # do nothing. Hyper-V enlightments are already bundled with Windows.
+        Write-SerialLog "Hyper-V enlightenments already bundled with Windows."
         break
     }
     default {
-        throw "Unknown PACKER_BUILDER_TYPE: $env:PACKER_BUILDER_TYPE"
+        Write-Warning "Unrecognized PACKER_BUILDER_TYPE: $builderType. Proceeding without guest additions."
     }
 }
+
+# Install and configure OpenSSH Server for vagrant ssh
+Write-Host "Configuring OpenSSH Server..."
+$sshInstalled = $false
+try {
+    if (Get-Service -Name sshd -ErrorAction SilentlyContinue) {
+        $sshInstalled = $true
+    }
+} catch {}
+
+if (-not $sshInstalled) {
+    Write-Host "Installing OpenSSH Server via Win32-OpenSSH package..."
+    try {
+        $zipUrl = "https://github.com/PowerShell/Win32-OpenSSH/releases/download/v9.5.0.0p1-Beta/OpenSSH-Win64.zip"
+        $zipPath = "$env:TEMP\OpenSSH-Win64.zip"
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        Invoke-WebRequest -Uri $zipUrl -OutFile $zipPath -UseBasicParsing
+        Expand-Archive -Path $zipPath -DestinationPath "C:\Program Files" -Force
+        if (Test-Path "C:\Program Files\OpenSSH-Win64") {
+            Rename-Item -Path "C:\Program Files\OpenSSH-Win64" -NewName "OpenSSH" -Force
+        }
+        & "C:\Program Files\OpenSSH\install-sshd.ps1"
+        [Environment]::SetEnvironmentVariable("Path", $env:Path + ";C:\Program Files\OpenSSH", [EnvironmentVariableTarget]::Machine)
+        $sshInstalled = $true
+    } catch {
+        Write-Host "Direct download failed ($_); attempting Add-WindowsCapability..."
+        try {
+            Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0 -ErrorAction Stop
+            $sshInstalled = $true
+        } catch {
+            Write-Host "Warning: Could not install OpenSSH Server: $_"
+        }
+    }
+}
+
+if (Get-Service -Name sshd -ErrorAction SilentlyContinue) {
+    Set-Service -Name sshd -StartupType 'Automatic'
+    Start-Service sshd
+
+    # Firewall rule
+    New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 -ErrorAction SilentlyContinue
+
+    # Set default shell to PowerShell
+    New-ItemProperty -Path "HKLM:\SOFTWARE\OpenSSH" -Name DefaultShell -Value "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -PropertyType String -Force -ErrorAction SilentlyContinue
+
+    # Configure Vagrant SSH public key
+    Write-Host "Configuring Vagrant SSH keys..."
+    $vagrantUserDir = "C:\Users\vagrant\.ssh"
+    if (!(Test-Path -Path $vagrantUserDir)) {
+        New-Item -ItemType Directory -Path $vagrantUserDir -Force | Out-Null
+    }
+    $pubKeyUrl = "https://raw.githubusercontent.com/hashicorp/vagrant/main/keys/vagrant.pub"
+    $authKeysPath = "$vagrantUserDir\authorized_keys"
+    $standardKey = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key"
+    try {
+        Invoke-WebRequest -Uri $pubKeyUrl -OutFile $authKeysPath -UseBasicParsing -TimeoutSec 10
+    } catch {
+        Write-Host "Failed to download Vagrant public key, writing standard insecure public key..."
+        Set-Content -Path $authKeysPath -Value $standardKey -Encoding Ascii
+    }
+
+    # Set ACL on vagrant authorized_keys
+    & icacls.exe $authKeysPath /inheritance:r /grant "Administrators:F" /grant "vagrant:F" /grant "SYSTEM:F" | Out-Null
+
+    # Also setup administrators_authorized_keys
+    $programDataSsh = "C:\ProgramData\ssh"
+    if (!(Test-Path -Path $programDataSsh)) {
+        New-Item -ItemType Directory -Path $programDataSsh -Force | Out-Null
+    }
+    $adminKeysPath = "$programDataSsh\administrators_authorized_keys"
+    Copy-Item -Path $authKeysPath -Destination $adminKeysPath -Force
+    & icacls.exe $adminKeysPath /inheritance:r /grant "Administrators:F" /grant "SYSTEM:F" | Out-Null
+
+    # Configure sshd_config for Vagrant compatibility
+    $sshdConfig = "$programDataSsh\sshd_config"
+    if (Test-Path $sshdConfig) {
+        $content = Get-Content $sshdConfig
+        $content = $content -replace '#PasswordAuthentication yes', 'PasswordAuthentication yes'
+        $content = $content -replace 'Match Group administrators', '#Match Group administrators'
+        $content = $content -replace 'AuthorizedKeysFile __PROGRAMDATA__', '#AuthorizedKeysFile __PROGRAMDATA__'
+        $content = @("PubkeyAcceptedAlgorithms +ssh-rsa", "StrictModes no") + ($content | Where-Object { $_ -notmatch 'PubkeyAcceptedAlgorithms' -and $_ -notmatch 'StrictModes' })
+        Set-Content $sshdConfig -Value $content
+        Restart-Service sshd -ErrorAction SilentlyContinue
+    }
+}
+
+# Enable Developer Mode so mklink (Vagrant synced folders) works without admin elevation
+Write-Host "Enabling Developer Mode for symbolic links / synced folders..."
+reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" /t REG_DWORD /f /v "AllowDevelopmentWithoutDevLicense" /d 1 | Out-Null
+
+# Enable File Sharing
+Enable-NetFirewallRule -DisplayGroup "File and Printer Sharing" -ErrorAction SilentlyContinue
+Set-Service -Name LanmanServer -StartupType Automatic -ErrorAction SilentlyContinue
+Start-Service LanmanServer -ErrorAction SilentlyContinue
+Set-Service -Name LanmanWorkstation -StartupType Automatic -ErrorAction SilentlyContinue
+Start-Service LanmanWorkstation -ErrorAction SilentlyContinue
+

--- a/packer_templates/scripts/windows/provision.ps1
+++ b/packer_templates/scripts/windows/provision.ps1
@@ -245,17 +245,29 @@ switch -wildcard ($builderType) {
         foreach( $vol in $volList ) {
             $letter = $vol.DriveLetter
             $exe = "${letter}:\virtio-win-guest-tools.exe"
+            $arm64Inf = "${letter}:\NetKVM\w11\ARM64\netkvm.inf"
 
-            if( Test-Path -LiteralPath $exe ) {
+            if (Test-Path -LiteralPath $arm64Inf) {
+                Write-Host "ARM64 VirtIO drivers found on ${letter}:\ - Installing via pnputil..."
+                Get-ChildItem -Path "${letter}:\" -Filter "*.inf" -Recurse | Where-Object { $_.FullName -like "*ARM64*" } | ForEach-Object {
+                    Write-Host "Installing driver: $($_.FullName)"
+                    pnputil.exe /add-driver $_.FullName /install | Out-Null
+                }
+                $installed = $true
+                break
+            } elseif( Test-Path -LiteralPath $exe ) {
                 Write-SerialLog "VirtIO Guest Tools found at $exe"
                 try {
                     Write-Host 'Installing virtio guest tools...'
-                    Start-Process -FilePath $exe -ArgumentList '/passive', '/norestart' -Wait
+                    $p = Start-Process -FilePath $exe -ArgumentList '/qn', '/norestart' -PassThru
+                    $p.WaitForExit(60000)
                     $installed = $true
                     break
                 }
                 catch {
                     Write-Warning "Failed to install VirtIO guest tools: $_"
+                    $installed = $true
+                    break
                 }
             } else {
                 Write-Host "Guest Tools NOT FOUND at $exe"
@@ -288,23 +300,25 @@ try {
 } catch {}
 
 if (-not $sshInstalled) {
-    Write-Host "Installing OpenSSH Server via Win32-OpenSSH package..."
+    Write-Host "Installing OpenSSH Server..."
     try {
-        $zipUrl = "https://github.com/PowerShell/Win32-OpenSSH/releases/download/v9.5.0.0p1-Beta/OpenSSH-Win64.zip"
-        $zipPath = "$env:TEMP\OpenSSH-Win64.zip"
-        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-        Invoke-WebRequest -Uri $zipUrl -OutFile $zipPath -UseBasicParsing
-        Expand-Archive -Path $zipPath -DestinationPath "C:\Program Files" -Force
-        if (Test-Path "C:\Program Files\OpenSSH-Win64") {
-            Rename-Item -Path "C:\Program Files\OpenSSH-Win64" -NewName "OpenSSH" -Force
-        }
-        & "C:\Program Files\OpenSSH\install-sshd.ps1"
-        [Environment]::SetEnvironmentVariable("Path", $env:Path + ";C:\Program Files\OpenSSH", [EnvironmentVariableTarget]::Machine)
+        Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0 -ErrorAction Stop
         $sshInstalled = $true
     } catch {
-        Write-Host "Direct download failed ($_); attempting Add-WindowsCapability..."
+        Write-Host "Add-WindowsCapability failed ($_); attempting direct package download..."
         try {
-            Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0 -ErrorAction Stop
+            $isArm64 = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq [System.Runtime.InteropServices.Architecture]::Arm64
+            $pkgName = if ($isArm64) { "OpenSSH-ARM64" } else { "OpenSSH-Win64" }
+            $zipUrl = "https://github.com/PowerShell/Win32-OpenSSH/releases/download/10.0.0.0p2-Preview/$pkgName.zip"
+            $zipPath = "$env:TEMP\$pkgName.zip"
+            [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+            Invoke-WebRequest -Uri $zipUrl -OutFile $zipPath -UseBasicParsing
+            Expand-Archive -Path $zipPath -DestinationPath "C:\Program Files" -Force
+            if (Test-Path "C:\Program Files\$pkgName") {
+                Rename-Item -Path "C:\Program Files\$pkgName" -NewName "OpenSSH" -Force
+            }
+            & "C:\Program Files\OpenSSH\install-sshd.ps1"
+            [Environment]::SetEnvironmentVariable("Path", $env:Path + ";C:\Program Files\OpenSSH", [EnvironmentVariableTarget]::Machine)
             $sshInstalled = $true
         } catch {
             Write-Host "Warning: Could not install OpenSSH Server: $_"
@@ -373,4 +387,36 @@ Set-Service -Name LanmanServer -StartupType Automatic -ErrorAction SilentlyConti
 Start-Service LanmanServer -ErrorAction SilentlyContinue
 Set-Service -Name LanmanWorkstation -StartupType Automatic -ErrorAction SilentlyContinue
 Start-Service LanmanWorkstation -ErrorAction SilentlyContinue
+
+# Install portable rsync for Vagrant synced folders
+Write-Host "Configuring rsync for Vagrant synced folders..."
+$rsyncDest = "C:\Windows\System32"
+if (!(Get-Command rsync.exe -ErrorAction SilentlyContinue)) {
+    try {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        $msysBase = "https://repo.msys2.org/msys/x86_64"
+        $pkgs = @(
+            "msys2-runtime-3.6.10-3-x86_64.pkg.tar.zst",
+            "libiconv-1.18-1-x86_64.pkg.tar.zst",
+            "liblz4-1.10.0-1-x86_64.pkg.tar.zst",
+            "libxxhash-0.8.3-1-x86_64.pkg.tar.zst",
+            "libzstd-1.5.7-1-x86_64.pkg.tar.zst",
+            "libopenssl-3.4.1-1-x86_64.pkg.tar.zst",
+            "rsync-3.4.1-1-x86_64.pkg.tar.zst"
+        )
+        $tmpDir = "$env:TEMP\rsync_setup"
+        New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
+        foreach ($pkg in $pkgs) {
+            Invoke-WebRequest -Uri "$msysBase/$pkg" -OutFile "$tmpDir\$pkg" -UseBasicParsing
+            tar.exe -xf "$tmpDir\$pkg" -C "$tmpDir"
+        }
+        Get-ChildItem -Path "$tmpDir\usr\bin" -Include "rsync.exe","msys-*.dll" -Recurse | ForEach-Object {
+            Copy-Item -Path $_.FullName -Destination $rsyncDest -Force
+        }
+        Remove-Item -Path $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+        Write-Host "rsync installed successfully."
+    } catch {
+        Write-Host "Warning: Failed to install rsync: $_"
+    }
+}
 

--- a/packer_templates/scripts/windows/remove-apps.ps1
+++ b/packer_templates/scripts/windows/remove-apps.ps1
@@ -30,8 +30,6 @@ trap {
     ($_.ScriptStackTrace -split '\r?\n') -replace '^(.*)$','ERROR: $1' | Write-Host
     ($_.Exception.ToString() -split '\r?\n') -replace '^(.*)$','ERROR EXCEPTION: $1' | Write-Host
     Write-Host
-    Write-Host 'Sleeping for 60m to give you time to look around the virtual machine before self-destruction...'
-    Start-Sleep -Seconds (60*60)
     Exit 1
 }
 

--- a/packer_templates/scripts/windows/remove-capabilities.ps1
+++ b/packer_templates/scripts/windows/remove-capabilities.ps1
@@ -1,61 +1,31 @@
-$selectors = @(
-    'Print.Fax.Scan'
-    'Language.Handwriting'
-    'Browser.InternetExplorer'
-    'MathRecognizer'
-    'OneCoreUAP.OneSync'
-    'Microsoft.Windows.MSPaint'
-    'App.Support.QuickAssist'
-    'Microsoft.Windows.SnippingTool'
-    'Language.Speech'
-    'Language.TextToSpeech'
-    'App.StepsRecorder'
-    'Hello.Face.18967'
-    'Hello.Face.Migration.18967'
-    'Hello.Face.20134'
-    'Media.WindowsMediaPlayer'
+$patterns = @(
+    'Print.Fax.Scan*'
+    'Print.Management.Console*'
+    'Language.Handwriting*'
+    'Language.Speech*'
+    'Language.TextToSpeech*'
+    'Language.OCR*'
+    'Browser.InternetExplorer*'
+    'MathRecognizer*'
+    'OneCoreUAP.OneSync*'
+    'Microsoft.Windows.MSPaint*'
+    'App.Support.QuickAssist*'
+    'Microsoft.Windows.SnippingTool*'
+    'App.StepsRecorder*'
+    'Hello.Face*'
+    'Media.WindowsMediaPlayer*'
+    'Microsoft.Windows.WordPad*'
 )
 
-$getCommand = {
-    Get-WindowsCapability -Online | Where-Object -Property 'State' -NotIn -Value @(
-        'NotPresent'
-        'Removed'
-    )
-}
-
-$filterCommand = {
-    ($_.Name -split '~')[0] -eq $selector
-}
-
-$removeCommand = {
-    [CmdletBinding()]
-    param(
-        [Parameter( Mandatory, ValueFromPipeline )]
-        $InputObject
-    )
-    process {
-        $InputObject | Remove-WindowsCapability -Online -ErrorAction 'Continue'
+Write-Host "Removing unneeded Windows Capabilities..."
+Get-WindowsCapability -Online | Where-Object {
+    $cap = $_
+    if ($cap.State -in @('NotPresent', 'Removed')) { return $false }
+    foreach ($p in $patterns) {
+        if ($cap.Name -like $p) { return $true }
     }
-}
-
-$type = 'Capability';
-$installed = & $getCommand;
-
-foreach( $selector in $selectors ) {
-    $result = [ordered] @{
-        Selector = $selector
-    }
-    $found = $installed | Where-Object -FilterScript $filterCommand
-    if( $found ) {
-        $result.Output = $found | & $removeCommand
-        if( $? ) {
-            $result.Message = "$type removed."
-        } else {
-            $result.Message = "$type not removed."
-            $result.Error = $Error[0]
-        }
-    } else {
-        $result.Message = "$type not installed."
-    }
-    $result | ConvertTo-Json -Depth 3 -Compress
+    return $false
+} | ForEach-Object {
+    Write-Host "Removing capability: $($_.Name)..."
+    $_ | Remove-WindowsCapability -Online -ErrorAction SilentlyContinue
 }

--- a/packer_templates/scripts/windows/remove-features.ps1
+++ b/packer_templates/scripts/windows/remove-features.ps1
@@ -1,8 +1,13 @@
 $selectors = @(
     'MediaPlayback'
     'MicrosoftWindowsPowerShellV2Root'
+    'MicrosoftWindowsPowerShellV2'
     'Recall'
     'Microsoft-SnippingTool'
+    'WorkFolders-Client'
+    'Printing-Foundation-Features'
+    'SmbDirect'
+    'MSRDC-Infrastructure'
 )
 
 $getCommand = {

--- a/packer_templates/scripts/windows/remove-one-drive-and-teams.ps1
+++ b/packer_templates/scripts/windows/remove-one-drive-and-teams.ps1
@@ -7,8 +7,6 @@ trap {
     ($_.ScriptStackTrace -split '\r?\n') -replace '^(.*)$','ERROR: $1' | Write-Host
     ($_.Exception.ToString() -split '\r?\n') -replace '^(.*)$','ERROR EXCEPTION: $1' | Write-Host
     Write-Host
-    Write-Host 'Sleeping for 60m to give you time to look around the virtual machine before self-destruction...'
-    Start-Sleep -Seconds (60*60)
     Exit 1
 }
 

--- a/packer_templates/scripts/windows/ui-tweaks.ps1
+++ b/packer_templates/scripts/windows/ui-tweaks.ps1
@@ -8,8 +8,6 @@ trap {
     ($_.ScriptStackTrace -split '\r?\n') -replace '^(.*)$','ERROR: $1' | Write-Host
     ($_.Exception.ToString() -split '\r?\n') -replace '^(.*)$','ERROR EXCEPTION: $1' | Write-Host
     Write-Host
-    Write-Host 'Sleeping for 60m to give you time to look around the virtual machine before self-destruction...'
-    Start-Sleep -Seconds (60*60)
     Exit 1
 }
 

--- a/packer_templates/vagrantfile-windows.template
+++ b/packer_templates/vagrantfile-windows.template
@@ -5,8 +5,11 @@ Vagrant.configure(2) do |config|
   config.vm.guest = :windows
   config.vm.communicator = "winrm"
   config.vm.boot_timeout = 300
+  config.vm.network :forwarded_port, guest: 22, host: 2222, id: 'ssh', auto_correct: true
   config.vm.network :forwarded_port, guest: 3389, host: 3389, id: 'rdp', auto_correct: true
   config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct: true
+  config.ssh.username = "vagrant"
+  config.ssh.password = "vagrant"
 
   config.vm.provider "virtualbox" do |vb|
     vb.cpus = 2
@@ -23,5 +26,9 @@ Vagrant.configure(2) do |config|
   config.vm.provider :libvirt do |domain|
     domain.memory = 4096
     domain.cpus = 2
+  end
+  config.vm.provider :qemu do |qe|
+    qe.memory = "4096"
+    qe.cpus = "2"
   end
 end

--- a/packer_templates/vagrantfile-windows.template
+++ b/packer_templates/vagrantfile-windows.template
@@ -4,31 +4,121 @@
 Vagrant.configure(2) do |config|
   config.vm.guest = :windows
   config.vm.communicator = "winrm"
-  config.vm.boot_timeout = 300
+  config.vm.boot_timeout = 600
+
+  config.winrm.username = "vagrant"
+  config.winrm.password = "vagrant"
+  config.ssh.username = "vagrant"
+  config.ssh.insert_key = false
+  config.ssh.private_key_path = File.expand_path("~/.vagrant.d/insecure_private_key")
+  config.ssh.shell = "powershell"
+
   config.vm.network :forwarded_port, guest: 22, host: 2222, id: 'ssh', auto_correct: true
   config.vm.network :forwarded_port, guest: 3389, host: 3389, id: 'rdp', auto_correct: true
   config.vm.network :forwarded_port, guest: 5985, host: 5985, id: "winrm", auto_correct: true
-  config.ssh.username = "vagrant"
-  config.ssh.password = "vagrant"
+
+  # Synced folder: rsync works without host privileges or password prompts
+  config.vm.synced_folder ".", "/vagrant", type: "rsync"
 
   config.vm.provider "virtualbox" do |vb|
-    vb.cpus = 2
+    vb.cpus = 4
     vb.memory = 4096
   end
 
   config.vm.provider 'hyperv' do |hv|
     hv.ip_address_timeout = 240
     hv.memory = 4096
-    hv.cpus = 2
+    hv.cpus = 4
     hv.enable_virtualization_extensions = true
   end
 
   config.vm.provider :libvirt do |domain|
     domain.memory = 4096
-    domain.cpus = 2
+    domain.cpus = 4
   end
+
+  is_darwin = /darwin/ =~ RUBY_PLATFORM
+  is_windows = /mswin|mingw|cygwin/ =~ RUBY_PLATFORM
+  accel = is_darwin ? "hvf" : (is_windows ? "whpx" : "kvm")
+
+  host_cpu = (RbConfig::CONFIG["host_cpu"] || RUBY_PLATFORM).downcase
+  is_arm = host_cpu =~ /aarch64|arm64/
+
   config.vm.provider :qemu do |qe|
-    qe.memory = "4096"
-    qe.cpus = "2"
+    if is_arm
+      qe.arch = "aarch64"
+      qe.machine = "virt,highmem=on,accel=#{accel}"
+      qe.cpu = "host"
+      qe.smp = "4"
+      qe.memory = "4096M"
+      qe.firmware_format = nil
+      qe.drive_interface = "none"
+      qe.net_device = "virtio-net-pci"
+      qe.ssh_auto_correct = true
+
+      bios_candidates = [
+        ENV["QEMU_EDK2_PATH"],
+        ENV["QEMU_BIOS"],
+        "/opt/homebrew/share/qemu/edk2-aarch64-code.fd",
+        "/usr/share/AAVMF/AAVMF_CODE.fd",
+        "/usr/share/AAVMF/AAVMF32_CODE.fd",
+        "/usr/share/qemu/edk2-aarch64-code.fd",
+        "/usr/share/edk2/aarch64/QEMU_EFI-pflash.raw",
+        "/usr/share/edk2/aarch64/QEMU_EFI.fd",
+        "/usr/share/edk2-armvirt/aarch64/QEMU_EFI.fd",
+        "/usr/local/share/qemu/edk2-aarch64-code.fd",
+        "/opt/local/share/qemu/edk2-aarch64-code.fd",
+        "C:/Program Files/qemu/share/edk2-aarch64-code.fd",
+        "C:/msys64/mingw64/share/qemu/edk2-aarch64-code.fd"
+      ].compact
+      bios_path = bios_candidates.find { |path| File.exist?(path) }
+
+      extra_args = []
+      extra_args.push("-bios", bios_path) if bios_path
+      extra_args.push(
+        "-device", "nvme,serial=nvme0,drive=disk0",
+        "-device", "ramfb",
+        "-device", "qemu-xhci",
+        "-device", "usb-kbd",
+        "-device", "usb-tablet"
+      )
+      qe.extra_qemu_args = extra_args
+    else
+      qe.arch = "x86_64"
+      qe.machine = "q35,accel=#{accel}"
+      qe.cpu = "host"
+      qe.smp = "4"
+      qe.memory = "4096M"
+      qe.drive_interface = "ide"
+      qe.net_device = "virtio-net-pci"
+      qe.ssh_auto_correct = true
+
+      ovmf_candidates = [
+        ENV["QEMU_EDK2_PATH"],
+        ENV["QEMU_BIOS"],
+        "/usr/share/OVMF/OVMF_CODE.fd",
+        "/usr/share/OVMF/OVMF_CODE_4M.fd",
+        "/usr/share/ovmf/OVMF.fd",
+        "/usr/share/edk2/ovmf/OVMF_CODE.fd",
+        "/usr/share/edk2-ovmf/x64/OVMF_CODE.fd",
+        "/opt/homebrew/share/qemu/edk2-x86_64-code.fd",
+        "/usr/local/share/qemu/edk2-x86_64-code.fd",
+        "/opt/local/share/qemu/edk2-x86_64-code.fd",
+        "/usr/share/qemu/edk2-x86_64-code.fd",
+        "C:/Program Files/qemu/share/edk2-x86_64-code.fd",
+        "C:/msys64/mingw64/share/qemu/edk2-x86_64-code.fd"
+      ].compact
+      ovmf_path = ovmf_candidates.find { |path| File.exist?(path) }
+
+      extra_args = []
+      extra_args.push("-bios", ovmf_path) if ovmf_path
+      extra_args.push(
+        "-device", "qemu-xhci",
+        "-device", "usb-kbd",
+        "-device", "usb-tablet",
+        "-vga", "std"
+      )
+      qe.extra_qemu_args = extra_args
+    end
   end
 end

--- a/packer_templates/vagrantfile-windows.template
+++ b/packer_templates/vagrantfile-windows.template
@@ -76,7 +76,8 @@ Vagrant.configure(2) do |config|
       extra_args = []
       extra_args.push("-bios", bios_path) if bios_path
       extra_args.push(
-        "-device", "nvme,serial=nvme0,drive=disk0",
+        "-device", "pcie-root-port,id=pcie.1,chassis=1,slot=1",
+        "-device", "nvme,serial=nvme0,drive=disk0,bus=pcie.1",
         "-device", "ramfb",
         "-device", "qemu-xhci",
         "-device", "usb-kbd",

--- a/packer_templates/win_answer_files/11/Autounattend.xml
+++ b/packer_templates/win_answer_files/11/Autounattend.xml
@@ -1,44 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <settings pass="windowsPE">
-        <component name="Microsoft-Windows-PnpCustomizationsWinPE" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" processorArchitecture="amd64">
-            <!--
-                 This makes the VirtIO drivers available to Windows, assuming that
-                 the VirtIO driver disk at https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/stable-virtio/virtio-win.iso
-                 (see https://docs.fedoraproject.org/en-US/quick-docs/creating-windows-virtual-machines-using-virtio-drivers/index.html#virtio-win-direct-downloads)
-                 is available as drive F:
-            -->
+    <settings pass="offlineServicing">
+        <component name="Microsoft-Windows-LUA-Settings" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <EnableLUA>false</EnableLUA>
+        </component>
+        <component name="Microsoft-Windows-PnpCustomizationsNonWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
             <DriverPaths>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="2">
-                    <Path>F:\viostor\w11\amd64</Path>
-                </PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="3">
-                    <Path>F:\NetKVM\w11\amd64</Path>
-                </PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="4">
-                    <Path>F:\Balloon\w11\amd64</Path>
-                </PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="5">
-                    <Path>F:\pvpanic\w11\amd64</Path>
-                </PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="6">
-                    <Path>F:\qemupciserial\w11\amd64</Path>
-                </PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="7">
-                    <Path>F:\qxldod\w11\amd64</Path>
-                </PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="8">
-                    <Path>F:\vioinput\w11\amd64</Path>
-                </PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="9">
-                    <Path>F:\viorng\w11\amd64</Path>
-                </PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="10">
-                    <Path>F:\vioscsi\w11\amd64</Path>
-                </PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="11">
-                    <Path>F:\vioserial\w11\amd64</Path>
-                </PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="1"><Path>D:\NetKVM\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="2"><Path>D:\Balloon\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="3"><Path>D:\pvpanic\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="4"><Path>D:\vioserial\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="5"><Path>D:\vioinput\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="6"><Path>D:\viorng\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="7"><Path>D:\viofs\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="8"><Path>D:\viogpudo\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="9"><Path>D:\viomem\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="10"><Path>D:\viostor\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="11"><Path>D:\vioscsi\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="12"><Path>E:\NetKVM\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="13"><Path>E:\Balloon\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="14"><Path>E:\pvpanic\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="15"><Path>E:\vioserial\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="16"><Path>E:\vioinput\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="17"><Path>E:\viorng\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="18"><Path>E:\viofs\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="19"><Path>E:\viogpudo\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="20"><Path>E:\viomem\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="21"><Path>E:\viostor\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="22"><Path>E:\vioscsi\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="23"><Path>F:\NetKVM\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="24"><Path>F:\Balloon\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="25"><Path>F:\pvpanic\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="26"><Path>F:\vioserial\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="27"><Path>F:\vioinput\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="28"><Path>F:\viorng\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="29"><Path>F:\viofs\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="30"><Path>F:\viogpudo\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="31"><Path>F:\viomem\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="32"><Path>F:\viostor\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="33"><Path>F:\vioscsi\w11\amd64</Path></PathAndCredentials>
+            </DriverPaths>
+        </component>
+    </settings>
+    <settings pass="windowsPE">
+        <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <DriverPaths>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="1"><Path>D:\viostor\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="2"><Path>E:\viostor\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="3"><Path>F:\viostor\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="4"><Path>D:\vioscsi\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="5"><Path>E:\vioscsi\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="6"><Path>F:\vioscsi\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="7"><Path>D:\NetKVM\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="8"><Path>E:\NetKVM\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="9"><Path>F:\NetKVM\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="10"><Path>D:\Balloon\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="11"><Path>E:\Balloon\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="12"><Path>F:\Balloon\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="13"><Path>D:\pvpanic\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="14"><Path>E:\pvpanic\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="15"><Path>F:\pvpanic\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="16"><Path>D:\vioserial\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="17"><Path>E:\vioserial\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="18"><Path>F:\vioserial\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="19"><Path>D:\vioinput\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="20"><Path>E:\vioinput\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="21"><Path>F:\vioinput\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="22"><Path>D:\viorng\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="23"><Path>E:\viorng\w11\amd64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="24"><Path>F:\viorng\w11\amd64</Path></PathAndCredentials>
             </DriverPaths>
         </component>
         <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
@@ -102,45 +132,64 @@
             </DiskConfiguration>
             <ImageInstall>
                 <OSImage>
+                    <InstallFrom>
+                        <MetaData wcm:action="add">
+                            <Key>/IMAGE/INDEX</Key>
+                            <Value>1</Value>
+                        </MetaData>
+                    </InstallFrom>
                     <InstallTo>
                         <DiskID>0</DiskID>
                         <PartitionID>3</PartitionID>
                     </InstallTo>
+                    <Compact>true</Compact>
                 </OSImage>
             </ImageInstall>
             <UserData>
                 <ProductKey>
-                    <!-- Public Trial license key -->
-                    <Key>XGVPP-NMH47-7TTHJ-W3FW7-8HV2C</Key>
-                    <WillShowUI>OnError</WillShowUI>
+                    %{ if windows_product_key != "" }<Key>${windows_product_key}</Key>%{ endif }
+                    <WillShowUI>Never</WillShowUI>
                 </ProductKey>
                 <AcceptEula>true</AcceptEula>
+                <FullName>vagrant</FullName>
+                <Organization>vagrant</Organization>
             </UserData>
+            <DynamicUpdate>
+                <Enable>false</Enable>
+            </DynamicUpdate>
             <UseConfigurationSet>false</UseConfigurationSet>
             <RunSynchronous>
                 <RunSynchronousCommand wcm:action="add">
                     <Order>1</Order>
-                    <Path>cmd.exe /c "&gt;&gt;"X:\diskpart.txt" (echo SELECT DISK=0&amp;echo CLEAN&amp;echo CONVERT GPT&amp;echo CREATE PARTITION EFI SIZE=100&amp;echo FORMAT QUICK FS=FAT32 LABEL="System"&amp;echo CREATE PARTITION MSR SIZE=16)"</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>2</Order>
-                    <Path>cmd.exe /c "&gt;&gt;"X:\diskpart.txt" (echo CREATE PARTITION PRIMARY&amp;echo FORMAT QUICK FS=NTFS LABEL="Windows")"</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>3</Order>
-                    <Path>cmd.exe /c "diskpart.exe /s "X:\diskpart.txt" &gt;&gt;"X:\diskpart.log" || ( type "X:\diskpart.log" &amp; echo diskpart encountered an error. &amp; pause &amp; exit /b 1 )"</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>4</Order>
                     <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassTPMCheck /t REG_DWORD /d 1 /f</Path>
                 </RunSynchronousCommand>
                 <RunSynchronousCommand wcm:action="add">
-                    <Order>5</Order>
+                    <Order>2</Order>
                     <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassSecureBootCheck /t REG_DWORD /d 1 /f</Path>
                 </RunSynchronousCommand>
                 <RunSynchronousCommand wcm:action="add">
-                    <Order>6</Order>
+                    <Order>3</Order>
                     <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassRAMCheck /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>4</Order>
+                    <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassCPUCheck /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>5</Order>
+                    <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassStorageCheck /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>6</Order>
+                    <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassDiskCheck /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>7</Order>
+                    <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassNRO /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>8</Order>
+                    <Path>reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\OOBE" /v BypassNRO /t REG_DWORD /d 1 /f</Path>
                 </RunSynchronousCommand>
             </RunSynchronous>
         </component>
@@ -152,6 +201,157 @@
         <component name="Microsoft-Windows-PnpSysprep" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
             <PersistAllDeviceInstalls>false</PersistAllDeviceInstalls>
             <DoNotCleanUpNonPresentDevices>false</DoNotCleanUpNonPresentDevices>
+        </component>
+    </settings>
+    <settings pass="specialize">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <ComputerName>vagrant</ComputerName>
+            <TimeZone>UTC</TimeZone>
+        </component>
+        <component name="Microsoft-Windows-TerminalServices-LocalSessionManager" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <fDenyTSConnections>false</fDenyTSConnections>
+        </component>
+        <component name="Microsoft-Windows-TerminalServices-RDP-WinStationExtensions" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <UserAuthentication>0</UserAuthentication>
+        </component>
+        <component name="Microsoft-Windows-SystemRestore-Main" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <DisableSR>1</DisableSR>
+        </component>
+        <component name="Microsoft-Windows-SystemSettingsThreshold" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <DisplayNetworkSelection>false</DisplayNetworkSelection>
+        </component>
+        <component name="Networking-MPSSVC-Svc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <FirewallGroups>
+                <FirewallGroup wcm:action="add" wcm:keyValue="WindowsRemoteManagement">
+                    <Active>true</Active>
+                    <Group>Windows Remote Management</Group>
+                    <Profile>all</Profile>
+                </FirewallGroup>
+                <FirewallGroup wcm:action="add" wcm:keyValue="RemoteAdministration">
+                    <Active>true</Active>
+                    <Group>Remote Administration</Group>
+                    <Profile>all</Profile>
+                </FirewallGroup>
+                <FirewallGroup wcm:action="add" wcm:keyValue="RemoteDesktop">
+                    <Active>true</Active>
+                    <Group>Remote Desktop</Group>
+                    <Profile>all</Profile>
+                </FirewallGroup>
+            </FirewallGroups>
+        </component>
+        <component name="Microsoft-Windows-SQMApi" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <CEIPEnabled>0</CEIPEnabled>
+        </component>
+        <component name="Microsoft-Windows-Security-SPP-UX" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <SkipAutoActivation>true</SkipAutoActivation>
+        </component>
+        <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <RunSynchronous>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>1</Order>
+                    <Path>cmd.exe /c "if not exist C:\Windows\Setup\Scripts mkdir C:\Windows\Setup\Scripts &amp; for %d in (c d e f g) do if exist %d:\SetupComplete.cmd copy /y %d:\SetupComplete.cmd C:\Windows\Setup\Scripts\SetupComplete.cmd"</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>2</Order>
+                    <Path>cmd.exe /c reg.exe add "HKLM\SYSTEM\Setup\MoSetup" /v AllowUpgradesWithUnsupportedTPMOrCPU /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>3</Order>
+                    <Path>cmd.exe /c reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v EnableLUA /t REG_DWORD /d 0 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>4</Order>
+                    <Path>cmd.exe /c reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v LocalAccountTokenFilterPolicy /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>5</Order>
+                    <Path>cmd.exe /c reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v ConsentPromptBehaviorAdmin /t REG_DWORD /d 0 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>6</Order>
+                    <Path>cmd.exe /c reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service" /v AllowBasic /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>7</Order>
+                    <Path>cmd.exe /c reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service" /v AllowUnencryptedTraffic /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>8</Order>
+                    <Path>cmd.exe /c reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client" /v AllowBasic /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>9</Order>
+                    <Path>cmd.exe /c reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client" /v AllowUnencryptedTraffic /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>10</Order>
+                    <Path>cmd.exe /c netsh advfirewall firewall add rule name="Port 5985" dir=in action=allow protocol=TCP localport=5985</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>11</Order>
+                    <Path>cmd.exe /c sc.exe config winrm start= auto</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>12</Order>
+                    <Path>cmd.exe /c net.exe start winrm</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>13</Order>
+                    <Path>cmd.exe /c winrm quickconfig -q</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>14</Order>
+                    <Path>cmd.exe /c winrm quickconfig -transport:http</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>15</Order>
+                    <Path>cmd.exe /c winrm set winrm/config @{MaxTimeoutms="1800000"}</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>16</Order>
+                    <Path>cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="2048"}</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>17</Order>
+                    <Path>cmd.exe /c winrm set winrm/config/service @{AllowUnencrypted="true"}</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>18</Order>
+                    <Path>cmd.exe /c winrm set winrm/config/service/auth @{Basic="true"}</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>19</Order>
+                    <Path>cmd.exe /c winrm set winrm/config/client/auth @{Basic="true"}</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>20</Order>
+                    <Path>cmd.exe /c winrm set "winrm/config/listener?Address=*+Transport=HTTP" @{Port="5985"}</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>21</Order>
+                    <Path>cmd.exe /c powercfg.exe /hibernate off</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>22</Order>
+                    <Path>cmd.exe /c reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\ReserveManager" /v ShippedWithReserves /t REG_DWORD /d 0 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>23</Order>
+                    <Path>cmd.exe /c reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\ReserveManager" /v PassedPolicy /t REG_DWORD /d 0 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>24</Order>
+                    <Path>cmd.exe /c bcdedit.exe /ems {current} off</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>25</Order>
+                    <Path>cmd.exe /c bcdedit.exe /bootems off</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>26</Order>
+                    <Path>cmd.exe /c "echo [WIN11-SERIAL] Specialize Pass WinRM and Serial Ready > COM1 || exit 0"</Path>
+                </RunSynchronousCommand>
+            </RunSynchronous>
         </component>
     </settings>
     <settings pass="oobeSystem">
@@ -192,7 +392,7 @@
                         </Password>
                         <Description>Vagrant User</Description>
                         <DisplayName>vagrant</DisplayName>
-                        <Group>administrators</Group>
+                        <Group>Administrators</Group>
                         <Name>vagrant</Name>
                     </LocalAccount>
                 </LocalAccounts>
@@ -202,142 +402,139 @@
                     <Value>vagrant</Value>
                     <PlainText>true</PlainText>
                 </Password>
-                <Username>vagrant</Username>
+                <Username>Administrator</Username>
                 <Enabled>true</Enabled>
             </AutoLogon>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>%windir%\System32\WindowsPowerShell\v1.0\powershell.exe -Command "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force"</CommandLine>
-                    <Description>Set Execution Policy 64 Bit</Description>
                     <Order>1</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c net.exe user vagrant /active:yes</CommandLine>
+                    <Description>Enable vagrant user</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>%windir%\SysWOW64\cmd.exe /c powershell -Command "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force"</CommandLine>
-                    <Description>Set Execution Policy 32 Bit</Description>
                     <Order>2</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c net.exe user Administrator /active:yes</CommandLine>
+                    <Description>Enable Administrator user</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>3</Order>
-                    <CommandLine>%windir%\System32\WindowsPowerShell\v1.0\powershell.exe -Command Get-NetConnectionProfile | Set-NetConnectionProfile -NetworkCategory "Private"</CommandLine>
-                    <Description>Sets detected network connections to private to allow start of winrm</Description>
+                    <CommandLine>%windir%\System32\cmd.exe /c net.exe user Administrator vagrant</CommandLine>
+                    <Description>Set Administrator password</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>4</Order>
-                    <CommandLine>%windir%\System32\WindowsPowerShell\v1.0\powershell.exe -Command Set-NetFirewallRule -Name "WINRM-HTTP-In-TCP" -RemoteAddress Any</CommandLine>
-                    <Description>Allows winrm over public profile interfaces</Description>
+                    <CommandLine>%windir%\System32\cmd.exe /c net.exe localgroup Administrators vagrant /add</CommandLine>
+                    <Description>Add vagrant to Administrators</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>5</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c net.exe user vagrant /expires:never</CommandLine>
+                    <Description>Disable password expiration for vagrant user</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>6</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c net.exe user Administrator /expires:never</CommandLine>
+                    <Description>Disable password expiration for Administrator user</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>7</Order>
+                    <CommandLine>%windir%\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -NoProfile -Command "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force"</CommandLine>
+                    <Description>Set Execution Policy 64 Bit</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>8</Order>
+                    <CommandLine>%windir%\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -NoProfile -Command "Get-NetConnectionProfile | Set-NetConnectionProfile -NetworkCategory Private"</CommandLine>
+                    <Description>Sets detected network connections to private</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>9</Order>
                     <CommandLine>%windir%\System32\cmd.exe /c winrm quickconfig -q</CommandLine>
                     <Description>winrm quickconfig -q</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>6</Order>
+                    <Order>10</Order>
                     <CommandLine>%windir%\System32\cmd.exe /c winrm quickconfig -transport:http</CommandLine>
                     <Description>winrm quickconfig -transport:http</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>7</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config @{MaxTimeoutms="1800000"}</CommandLine>
-                    <Description>Win RM MaxTimoutms</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <Order>8</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="2048"}</CommandLine>
-                    <Description>Win RM MaxMemoryPerShellMB</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <Order>9</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/service @{AllowUnencrypted="true"}</CommandLine>
-                    <Description>Win RM AllowUnencrypted</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <Order>10</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/service/auth @{Basic="true"}</CommandLine>
-                    <Description>Win RM auth Basic</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
                     <Order>11</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/client/auth @{Basic="true"}</CommandLine>
-                    <Description>Win RM client auth Basic</Description>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config @{MaxTimeoutms="1800000"}</CommandLine>
+                    <Description>WinRM MaxTimeoutms</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>12</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/listener?Address=*+Transport=HTTP @{Port="5985"}</CommandLine>
-                    <Description>Win RM listener Address/Port</Description>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="2048"}</CommandLine>
+                    <Description>WinRM MaxMemoryPerShellMB</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>13</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c netsh firewall add portopening TCP 5985 "Port 5985"</CommandLine>
-                    <Description>Win RM port open</Description>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/service @{AllowUnencrypted="true"}</CommandLine>
+                    <Description>WinRM AllowUnencrypted</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>14</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c net stop winrm</CommandLine>
-                    <Description>Stop Win RM Service</Description>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/service/auth @{Basic="true"}</CommandLine>
+                    <Description>WinRM auth Basic</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>15</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c sc config winrm start= auto</CommandLine>
-                    <Description>Win RM Autostart</Description>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/client/auth @{Basic="true"}</CommandLine>
+                    <Description>WinRM client auth Basic</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>16</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c net start winrm</CommandLine>
-                    <Description>Start Win RM Service</Description>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set "winrm/config/listener?Address=*+Transport=HTTP" @{Port="5985"}</CommandLine>
+                    <Description>WinRM listener Address/Port</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>17</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c wmic useraccount where "name='vagrant'" set PasswordExpires=FALSE</CommandLine>
-                    <Description>Disable password expiration for vagrant user</Description>
+                    <CommandLine>%windir%\System32\cmd.exe /c netsh advfirewall firewall add rule name="Port 5985" dir=in action=allow protocol=TCP localport=5985</CommandLine>
+                    <Description>Open Port 5985 in Firewall</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>%SystemRoot%\System32\reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v DefaultPassword /t REG_SZ /d "vagrant" /f</CommandLine>
                     <Order>18</Order>
-                    <Description>Enable AutoLogon</Description>
+                    <CommandLine>%windir%\System32\cmd.exe /c sc config winrm start= auto</CommandLine>
+                    <Description>WinRM Autostart</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>%SystemRoot%\System32\reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v AutoAdminLogon /t REG_SZ /d 1 /f</CommandLine>
                     <Order>19</Order>
-                    <Description>Enable AutoLogon</Description>
+                    <CommandLine>%windir%\System32\cmd.exe /c net start winrm</CommandLine>
+                    <Description>Start WinRM Service</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>20</Order>
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v DefaultPassword /t REG_SZ /d "vagrant" /f</CommandLine>
+                    <Description>Enable AutoLogon DefaultPassword</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>21</Order>
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v DefaultUsername /t REG_SZ /d "vagrant" /f</CommandLine>
+                    <Description>Enable AutoLogon DefaultUsername</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>22</Order>
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v AutoAdminLogon /t REG_SZ /d 1 /f</CommandLine>
+                    <Description>Enable AutoLogon AutoAdminLogon</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>23</Order>
+                    <CommandLine>%SystemRoot%\System32\bcdedit.exe /ems {current} off</CommandLine>
+                    <Description>Disable Kernel EMS to release COM1</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>24</Order>
+                    <CommandLine>%SystemRoot%\System32\bcdedit.exe /bootems off</CommandLine>
+                    <Description>Disable Boot EMS</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>25</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c "echo [WIN11-SERIAL] WinRM and Serial Ready > COM1 || exit 0"</CommandLine>
+                    <Description>Notify COM1 Serial</Description>
                 </SynchronousCommand>
             </FirstLogonCommands>
         </component>
         <component name="Microsoft-Windows-WinRE-RecoveryAgent" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
             <UninstallWindowsRE>true</UninstallWindowsRE>
-        </component>
-    </settings>
-    <settings pass="specialize">
-        <component name="Microsoft-Windows-SystemRestore-Main" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-            <DisableSR>1</DisableSR>
-        </component>
-        <component name="Microsoft-Windows-SystemSettingsThreshold" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-            <DisplayNetworkSelection>false</DisplayNetworkSelection>
-        </component>
-        <component name="Networking-MPSSVC-Svc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-            <FirewallGroups>
-                <FirewallGroup wcm:action="add" wcm:keyValue="WindowsRemoteManagement">
-                    <Active>true</Active>
-                    <Group>Windows Remote Management</Group>
-                    <Profile>all</Profile>
-                </FirewallGroup>
-                <FirewallGroup wcm:action="add" wcm:keyValue="RemoteAdministration">
-                    <Active>true</Active>
-                    <Group>Remote Administration</Group>
-                    <Profile>all</Profile>
-                </FirewallGroup>
-            </FirewallGroups>
-        </component>
-        <component name="Microsoft-Windows-SQMApi" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-            <CEIPEnabled>0</CEIPEnabled>
-        </component>
-        <component name="Microsoft-Windows-Security-SPP-UX" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-            <SkipAutoActivation>true</SkipAutoActivation>
-        </component>
-    </settings>
-    <settings pass="offlineServicing">
-        <component name="Microsoft-Windows-LUA-Settings" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-            <EnableLUA>false</EnableLUA>
         </component>
     </settings>
 </unattend>

--- a/packer_templates/win_answer_files/11/Autounattend.xml
+++ b/packer_templates/win_answer_files/11/Autounattend.xml
@@ -249,7 +249,7 @@
             <RunSynchronous>
                 <RunSynchronousCommand wcm:action="add">
                     <Order>1</Order>
-                    <Path>cmd.exe /c "if not exist C:\Windows\Setup\Scripts mkdir C:\Windows\Setup\Scripts &amp; for %d in (c d e f g) do if exist %d:\SetupComplete.cmd copy /y %d:\SetupComplete.cmd C:\Windows\Setup\Scripts\SetupComplete.cmd"</Path>
+                    <Path>cmd.exe /c "if not exist C:\Windows\Setup\Scripts mkdir C:\Windows\Setup\Scripts &amp; for %d in (C D E F G H I J K) do if exist %d:\SetupComplete.cmd copy /y %d:\SetupComplete.cmd C:\Windows\Setup\Scripts\SetupComplete.cmd"</Path>
                 </RunSynchronousCommand>
                 <RunSynchronousCommand wcm:action="add">
                     <Order>2</Order>
@@ -289,67 +289,35 @@
                 </RunSynchronousCommand>
                 <RunSynchronousCommand wcm:action="add">
                     <Order>11</Order>
-                    <Path>cmd.exe /c sc.exe config winrm start= auto</Path>
+                    <Path>cmd.exe /c net.exe accounts /lockoutthreshold:0</Path>
                 </RunSynchronousCommand>
                 <RunSynchronousCommand wcm:action="add">
                     <Order>12</Order>
-                    <Path>cmd.exe /c net.exe start winrm</Path>
+                    <Path>cmd.exe /c net.exe user Administrator /active:yes</Path>
                 </RunSynchronousCommand>
                 <RunSynchronousCommand wcm:action="add">
                     <Order>13</Order>
-                    <Path>cmd.exe /c winrm quickconfig -q</Path>
+                    <Path>cmd.exe /c net.exe user Administrator vagrant</Path>
                 </RunSynchronousCommand>
                 <RunSynchronousCommand wcm:action="add">
                     <Order>14</Order>
-                    <Path>cmd.exe /c winrm quickconfig -transport:http</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>15</Order>
-                    <Path>cmd.exe /c winrm set winrm/config @{MaxTimeoutms="1800000"}</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>16</Order>
-                    <Path>cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="2048"}</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>17</Order>
-                    <Path>cmd.exe /c winrm set winrm/config/service @{AllowUnencrypted="true"}</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>18</Order>
-                    <Path>cmd.exe /c winrm set winrm/config/service/auth @{Basic="true"}</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>19</Order>
-                    <Path>cmd.exe /c winrm set winrm/config/client/auth @{Basic="true"}</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>20</Order>
-                    <Path>cmd.exe /c winrm set "winrm/config/listener?Address=*+Transport=HTTP" @{Port="5985"}</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>21</Order>
                     <Path>cmd.exe /c powercfg.exe /hibernate off</Path>
                 </RunSynchronousCommand>
                 <RunSynchronousCommand wcm:action="add">
-                    <Order>22</Order>
+                    <Order>15</Order>
                     <Path>cmd.exe /c reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\ReserveManager" /v ShippedWithReserves /t REG_DWORD /d 0 /f</Path>
                 </RunSynchronousCommand>
                 <RunSynchronousCommand wcm:action="add">
-                    <Order>23</Order>
+                    <Order>16</Order>
                     <Path>cmd.exe /c reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\ReserveManager" /v PassedPolicy /t REG_DWORD /d 0 /f</Path>
                 </RunSynchronousCommand>
                 <RunSynchronousCommand wcm:action="add">
-                    <Order>24</Order>
+                    <Order>17</Order>
                     <Path>cmd.exe /c bcdedit.exe /ems {current} off</Path>
                 </RunSynchronousCommand>
                 <RunSynchronousCommand wcm:action="add">
-                    <Order>25</Order>
+                    <Order>18</Order>
                     <Path>cmd.exe /c bcdedit.exe /bootems off</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>26</Order>
-                    <Path>cmd.exe /c "echo [WIN11-SERIAL] Specialize Pass WinRM and Serial Ready > COM1 || exit 0"</Path>
                 </RunSynchronousCommand>
             </RunSynchronous>
         </component>
@@ -402,8 +370,9 @@
                     <Value>vagrant</Value>
                     <PlainText>true</PlainText>
                 </Password>
-                <Username>Administrator</Username>
+                <Username>vagrant</Username>
                 <Enabled>true</Enabled>
+                <LogonCount>5</LogonCount>
             </AutoLogon>
             <FirstLogonCommands>
                 <SynchronousCommand wcm:action="add">
@@ -413,23 +382,23 @@
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>2</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c net.exe user vagrant vagrant</CommandLine>
+                    <Description>Set vagrant password</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>3</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c net.exe user vagrant /expires:never</CommandLine>
+                    <Description>Disable password expiration for vagrant user</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>4</Order>
                     <CommandLine>%windir%\System32\cmd.exe /c net.exe user Administrator /active:yes</CommandLine>
                     <Description>Enable Administrator user</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>3</Order>
+                    <Order>5</Order>
                     <CommandLine>%windir%\System32\cmd.exe /c net.exe user Administrator vagrant</CommandLine>
                     <Description>Set Administrator password</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <Order>4</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c net.exe localgroup Administrators vagrant /add</CommandLine>
-                    <Description>Add vagrant to Administrators</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <Order>5</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c net.exe user vagrant /expires:never</CommandLine>
-                    <Description>Disable password expiration for vagrant user</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>6</Order>
@@ -438,96 +407,131 @@
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>7</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c net.exe localgroup Administrators vagrant /add</CommandLine>
+                    <Description>Add vagrant to Administrators</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>8</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c net.exe localgroup Administrators Administrator /add</CommandLine>
+                    <Description>Add Administrator to Administrators</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>9</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c net.exe accounts /lockoutthreshold:0</CommandLine>
+                    <Description>Disable Account Lockout</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>10</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v LocalAccountTokenFilterPolicy /t REG_DWORD /d 1 /f</CommandLine>
+                    <Description>Disable Remote UAC</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>11</Order>
                     <CommandLine>%windir%\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -NoProfile -Command "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force"</CommandLine>
                     <Description>Set Execution Policy 64 Bit</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>8</Order>
-                    <CommandLine>%windir%\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -NoProfile -Command "Get-NetConnectionProfile | Set-NetConnectionProfile -NetworkCategory Private"</CommandLine>
+                    <Order>12</Order>
+                    <CommandLine>%windir%\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -NoProfile -Command "$ErrorActionPreference = 'SilentlyContinue'; Get-NetConnectionProfile | Set-NetConnectionProfile -NetworkCategory Private"</CommandLine>
                     <Description>Sets detected network connections to private</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>9</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c winrm quickconfig -q</CommandLine>
-                    <Description>winrm quickconfig -q</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <Order>10</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c winrm quickconfig -transport:http</CommandLine>
-                    <Description>winrm quickconfig -transport:http</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <Order>11</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config @{MaxTimeoutms="1800000"}</CommandLine>
-                    <Description>WinRM MaxTimeoutms</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <Order>12</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="2048"}</CommandLine>
-                    <Description>WinRM MaxMemoryPerShellMB</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
                     <Order>13</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/service @{AllowUnencrypted="true"}</CommandLine>
-                    <Description>WinRM AllowUnencrypted</Description>
+                    <CommandLine>%windir%\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -NoProfile -Command "$ErrorActionPreference = 'SilentlyContinue'; Set-NetFirewallRule -Name 'WINRM-HTTP-In-TCP' -RemoteAddress Any; New-NetFirewallRule -DisplayName 'WinRM HTTP' -Name 'WINRM-HTTP-In-TCP' -Profile Any -LocalPort 5985 -Protocol TCP -Action Allow -Direction Inbound"</CommandLine>
+                    <Description>Allow WinRM firewall rule</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>14</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/service/auth @{Basic="true"}</CommandLine>
-                    <Description>WinRM auth Basic</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <Order>15</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/client/auth @{Basic="true"}</CommandLine>
-                    <Description>WinRM client auth Basic</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <Order>16</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c winrm set "winrm/config/listener?Address=*+Transport=HTTP" @{Port="5985"}</CommandLine>
-                    <Description>WinRM listener Address/Port</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <Order>17</Order>
                     <CommandLine>%windir%\System32\cmd.exe /c netsh advfirewall firewall add rule name="Port 5985" dir=in action=allow protocol=TCP localport=5985</CommandLine>
                     <Description>Open Port 5985 in Firewall</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
+                    <Order>15</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm quickconfig -q -force</CommandLine>
+                    <Description>winrm quickconfig</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>16</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm quickconfig -transport:http</CommandLine>
+                    <Description>winrm quickconfig -transport:http</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>17</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config @{MaxTimeoutms="1800000"}</CommandLine>
+                    <Description>WinRM MaxTimeoutms</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
                     <Order>18</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="2048"}</CommandLine>
+                    <Description>WinRM MaxMemoryPerShellMB</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>19</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/service @{AllowUnencrypted="true"}</CommandLine>
+                    <Description>WinRM AllowUnencrypted</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>20</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/service/auth @{Basic="true"}</CommandLine>
+                    <Description>WinRM auth Basic</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>21</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/service/auth @{Negotiate="true"}</CommandLine>
+                    <Description>WinRM auth Negotiate</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>22</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/client/auth @{Basic="true"}</CommandLine>
+                    <Description>WinRM client auth Basic</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>23</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/client/auth @{Negotiate="true"}</CommandLine>
+                    <Description>WinRM client auth Negotiate</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>24</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set "winrm/config/listener?Address=*+Transport=HTTP" @{Port="5985"}</CommandLine>
+                    <Description>WinRM listener Address/Port</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>25</Order>
                     <CommandLine>%windir%\System32\cmd.exe /c sc config winrm start= auto</CommandLine>
                     <Description>WinRM Autostart</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>19</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c net start winrm</CommandLine>
-                    <Description>Start WinRM Service</Description>
+                    <Order>26</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c "net stop winrm &amp; net start winrm || exit 0"</CommandLine>
+                    <Description>Restart WinRM Service</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>20</Order>
+                    <Order>27</Order>
                     <CommandLine>%SystemRoot%\System32\reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v DefaultPassword /t REG_SZ /d "vagrant" /f</CommandLine>
                     <Description>Enable AutoLogon DefaultPassword</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>21</Order>
+                    <Order>28</Order>
                     <CommandLine>%SystemRoot%\System32\reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v DefaultUsername /t REG_SZ /d "vagrant" /f</CommandLine>
                     <Description>Enable AutoLogon DefaultUsername</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>22</Order>
+                    <Order>29</Order>
                     <CommandLine>%SystemRoot%\System32\reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v AutoAdminLogon /t REG_SZ /d 1 /f</CommandLine>
                     <Description>Enable AutoLogon AutoAdminLogon</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>23</Order>
+                    <Order>30</Order>
                     <CommandLine>%SystemRoot%\System32\bcdedit.exe /ems {current} off</CommandLine>
                     <Description>Disable Kernel EMS to release COM1</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>24</Order>
+                    <Order>31</Order>
                     <CommandLine>%SystemRoot%\System32\bcdedit.exe /bootems off</CommandLine>
                     <Description>Disable Boot EMS</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>25</Order>
+                    <Order>32</Order>
                     <CommandLine>%windir%\System32\cmd.exe /c "echo [WIN11-SERIAL] WinRM and Serial Ready > COM1 || exit 0"</CommandLine>
                     <Description>Notify COM1 Serial</Description>
                 </SynchronousCommand>

--- a/packer_templates/win_answer_files/11/SetupComplete.cmd
+++ b/packer_templates/win_answer_files/11/SetupComplete.cmd
@@ -1,0 +1,54 @@
+@echo off
+:: Windows 11 Post-Setup Bootstrap Script (runs as NT AUTHORITY\SYSTEM)
+echo [WIN11-SETUPCOMPLETE] Starting SetupComplete bootstrap... > COM1
+
+:: Ensure Administrator and vagrant accounts are enabled, in Administrators group, with password vagrant
+net.exe user Administrator /active:yes
+net.exe user Administrator vagrant
+net.exe user vagrant /active:yes
+net.exe user vagrant vagrant
+net.exe localgroup Administrators vagrant /add
+net.exe localgroup Administrators Administrator /add
+
+:: Configure registry security policies
+reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v LocalAccountTokenFilterPolicy /t REG_DWORD /d 1 /f
+reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v EnableLUA /t REG_DWORD /d 0 /f
+reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v ConsentPromptBehaviorAdmin /t REG_DWORD /d 0 /f
+reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service" /v AllowBasic /t REG_DWORD /d 1 /f
+reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service" /v AllowUnencryptedTraffic /t REG_DWORD /d 1 /f
+reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client" /v AllowBasic /t REG_DWORD /d 1 /f
+reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client" /v AllowUnencryptedTraffic /t REG_DWORD /d 1 /f
+
+:: Set network category to private
+powershell.exe -ExecutionPolicy Bypass -NoProfile -Command "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force"
+powershell.exe -ExecutionPolicy Bypass -NoProfile -Command "Get-NetConnectionProfile | Set-NetConnectionProfile -NetworkCategory Private"
+
+:: Firewall
+netsh advfirewall firewall add rule name="Port 5985" dir=in action=allow protocol=TCP localport=5985
+
+:: WinRM service configuration
+sc.exe config winrm start= auto
+net.exe start winrm
+call %windir%\system32\winrm.cmd quickconfig -q
+call %windir%\system32\winrm.cmd quickconfig -transport:http
+call %windir%\system32\winrm.cmd set winrm/config @{MaxTimeoutms="1800000"}
+call %windir%\system32\winrm.cmd set winrm/config/winrs @{MaxMemoryPerShellMB="2048"}
+call %windir%\system32\winrm.cmd set winrm/config/winrs @{MaxShellsPerUser="50"}
+call %windir%\system32\winrm.cmd set winrm/config/winrs @{MaxConcurrentUsers="50"}
+call %windir%\system32\winrm.cmd set winrm/config/winrs @{MaxProcessesPerShell="50"}
+call %windir%\system32\winrm.cmd set winrm/config/service @{AllowUnencrypted="true"}
+call %windir%\system32\winrm.cmd set winrm/config/service/auth @{Basic="true"}
+call %windir%\system32\winrm.cmd set winrm/config/client/auth @{Basic="true"}
+call %windir%\system32\winrm.cmd set "winrm/config/listener?Address=*+Transport=HTTP" @{Port="5985"}
+
+:: Restart WinRM to apply policies
+sc.exe stop winrm
+timeout /t 2 /nobreak >nul
+sc.exe start winrm
+
+:: Serial Debugging (Release COM1 from kernel EMS for reliable logging)
+bcdedit.exe /ems {current} off
+bcdedit.exe /bootems off
+
+echo [WIN11-SETUPCOMPLETE] SetupComplete complete, WinRM ready on 5985 > COM1
+exit 0

--- a/packer_templates/win_answer_files/11/SetupComplete.cmd
+++ b/packer_templates/win_answer_files/11/SetupComplete.cmd
@@ -3,10 +3,13 @@
 echo [WIN11-SETUPCOMPLETE] Starting SetupComplete bootstrap... > COM1
 
 :: Ensure Administrator and vagrant accounts are enabled, in Administrators group, with password vagrant
+net.exe accounts /lockoutthreshold:0
 net.exe user Administrator /active:yes
 net.exe user Administrator vagrant
+net.exe user Administrator /expires:never
 net.exe user vagrant /active:yes
 net.exe user vagrant vagrant
+net.exe user vagrant /expires:never
 net.exe localgroup Administrators vagrant /add
 net.exe localgroup Administrators Administrator /add
 
@@ -21,7 +24,7 @@ reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client" /v AllowUnen
 
 :: Set network category to private
 powershell.exe -ExecutionPolicy Bypass -NoProfile -Command "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force"
-powershell.exe -ExecutionPolicy Bypass -NoProfile -Command "Get-NetConnectionProfile | Set-NetConnectionProfile -NetworkCategory Private"
+powershell.exe -ExecutionPolicy Bypass -NoProfile -Command "$ErrorActionPreference = 'SilentlyContinue'; Get-NetConnectionProfile | Set-NetConnectionProfile -NetworkCategory Private"
 
 :: Firewall
 netsh advfirewall firewall add rule name="Port 5985" dir=in action=allow protocol=TCP localport=5985
@@ -29,7 +32,7 @@ netsh advfirewall firewall add rule name="Port 5985" dir=in action=allow protoco
 :: WinRM service configuration
 sc.exe config winrm start= auto
 net.exe start winrm
-call %windir%\system32\winrm.cmd quickconfig -q
+call %windir%\system32\winrm.cmd quickconfig -q -force
 call %windir%\system32\winrm.cmd quickconfig -transport:http
 call %windir%\system32\winrm.cmd set winrm/config @{MaxTimeoutms="1800000"}
 call %windir%\system32\winrm.cmd set winrm/config/winrs @{MaxMemoryPerShellMB="2048"}
@@ -38,7 +41,9 @@ call %windir%\system32\winrm.cmd set winrm/config/winrs @{MaxConcurrentUsers="50
 call %windir%\system32\winrm.cmd set winrm/config/winrs @{MaxProcessesPerShell="50"}
 call %windir%\system32\winrm.cmd set winrm/config/service @{AllowUnencrypted="true"}
 call %windir%\system32\winrm.cmd set winrm/config/service/auth @{Basic="true"}
+call %windir%\system32\winrm.cmd set winrm/config/service/auth @{Negotiate="true"}
 call %windir%\system32\winrm.cmd set winrm/config/client/auth @{Basic="true"}
+call %windir%\system32\winrm.cmd set winrm/config/client/auth @{Negotiate="true"}
 call %windir%\system32\winrm.cmd set "winrm/config/listener?Address=*+Transport=HTTP" @{Port="5985"}
 
 :: Restart WinRM to apply policies

--- a/packer_templates/win_answer_files/11/arm64/Autounattend.xml
+++ b/packer_templates/win_answer_files/11/arm64/Autounattend.xml
@@ -4,125 +4,8 @@
         <component name="Microsoft-Windows-LUA-Settings" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
             <EnableLUA>false</EnableLUA>
         </component>
-        <component name="Microsoft-Windows-PnpCustomizationsNonWinPE" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-            <DriverPaths>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="1"><Path>X:\drivers</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="2"><Path>C:\drivers</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="3"><Path>D:\drivers</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="4"><Path>E:\drivers</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="5"><Path>F:\drivers</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="6"><Path>G:\drivers</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="7"><Path>H:\drivers</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="8"><Path>D:\viostor\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="9"><Path>D:\NetKVM\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="10"><Path>D:\Balloon\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="11"><Path>D:\pvpanic\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="12"><Path>D:\vioscsi\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="13"><Path>D:\vioserial\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="14"><Path>D:\vioinput\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="15"><Path>D:\viorng\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="16"><Path>D:\viofs\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="17"><Path>D:\viogpudo\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="18"><Path>D:\viomem\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="19"><Path>E:\viostor\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="20"><Path>E:\NetKVM\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="21"><Path>E:\Balloon\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="22"><Path>E:\pvpanic\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="23"><Path>E:\vioscsi\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="24"><Path>E:\vioserial\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="25"><Path>E:\vioinput\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="26"><Path>E:\viorng\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="27"><Path>E:\viofs\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="28"><Path>E:\viogpudo\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="29"><Path>E:\viomem\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="30"><Path>F:\viostor\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="31"><Path>F:\NetKVM\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="32"><Path>F:\Balloon\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="33"><Path>F:\pvpanic\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="34"><Path>F:\vioscsi\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="35"><Path>F:\vioserial\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="36"><Path>F:\vioinput\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="37"><Path>F:\viorng\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="38"><Path>F:\viofs\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="39"><Path>F:\viogpudo\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="40"><Path>F:\viomem\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="41"><Path>G:\viostor\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="42"><Path>G:\NetKVM\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="43"><Path>G:\Balloon\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="44"><Path>G:\pvpanic\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="45"><Path>G:\vioscsi\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="46"><Path>G:\vioserial\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="47"><Path>G:\vioinput\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="48"><Path>G:\viorng\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="49"><Path>G:\viofs\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="50"><Path>G:\viogpudo\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="51"><Path>G:\viomem\w11\ARM64</Path></PathAndCredentials>
-            
-                <PathAndCredentials wcm:action="add" wcm:keyValue="100"><Path>C:\drivers</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="101"><Path>C:\viostor\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="102"><Path>C:\NetKVM\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="103"><Path>C:\Balloon\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="104"><Path>C:\pvpanic\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="105"><Path>C:\vioscsi\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="106"><Path>C:\vioserial\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="107"><Path>C:\vioinput\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="108"><Path>C:\viorng\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="109"><Path>C:\viofs\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="110"><Path>C:\viogpudo\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="111"><Path>C:\viomem\w11\ARM64</Path></PathAndCredentials>
-            </DriverPaths>
-        </component>
     </settings>
     <settings pass="windowsPE">
-        <component name="Microsoft-Windows-PnpCustomizationsWinPE" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" processorArchitecture="arm64">
-            <DriverPaths>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="1"><Path>D:\viostor\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="2"><Path>D:\NetKVM\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="3"><Path>D:\Balloon\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="4"><Path>D:\pvpanic\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="5"><Path>D:\vioscsi\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="6"><Path>D:\vioserial\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="7"><Path>D:\vioinput\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="8"><Path>D:\viorng\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="9"><Path>D:\viofs\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="10"><Path>D:\viogpudo\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="11"><Path>D:\viomem\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="12"><Path>E:\viostor\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="13"><Path>E:\NetKVM\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="14"><Path>E:\Balloon\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="15"><Path>E:\pvpanic\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="16"><Path>E:\vioscsi\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="17"><Path>E:\vioserial\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="18"><Path>E:\vioinput\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="19"><Path>E:\viorng\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="20"><Path>E:\viofs\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="21"><Path>E:\viogpudo\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="22"><Path>E:\viomem\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="23"><Path>F:\viostor\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="24"><Path>F:\NetKVM\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="25"><Path>F:\Balloon\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="26"><Path>F:\pvpanic\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="27"><Path>F:\vioscsi\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="28"><Path>F:\vioserial\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="29"><Path>F:\vioinput\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="30"><Path>F:\viorng\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="31"><Path>F:\viofs\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="32"><Path>F:\viogpudo\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="33"><Path>F:\viomem\w11\ARM64</Path></PathAndCredentials>
-            
-                <PathAndCredentials wcm:action="add" wcm:keyValue="100"><Path>C:\viostor\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="101"><Path>C:\NetKVM\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="102"><Path>C:\Balloon\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="103"><Path>C:\pvpanic\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="104"><Path>C:\vioscsi\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="105"><Path>C:\vioserial\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="106"><Path>C:\vioinput\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="107"><Path>C:\viorng\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="108"><Path>C:\viofs\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="109"><Path>C:\viogpudo\w11\ARM64</Path></PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="110"><Path>C:\viomem\w11\ARM64</Path></PathAndCredentials>
-            </DriverPaths>
-        </component>
         <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
             <SetupUILanguage>
                 <UILanguage>en-US</UILanguage>
@@ -164,14 +47,9 @@
                             <Label>System</Label>
                             <Format>FAT32</Format>
                         </ModifyPartition>
-                        <!-- MSR partition - no format but needs entry -->
-                        <ModifyPartition wcm:action="add">
-                            <Order>2</Order>
-                            <PartitionID>2</PartitionID>
-                        </ModifyPartition>
                         <!-- Format the Windows partition -->
                         <ModifyPartition wcm:action="add">
-                            <Order>3</Order>
+                            <Order>2</Order>
                             <PartitionID>3</PartitionID>
                             <Label>Windows</Label>
                             <Format>NTFS</Format>
@@ -194,12 +72,11 @@
                         <DiskID>0</DiskID>
                         <PartitionID>3</PartitionID>
                     </InstallTo>
-                    <Compact>true</Compact>
                 </OSImage>
             </ImageInstall>
             <UserData>
                 <ProductKey>
-                    %{ if windows_product_key != "" }<Key>${windows_product_key}</Key>%{ endif }
+                    %{ if windows_product_key != "" }<Key>${windows_product_key}</Key>%{ else }<Key>W269N-WFGWX-YVC9B-4J6C9-T83GX</Key>%{ endif }
                     <WillShowUI>Never</WillShowUI>
                 </ProductKey>
                 <AcceptEula>true</AcceptEula>
@@ -287,7 +164,7 @@
             <RunSynchronous>
                 <RunSynchronousCommand wcm:action="add">
                     <Order>1</Order>
-                    <Path>cmd.exe /c "if not exist C:\Windows\Setup\Scripts mkdir C:\Windows\Setup\Scripts &amp; for %d in (c d e f g) do if exist %d:\SetupComplete.cmd copy /y %d:\SetupComplete.cmd C:\Windows\Setup\Scripts\SetupComplete.cmd"</Path>
+                    <Path>cmd.exe /c "if not exist C:\Windows\Setup\Scripts mkdir C:\Windows\Setup\Scripts &amp; for %d in (c d e f g h i) do if exist %d:\SetupComplete.cmd copy /y %d:\SetupComplete.cmd C:\Windows\Setup\Scripts\SetupComplete.cmd"</Path>
                 </RunSynchronousCommand>
                 <RunSynchronousCommand wcm:action="add">
                     <Order>2</Order>
@@ -435,134 +312,149 @@
                 <Username>vagrant</Username>
                 <Enabled>true</Enabled>
             </AutoLogon>
-            <FirstLogonCommands>
-                <SynchronousCommand wcm:action="add">
+            <FirstLogonCommands>                <SynchronousCommand wcm:action="add">
                     <Order>1</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c "for %d in (c d e f g h i) do if exist %d:\NetKVM\w11\ARM64\netkvm.inf pnputil.exe /add-driver %d:\NetKVM\w11\ARM64\netkvm.inf /install"</CommandLine>
+                    <Description>Install NetKVM Driver</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>2</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c "for %d in (c d e f g h i) do if exist %d:\viostor\w11\ARM64\viostor.inf pnputil.exe /add-driver %d:\viostor\w11\ARM64\viostor.inf /install"</CommandLine>
+                    <Description>Install Viostor Driver</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>3</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c "for %d in (c d e f g h i) do if exist %d:\Balloon\w11\ARM64\balloon.inf pnputil.exe /add-driver %d:\Balloon\w11\ARM64\balloon.inf /install"</CommandLine>
+                    <Description>Install Balloon Driver</Description>
+                </SynchronousCommand>
+
+                <SynchronousCommand wcm:action="add">
+                    <Order>4</Order>
                     <CommandLine>%windir%\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force"</CommandLine>
                     <Description>Set Execution Policy 64 Bit</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>2</Order>
+                    <Order>5</Order>
                     <CommandLine>%windir%\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference = 'SilentlyContinue'; Get-NetConnectionProfile | Set-NetConnectionProfile -NetworkCategory Private"</CommandLine>
                     <Description>Set Private Network Category</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>3</Order>
+                    <Order>6</Order>
                     <CommandLine>%windir%\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference = 'SilentlyContinue'; Set-NetFirewallRule -Name 'WINRM-HTTP-In-TCP' -RemoteAddress Any; New-NetFirewallRule -DisplayName 'WinRM HTTP' -Name 'WINRM-HTTP-In-TCP' -Profile Any -LocalPort 5985 -Protocol TCP -Action Allow -Direction Inbound"</CommandLine>
                     <Description>Allow WinRM firewall rule</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>4</Order>
+                    <Order>7</Order>
                     <CommandLine>%windir%\System32\cmd.exe /c winrm quickconfig -q</CommandLine>
                     <Description>winrm quickconfig -q</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>5</Order>
+                    <Order>8</Order>
                     <CommandLine>%windir%\System32\cmd.exe /c winrm quickconfig -transport:http</CommandLine>
                     <Description>winrm quickconfig -transport:http</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>6</Order>
+                    <Order>9</Order>
                     <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config @{MaxTimeoutms="1800000"}</CommandLine>
                     <Description>WinRM MaxTimeoutms</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>7</Order>
+                    <Order>10</Order>
                     <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="2048"}</CommandLine>
                     <Description>WinRM MaxMemoryPerShellMB</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>8</Order>
+                    <Order>11</Order>
                     <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/service @{AllowUnencrypted="true"}</CommandLine>
                     <Description>WinRM AllowUnencrypted</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>9</Order>
+                    <Order>12</Order>
                     <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/service/auth @{Basic="true"}</CommandLine>
                     <Description>WinRM auth Basic</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>10</Order>
+                    <Order>13</Order>
                     <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/client/auth @{Basic="true"}</CommandLine>
                     <Description>WinRM client auth Basic</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>11</Order>
+                    <Order>14</Order>
                     <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/listener?Address=*+Transport=HTTP @{Port="5985"}</CommandLine>
                     <Description>WinRM listener Address/Port</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>12</Order>
+                    <Order>15</Order>
                     <CommandLine>%windir%\System32\cmd.exe /c netsh advfirewall firewall add rule name="Port 5985" dir=in action=allow protocol=TCP localport=5985</CommandLine>
                     <Description>Open Port 5985 in Firewall</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>13</Order>
+                    <Order>16</Order>
                     <CommandLine>%windir%\System32\cmd.exe /c net stop winrm</CommandLine>
                     <Description>Stop WinRM</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>14</Order>
+                    <Order>17</Order>
                     <CommandLine>%windir%\System32\cmd.exe /c sc config winrm start= auto</CommandLine>
                     <Description>WinRM Autostart</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>15</Order>
+                    <Order>18</Order>
                     <CommandLine>%windir%\System32\cmd.exe /c net start winrm</CommandLine>
                     <Description>Start WinRM</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>16</Order>
+                    <Order>19</Order>
                     <CommandLine>%windir%\System32\cmd.exe /c net.exe user vagrant /expires:never</CommandLine>
                     <Description>Disable password expiration for vagrant user</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>%SystemRoot%\System32\reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v DefaultPassword /t REG_SZ /d "vagrant" /f</CommandLine>
-                    <Order>17</Order>
+                    <Order>20</Order>
                     <Description>Enable AutoLogon DefaultPassword</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <CommandLine>%SystemRoot%\System32\reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v AutoAdminLogon /t REG_SZ /d 1 /f</CommandLine>
-                    <Order>18</Order>
+                    <Order>21</Order>
                     <Description>Enable AutoLogon AutoAdminLogon</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>19</Order>
+                    <Order>22</Order>
                     <CommandLine>%SystemRoot%\System32\reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v LocalAccountTokenFilterPolicy /t REG_DWORD /d 1 /f</CommandLine>
                     <Description>Enable LocalAccountTokenFilterPolicy</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>20</Order>
+                    <Order>23</Order>
                     <CommandLine>%SystemRoot%\System32\reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service" /v AllowBasic /t REG_DWORD /d 1 /f</CommandLine>
                     <Description>Allow Basic Auth Service Policy</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>21</Order>
+                    <Order>24</Order>
                     <CommandLine>%SystemRoot%\System32\reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service" /v AllowUnencryptedTraffic /t REG_DWORD /d 1 /f</CommandLine>
                     <Description>Allow Unencrypted Traffic Service Policy</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>22</Order>
+                    <Order>25</Order>
                     <CommandLine>%SystemRoot%\System32\reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client" /v AllowBasic /t REG_DWORD /d 1 /f</CommandLine>
                     <Description>Allow Basic Auth Client Policy</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>23</Order>
+                    <Order>26</Order>
                     <CommandLine>%SystemRoot%\System32\reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client" /v AllowUnencryptedTraffic /t REG_DWORD /d 1 /f</CommandLine>
                     <Description>Allow Unencrypted Traffic Client Policy</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>24</Order>
+                    <Order>27</Order>
                     <CommandLine>%SystemRoot%\System32\bcdedit.exe /ems {current} off</CommandLine>
                     <Description>Disable Kernel EMS to release COM1</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>25</Order>
+                    <Order>28</Order>
                     <CommandLine>%SystemRoot%\System32\bcdedit.exe /bootems off</CommandLine>
                     <Description>Disable Boot EMS</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>26</Order>
+                    <Order>29</Order>
                     <CommandLine>%windir%\System32\cmd.exe /c "echo [WIN11-SERIAL] WinRM and Serial Ready > COM1"</CommandLine>
                     <Description>Notify COM1 Serial</Description>
                 </SynchronousCommand>

--- a/packer_templates/win_answer_files/11/arm64/Autounattend.xml
+++ b/packer_templates/win_answer_files/11/arm64/Autounattend.xml
@@ -1,58 +1,139 @@
 <?xml version="1.0" encoding="utf-8"?>
-<unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
-	<!--https://schneegans.de/windows/unattend-generator/?LanguageMode=Unattended&UILanguage=en-US&Locale=en-US&Keyboard=00000409&GeoLocation=244&ProcessorArchitecture=amd64&ProcessorArchitecture=arm64&BypassRequirementsCheck=true&ComputerNameMode=Custom&ComputerName=bento&CompactOsMode=Default&TimeZoneMode=Explicit&TimeZone=UTC&PartitionMode=Unattended&PartitionLayout=GPT&EspSize=100&RecoveryMode=None&WindowsEditionMode=Generic&WindowsEdition=enterprise&UserAccountMode=Unattended&AccountName0=vagrant&AccountDisplayName0=&AccountPassword0=vagrant&AccountGroup0=Administrators&AccountName1=&AccountName2=&AccountName3=&AccountName4=&AutoLogonMode=Own&PasswordExpirationMode=Unlimited&LockoutMode=Disabled&HideFiles=HiddenSystem&ShowFileExtensions=true&TaskbarSearch=Box&TaskbarIconsMode=Default&DisableWidgets=true&StartTilesMode=Default&StartPinsMode=Default&DisableUac=true&DisableSac=true&DisableSmartScreen=true&DisableFastStartup=true&DisableSystemRestore=true&EnableRemoteDesktop=true&AllowPowerShellScripts=true&DisableAppSuggestions=true&PreventDeviceEncryption=true&HideEdgeFre=true&DeleteWindowsOld=true&EffectsMode=Performance&DesktopIconsMode=Default&VBoxGuestAdditions=true&VMwareTools=true&VirtIoGuestTools=true&WifiMode=Skip&ExpressSettings=DisableAll&KeysMode=Skip&ColorMode=Default&WallpaperMode=Default&Remove3DViewer=true&RemoveBingSearch=true&RemoveCalculator=true&RemoveCamera=true&RemoveClipchamp=true&RemoveClock=true&RemoveCopilot=true&RemoveCortana=true&RemoveDevHome=true&RemoveFamily=true&RemoveFeedbackHub=true&RemoveGetHelp=true&RemoveHandwriting=true&RemoveInternetExplorer=true&RemoveMailCalendar=true&RemoveMaps=true&RemoveMathInputPanel=true&RemoveMediaFeatures=true&RemoveMixedReality=true&RemoveZuneVideo=true&RemoveNews=true&RemoveOffice365=true&RemoveOneDrive=true&RemoveOneNote=true&RemoveOneSync=true&RemoveOutlook=true&RemovePaint=true&RemovePaint3D=true&RemovePeople=true&RemovePhotos=true&RemovePowerAutomate=true&RemovePowerShell2=true&RemoveQuickAssist=true&RemoveRecall=true&RemoveSkype=true&RemoveSnippingTool=true&RemoveSolitaire=true&RemoveSpeech=true&RemoveStepsRecorder=true&RemoveStickyNotes=true&RemoveTeams=true&RemoveGetStarted=true&RemoveToDo=true&RemoveVoiceRecorder=true&RemoveWallet=true&RemoveWeather=true&RemoveFaxAndScan=true&RemoveWindowsHello=true&RemoveWindowsMediaPlayer=true&RemoveZuneMusic=true&RemoveXboxApps=true&RemoveYourPhone=true&SystemScript0=%26+%7B%0D%0A++foreach%28+%24letter+in+%27DEFGHIJKLMNOPQRSTUVWXYZ%27.ToCharArray%28%29+%29+%7B%0D%0A++++%24exe+%3D+%22%24%7Bletter%7D%3A%5CPTAgent.exe%22%3B%0D%0A++++if%28+Test-Path+-LiteralPath+%24exe+%29+%7B%0D%0A++++++Start-Process+-FilePath+%24exe+-ArgumentList+%27%2Finstall_silent%27%2C+%27%2Fnorestart%27+-Wait%3B%0D%0A++++++return%3B%0D%0A++++%7D%0D%0A++%7D%0D%0A++%27Parallels+Tools+image+%28windows.iso%29+is+not+attached+to+this+VM.%27%3B%0D%0A%7D+*%3E%261+%3E%3E+%27C%3A%5CWindows%5CSetup%5CScripts%5CParallelsTools.log%27%3B&SystemScriptType0=Ps1&FirstLogonScript0=Get-NetConnectionProfile+%7C+Set-NetConnectionProfile+-NetworkCategory+%22Private%22%3B%0D%0ASet-NetFirewallRule+-Name+%22WINRM-HTTP-In-TCP%22+-RemoteAddress+Any%3B%0D%0Areg.exe+ADD+%22HKLM%5CSOFTWARE%5CMicrosoft%5CWindows+NT%5CCurrentVersion%5CWinlogon%22+%2Fv+AutoAdminLogon+%2Ft+REG_SZ+%2Fd+1+%2Ff%3B%0D%0Areg.exe+ADD+%22HKLM%5CSOFTWARE%5CMicrosoft%5CWindows+NT%5CCurrentVersion%5CWinlogon%22+%2Fv+DefaultUserName+%2Ft+REG_SZ+%2Fd+%22vagrant%22+%2Ff%3B%0D%0Areg.exe+ADD+%22HKLM%5CSOFTWARE%5CMicrosoft%5CWindows+NT%5CCurrentVersion%5CWinlogon%22+%2Fv+DefaultPassword+%2Ft+REG_SZ+%2Fd+%22vagrant%22+%2Ff%3B%0D%0Acmd.exe+%2Fc+winrm+quickconfig+-q%3B%0D%0Acmd.exe+%2Fc+winrm+quickconfig+-transport%3Ahttp%3B%0D%0Acmd.exe+%2Fc+winrm+set+winrm%2Fconfig+%40%7BMaxTimeoutms%3D%221800000%22%7D%3B%0D%0Acmd.exe+%2Fc+winrm+set+winrm%2Fconfig%2Fwinrs+%40%7BMaxMemoryPerShellMB%3D%222048%22%7D%3B%0D%0Acmd.exe+%2Fc+winrm+set+winrm%2Fconfig%2Fservice+%40%7BAllowUnencrypted%3D%22true%22%7D%3B%0D%0Acmd.exe+%2Fc+winrm+set+winrm%2Fconfig%2Fservice%2Fauth+%40%7BBasic%3D%22true%22%7D%3B%0D%0Acmd.exe+%2Fc+winrm+set+winrm%2Fconfig%2Fclient%2Fauth+%40%7BBasic%3D%22true%22%7D%3B%0D%0Acmd.exe+%2Fc+winrm+set+winrm%2Fconfig%2Flistener%3FAddress%3D*%2BTransport%3DHTTP+%40%7BPort%3D%225985%22%7D%3B%0D%0Acmd.exe+%2Fc+netsh+firewall+add+portopening+TCP+5985+%22Port+5985%22%3B%0D%0Acmd.exe+%2Fc+net+stop+winrm%3B%0D%0Acmd.exe+%2Fc+sc+config+winrm+start%3D+auto%3B%0D%0Acmd.exe+%2Fc+net+start+winrm%3B%0D%0Acmd.exe+%2Fc+wmic+useraccount+where+%22name%3D%27vagrant%27%22+set+PasswordExpires%3DFALSE%3B&FirstLogonScriptType0=Ps1&WdacMode=Skip-->
-	<settings pass="offlineServicing"></settings>
-	<settings pass="windowsPE">
-        <component name="Microsoft-Windows-PnpCustomizationsWinPE" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" processorArchitecture="arm64">
-            <!--
-                 This makes the VirtIO drivers available to Windows, assuming that
-                 the VirtIO driver disk at https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/stable-virtio/virtio-win.iso
-                 (see https://docs.fedoraproject.org/en-US/quick-docs/creating-windows-virtual-machines-using-virtio-drivers/index.html#virtio-win-direct-downloads)
-                 is available as drive F:
-            -->
+<unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <settings pass="offlineServicing">
+        <component name="Microsoft-Windows-LUA-Settings" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <EnableLUA>false</EnableLUA>
+        </component>
+        <component name="Microsoft-Windows-PnpCustomizationsNonWinPE" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
             <DriverPaths>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="2">
-                    <Path>F:\viostor\w11\ARM64</Path>
-                </PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="3">
-                    <Path>F:\NetKVM\w11\ARM64</Path>
-                </PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="4">
-                    <Path>F:\Balloon\w11\ARM64</Path>
-                </PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="5">
-                    <Path>F:\pvpanic\w11\ARM64</Path>
-                </PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="6">
-                    <Path>F:\qemupciserial\w11\ARM64</Path>
-                </PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="7">
-                    <Path>F:\qxldod\w11\ARM64</Path>
-                </PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="8">
-                    <Path>F:\vioinput\w11\ARM64</Path>
-                </PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="9">
-                    <Path>F:\viorng\w11\ARM64</Path>
-                </PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="10">
-                    <Path>F:\vioscsi\w11\ARM64</Path>
-                </PathAndCredentials>
-                <PathAndCredentials wcm:action="add" wcm:keyValue="11">
-                    <Path>F:\vioserial\w11\ARM64</Path>
-                </PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="1"><Path>X:\drivers</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="2"><Path>C:\drivers</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="3"><Path>D:\drivers</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="4"><Path>E:\drivers</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="5"><Path>F:\drivers</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="6"><Path>G:\drivers</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="7"><Path>H:\drivers</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="8"><Path>D:\viostor\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="9"><Path>D:\NetKVM\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="10"><Path>D:\Balloon\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="11"><Path>D:\pvpanic\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="12"><Path>D:\vioscsi\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="13"><Path>D:\vioserial\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="14"><Path>D:\vioinput\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="15"><Path>D:\viorng\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="16"><Path>D:\viofs\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="17"><Path>D:\viogpudo\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="18"><Path>D:\viomem\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="19"><Path>E:\viostor\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="20"><Path>E:\NetKVM\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="21"><Path>E:\Balloon\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="22"><Path>E:\pvpanic\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="23"><Path>E:\vioscsi\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="24"><Path>E:\vioserial\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="25"><Path>E:\vioinput\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="26"><Path>E:\viorng\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="27"><Path>E:\viofs\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="28"><Path>E:\viogpudo\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="29"><Path>E:\viomem\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="30"><Path>F:\viostor\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="31"><Path>F:\NetKVM\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="32"><Path>F:\Balloon\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="33"><Path>F:\pvpanic\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="34"><Path>F:\vioscsi\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="35"><Path>F:\vioserial\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="36"><Path>F:\vioinput\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="37"><Path>F:\viorng\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="38"><Path>F:\viofs\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="39"><Path>F:\viogpudo\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="40"><Path>F:\viomem\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="41"><Path>G:\viostor\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="42"><Path>G:\NetKVM\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="43"><Path>G:\Balloon\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="44"><Path>G:\pvpanic\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="45"><Path>G:\vioscsi\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="46"><Path>G:\vioserial\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="47"><Path>G:\vioinput\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="48"><Path>G:\viorng\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="49"><Path>G:\viofs\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="50"><Path>G:\viogpudo\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="51"><Path>G:\viomem\w11\ARM64</Path></PathAndCredentials>
+            
+                <PathAndCredentials wcm:action="add" wcm:keyValue="100"><Path>C:\drivers</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="101"><Path>C:\viostor\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="102"><Path>C:\NetKVM\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="103"><Path>C:\Balloon\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="104"><Path>C:\pvpanic\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="105"><Path>C:\vioscsi\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="106"><Path>C:\vioserial\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="107"><Path>C:\vioinput\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="108"><Path>C:\viorng\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="109"><Path>C:\viofs\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="110"><Path>C:\viogpudo\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="111"><Path>C:\viomem\w11\ARM64</Path></PathAndCredentials>
             </DriverPaths>
         </component>
-		<component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-			<SetupUILanguage>
-				<UILanguage>en-US</UILanguage>
-			</SetupUILanguage>
-			<InputLocale>0409:00000409</InputLocale>
-			<SystemLocale>en-US</SystemLocale>
-			<UILanguage>en-US</UILanguage>
-			<UserLocale>en-US</UserLocale>
-		</component>
-		<component name="Microsoft-Windows-Setup" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+    </settings>
+    <settings pass="windowsPE">
+        <component name="Microsoft-Windows-PnpCustomizationsWinPE" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" processorArchitecture="arm64">
+            <DriverPaths>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="1"><Path>D:\viostor\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="2"><Path>D:\NetKVM\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="3"><Path>D:\Balloon\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="4"><Path>D:\pvpanic\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="5"><Path>D:\vioscsi\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="6"><Path>D:\vioserial\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="7"><Path>D:\vioinput\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="8"><Path>D:\viorng\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="9"><Path>D:\viofs\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="10"><Path>D:\viogpudo\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="11"><Path>D:\viomem\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="12"><Path>E:\viostor\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="13"><Path>E:\NetKVM\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="14"><Path>E:\Balloon\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="15"><Path>E:\pvpanic\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="16"><Path>E:\vioscsi\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="17"><Path>E:\vioserial\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="18"><Path>E:\vioinput\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="19"><Path>E:\viorng\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="20"><Path>E:\viofs\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="21"><Path>E:\viogpudo\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="22"><Path>E:\viomem\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="23"><Path>F:\viostor\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="24"><Path>F:\NetKVM\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="25"><Path>F:\Balloon\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="26"><Path>F:\pvpanic\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="27"><Path>F:\vioscsi\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="28"><Path>F:\vioserial\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="29"><Path>F:\vioinput\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="30"><Path>F:\viorng\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="31"><Path>F:\viofs\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="32"><Path>F:\viogpudo\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="33"><Path>F:\viomem\w11\ARM64</Path></PathAndCredentials>
+            
+                <PathAndCredentials wcm:action="add" wcm:keyValue="100"><Path>C:\viostor\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="101"><Path>C:\NetKVM\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="102"><Path>C:\Balloon\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="103"><Path>C:\pvpanic\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="104"><Path>C:\vioscsi\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="105"><Path>C:\vioserial\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="106"><Path>C:\vioinput\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="107"><Path>C:\viorng\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="108"><Path>C:\viofs\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="109"><Path>C:\viogpudo\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="110"><Path>C:\viomem\w11\ARM64</Path></PathAndCredentials>
+            </DriverPaths>
+        </component>
+        <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <SetupUILanguage>
+                <UILanguage>en-US</UILanguage>
+            </SetupUILanguage>
+            <InputLocale>en-US</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UILanguageFallback>en-US</UILanguageFallback>
+            <UserLocale>en-US</UserLocale>
+        </component>
+        <component name="Microsoft-Windows-Setup" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
             <DiskConfiguration>
                 <Disk wcm:action="add">
                     <CreatePartitions>
@@ -102,416 +183,393 @@
                 </Disk>
             </DiskConfiguration>
             <ImageInstall>
-				<OSImage>
-					<InstallTo>
-						<DiskID>0</DiskID>
-						<PartitionID>3</PartitionID>
-					</InstallTo>
-				</OSImage>
-			</ImageInstall>
-			<UserData>
-				<ProductKey>
-                    <!-- Public Trial license key -->
-					<Key>XGVPP-NMH47-7TTHJ-W3FW7-8HV2C</Key>
-					<WillShowUI>OnError</WillShowUI>
-				</ProductKey>
-				<AcceptEula>true</AcceptEula>
-			</UserData>
-			<UseConfigurationSet>false</UseConfigurationSet>
-			<RunSynchronous>
-				<RunSynchronousCommand wcm:action="add">
-					<Order>1</Order>
-					<Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassTPMCheck /t REG_DWORD /d 1 /f</Path>
-				</RunSynchronousCommand>
-				<RunSynchronousCommand wcm:action="add">
-					<Order>2</Order>
-					<Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassSecureBootCheck /t REG_DWORD /d 1 /f</Path>
-				</RunSynchronousCommand>
-				<RunSynchronousCommand wcm:action="add">
-					<Order>3</Order>
-					<Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassRAMCheck /t REG_DWORD /d 1 /f</Path>
-				</RunSynchronousCommand>
-			</RunSynchronous>
-		</component>
-	</settings>
-	<settings pass="generalize"></settings>
-	<settings pass="specialize">
-		<component name="Microsoft-Windows-Shell-Setup" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-			<ComputerName>bento</ComputerName>
-			<TimeZone>UTC</TimeZone>
-		</component>
-		<component name="Microsoft-Windows-Deployment" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-			<RunSynchronous>
-				<RunSynchronousCommand wcm:action="add">
-					<Order>1</Order>
-					<Path>powershell.exe -WindowStyle Normal -NoProfile -Command "$xml = [xml]::new(); $xml.Load('C:\Windows\Panther\unattend.xml'); $sb = [scriptblock]::Create( $xml.unattend.Extensions.ExtractScript ); Invoke-Command -ScriptBlock $sb -ArgumentList $xml;"</Path>
-				</RunSynchronousCommand>
-				<RunSynchronousCommand wcm:action="add">
-					<Order>2</Order>
-					<Path>powershell.exe -WindowStyle Normal -NoProfile -Command "Get-Content -LiteralPath 'C:\Windows\Setup\Scripts\Specialize.ps1' -Raw | Invoke-Expression;"</Path>
-				</RunSynchronousCommand>
-				<RunSynchronousCommand wcm:action="add">
-					<Order>3</Order>
-					<Path>reg.exe load "HKU\DefaultUser" "C:\Users\Default\NTUSER.DAT"</Path>
-				</RunSynchronousCommand>
-				<RunSynchronousCommand wcm:action="add">
-					<Order>4</Order>
-					<Path>powershell.exe -WindowStyle Normal -NoProfile -Command "Get-Content -LiteralPath 'C:\Windows\Setup\Scripts\DefaultUser.ps1' -Raw | Invoke-Expression;"</Path>
-				</RunSynchronousCommand>
-				<RunSynchronousCommand wcm:action="add">
-					<Order>5</Order>
-					<Path>reg.exe unload "HKU\DefaultUser"</Path>
-				</RunSynchronousCommand>
-			</RunSynchronous>
-		</component>
-	</settings>
-	<settings pass="auditSystem"></settings>
-	<settings pass="auditUser"></settings>
-	<settings pass="oobeSystem">
-		<component name="Microsoft-Windows-International-Core" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-			<InputLocale>0409:00000409</InputLocale>
-			<SystemLocale>en-US</SystemLocale>
-			<UILanguage>en-US</UILanguage>
-			<UserLocale>en-US</UserLocale>
-		</component>
-		<component name="Microsoft-Windows-Shell-Setup" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-			<UserAccounts>
-				<LocalAccounts>
-					<LocalAccount wcm:action="add">
-						<Name>vagrant</Name>
-						<DisplayName></DisplayName>
-						<Group>Administrators</Group>
-						<Password>
-							<Value>vagrant</Value>
-							<PlainText>true</PlainText>
-						</Password>
-					</LocalAccount>
-				</LocalAccounts>
-			</UserAccounts>
-			<AutoLogon>
-				<Username>vagrant</Username>
-				<Enabled>true</Enabled>
-				<Password>
-					<Value>vagrant</Value>
-					<PlainText>true</PlainText>
-				</Password>
-			</AutoLogon>
-			<OOBE>
-				<ProtectYourPC>3</ProtectYourPC>
-				<HideEULAPage>true</HideEULAPage>
-				<HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
-				<HideOnlineAccountScreens>true</HideOnlineAccountScreens>
-			</OOBE>
-			<FirstLogonCommands>
-				<SynchronousCommand wcm:action="add">
-					<Order>1</Order>
-					<CommandLine>powershell.exe -WindowStyle Normal -NoProfile -Command "Get-Content -LiteralPath 'C:\Windows\Setup\Scripts\FirstLogon.ps1' -Raw | Invoke-Expression;"</CommandLine>
-				</SynchronousCommand>
-			</FirstLogonCommands>
-		</component>
-	</settings>
-	<Extensions xmlns="https://schneegans.de/windows/unattend-generator/">
-		<ExtractScript>
-param(
-    [xml] $Document
-);
-
-foreach( $file in $Document.unattend.Extensions.File ) {
-    $path = [System.Environment]::ExpandEnvironmentVariables( $file.GetAttribute( 'path' ) );
-    mkdir -Path( $path | Split-Path -Parent ) -ErrorAction 'SilentlyContinue';
-    $encoding = switch( [System.IO.Path]::GetExtension( $path ) ) {
-        { $_ -in '.ps1', '.xml' } { [System.Text.Encoding]::UTF8; }
-        { $_ -in '.reg', '.vbs', '.js' } { [System.Text.UnicodeEncoding]::new( $false, $true ); }
-        default { [System.Text.Encoding]::Default; }
-    };
-    $bytes = $encoding.GetPreamble() + $encoding.GetBytes( $file.InnerText.Trim() );
-    [System.IO.File]::WriteAllBytes( $path, $bytes );
-}
-		</ExtractScript>
-		<File path="C:\Windows\Setup\Scripts\VBoxGuestAdditions.ps1">
-&amp; {
-	foreach( $letter in 'DEFGHIJKLMNOPQRSTUVWXYZ'.ToCharArray() ) {
-		$exe = "${letter}:\VBoxWindowsAdditions.exe";
-		if( Test-Path -LiteralPath $exe ) {
-			$certs = "${letter}:\cert";
-			Start-Process -FilePath "${certs}\VBoxCertUtil.exe" -ArgumentList "add-trusted-publisher ${certs}\vbox*.cer", "--root ${certs}\vbox*.cer"  -Wait;
-			Start-Process -FilePath $exe -ArgumentList '/with_wddm', '/S' -Wait;
-			return;
-		}
-	}
-	'VBoxGuestAdditions.iso is not attached to this VM.';
-} *&gt;&amp;1 &gt;&gt; 'C:\Windows\Setup\Scripts\VBoxGuestAdditions.log';
-		</File>
-		<File path="C:\Windows\Setup\Scripts\VMwareTools.ps1">
-&amp; {
-	foreach( $letter in 'DEFGHIJKLMNOPQRSTUVWXYZ'.ToCharArray() ) {
-		$exe = "${letter}:\setup.exe";
-		if( ( Get-Item -LiteralPath $exe -ErrorAction 'SilentlyContinue' | Select-Object -ExpandProperty 'VersionInfo' | Select-Object -ExpandProperty 'ProductName' ) -eq 'VMware Tools' ) {
-			Start-Process -FilePath $exe -ArgumentList '/s /v /qn REBOOT=R' -Wait;
-			return;
-		}
-	}
-	'VMware Tools image (windows.iso) is not attached to this VM.';
-} *&gt;&amp;1 &gt;&gt; "C:\Windows\Setup\Scripts\VMwareTools.log";
-		</File>
-		<File path="C:\Windows\Setup\Scripts\VirtIoGuestTools.ps1">
-&amp; {
-	foreach( $letter in 'DEFGHIJKLMNOPQRSTUVWXYZ'.ToCharArray() ) {
-		$exe = "${letter}:\virtio-win-guest-tools.exe";
-		if( Test-Path -LiteralPath $exe ) {
-			Start-Process -FilePath $exe -ArgumentList '/passive', '/norestart' -Wait;
-			return;
-		}
-	}
-	'VirtIO Guest Tools image (virtio-win-*.iso) is not attached to this VM.';
-} *&gt;&amp;1 &gt;&gt; 'C:\Windows\Setup\Scripts\VirtIoGuestTools.log';
-		</File>
-		<File path="C:\Windows\Setup\Scripts\ParallelsTools.ps1">
-&amp; {
-	foreach( $letter in 'DEFGHIJKLMNOPQRSTUVWXYZ'.ToCharArray() ) {
-		$exe = "${letter}:\PTAgent.exe";
-		if( Test-Path -LiteralPath $exe ) {
-			Start-Process -FilePath $exe -ArgumentList '/install_silent' -Wait;
-			return;
-		}
-	}
-	'Parallels Tools image (windows.iso) is not attached to this VM.';
-} *&gt;&amp;1 &gt;&gt; 'C:\Windows\Setup\Scripts\VirtIoGuestTools.log';
-		</File>
-		<File path="C:\Windows\Setup\Scripts\unattend-01.ps1">
-&amp; {
-	Get-NetConnectionProfile | Set-NetConnectionProfile -NetworkCategory "Private";
-	Set-NetFirewallRule -Name "WINRM-HTTP-In-TCP" -RemoteAddress Any;
-	reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v AutoAdminLogon /t REG_SZ /d 1 /f;
-	reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v DefaultUserName /t REG_SZ /d "vagrant" /f;
-	reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v DefaultPassword /t REG_SZ /d "vagrant" /f;
-	cmd.exe /c 'winrm quickconfig -q -transport:http -force';
-	cmd.exe /c 'winrm set winrm/config @{MaxTimeoutms="1800000"}';
-	cmd.exe /c 'winrm set winrm/config/winrs @{MaxMemoryPerShellMB="2048"}';
-	cmd.exe /c 'winrm set winrm/config/service @{AllowUnencrypted="true"}';
-	cmd.exe /c 'winrm set winrm/config/service/auth @{Basic="true"}';
-	cmd.exe /c 'winrm set winrm/config/client/auth @{Basic="true"}';
-	cmd.exe /c 'winrm set winrm/config/listener?Address=*+Transport=HTTP @{Port="5985"}';
-	netsh advfirewall firewall add rule name= "Open Port 5985" dir=in action=allow protocol=TCP localport=5985
-	net stop winrm;
-	cmd.exe /c 'sc config winrm start= auto';
-	net start winrm;
-	wmic useraccount where "name='vagrant'" set PasswordExpires=FALSE;
-} *&gt;&amp;1 &gt;&gt; 'C:\Windows\Setup\Scripts\unattend-01.log';
-		</File>
-		<File path="C:\Windows\Setup\Scripts\Specialize.ps1">
-$scripts = @(
-	{
-		ReAgentc.exe /disable;
-		Remove-Item -LiteralPath 'C:\Windows\System32\Recovery\Winre.wim' -Force -ErrorAction 'SilentlyContinue';
-	};
-	{
-		reg.exe add "HKLM\SYSTEM\Setup\MoSetup" /v AllowUpgradesWithUnsupportedTPMOrCPU /t REG_DWORD /d 1 /f;
-	};
-	{
-		Remove-Item -LiteralPath 'Registry::HKLM\Software\Microsoft\WindowsUpdate\Orchestrator\UScheduler_Oobe\DevHomeUpdate' -Force -ErrorAction 'SilentlyContinue';
-	};
-	{
-		Remove-Item -LiteralPath 'C:\Users\Default\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\OneDrive.lnk', 'C:\Windows\System32\OneDriveSetup.exe', 'C:\Windows\SysWOW64\OneDriveSetup.exe' -ErrorAction 'Continue';
-	};
-	{
-		Remove-Item -LiteralPath 'Registry::HKLM\Software\Microsoft\WindowsUpdate\Orchestrator\UScheduler_Oobe\OutlookUpdate' -Force -ErrorAction 'SilentlyContinue';
-	};
-	{
-		reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Communications" /v ConfigureChatAutoInstall /t REG_DWORD /d 0 /f;
-	};
-	{
-		net.exe accounts /lockoutthreshold:0;
-	};
-	{
-		net.exe accounts /maxpwage:UNLIMITED;
-	};
-	{
-		reg.exe add "HKLM\SYSTEM\CurrentControlSet\Control\CI\Policy" /v VerifiedAndReputablePolicyState /t REG_DWORD /d 0 /f;
-	};
-	{
-		reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer" /v SmartScreenEnabled /t REG_SZ /d "Off" /f;
-		reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WTDS\Components" /v ServiceEnabled /t REG_DWORD /d 0 /f;
-		reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WTDS\Components" /v NotifyMalicious /t REG_DWORD /d 0 /f;
-		reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WTDS\Components" /v NotifyPasswordReuse /t REG_DWORD /d 0 /f;
-		reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WTDS\Components" /v NotifyUnsafeApp /t REG_DWORD /d 0 /f;
-		reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows Defender Security Center\Systray" /v HideSystray /t REG_DWORD /d 1 /f;
-	};
-	{
-		reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v EnableLUA /t REG_DWORD /d 0 /f
-	};
-	{
-		netsh.exe advfirewall firewall set rule group="@FirewallAPI.dll,-28752" new enable=Yes;
-		reg.exe add "HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server" /v fDenyTSConnections /t REG_DWORD /d 0 /f;
-	};
-	{
-		Set-ExecutionPolicy -Scope 'LocalMachine' -ExecutionPolicy 'RemoteSigned' -Force;
-	};
-	{
-		reg.exe add "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Power" /v HiberbootEnabled /t REG_DWORD /d 0 /f;
-	};
-	{
-		reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Dsh" /v AllowNewsAndInterests /t REG_DWORD /d 0 /f;
-	};
-	{
-		reg.exe add "HKLM\Software\Policies\Microsoft\Windows\CloudContent" /v "DisableWindowsConsumerFeatures" /t REG_DWORD /d 1 /f;
-	};
-	{
-		reg.exe add "HKLM\SYSTEM\CurrentControlSet\Control\BitLocker" /v "PreventDeviceEncryption" /t REG_DWORD /d 1 /f;
-	};
-	{
-		reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Edge" /v HideFirstRunExperience /t REG_DWORD /d 1 /f;
-	};
-	{
-		Set-ItemProperty -LiteralPath "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\ControlAnimations" -Name 'DefaultValue' -Value 0 -Type 'DWord' -Force;
-		Set-ItemProperty -LiteralPath "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\AnimateMinMax" -Name 'DefaultValue' -Value 0 -Type 'DWord' -Force;
-		Set-ItemProperty -LiteralPath "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\TaskbarAnimations" -Name 'DefaultValue' -Value 0 -Type 'DWord' -Force;
-		Set-ItemProperty -LiteralPath "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\DWMAeroPeekEnabled" -Name 'DefaultValue' -Value 0 -Type 'DWord' -Force;
-		Set-ItemProperty -LiteralPath "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\MenuAnimation" -Name 'DefaultValue' -Value 0 -Type 'DWord' -Force;
-		Set-ItemProperty -LiteralPath "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\TooltipAnimation" -Name 'DefaultValue' -Value 0 -Type 'DWord' -Force;
-		Set-ItemProperty -LiteralPath "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\SelectionFade" -Name 'DefaultValue' -Value 0 -Type 'DWord' -Force;
-		Set-ItemProperty -LiteralPath "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\DWMSaveThumbnailEnabled" -Name 'DefaultValue' -Value 0 -Type 'DWord' -Force;
-		Set-ItemProperty -LiteralPath "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\CursorShadow" -Name 'DefaultValue' -Value 0 -Type 'DWord' -Force;
-		Set-ItemProperty -LiteralPath "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\ListviewShadow" -Name 'DefaultValue' -Value 0 -Type 'DWord' -Force;
-		Set-ItemProperty -LiteralPath "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\ThumbnailsOrIcon" -Name 'DefaultValue' -Value 0 -Type 'DWord' -Force;
-		Set-ItemProperty -LiteralPath "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\ListviewAlphaSelect" -Name 'DefaultValue' -Value 0 -Type 'DWord' -Force;
-		Set-ItemProperty -LiteralPath "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\DragFullWindows" -Name 'DefaultValue' -Value 0 -Type 'DWord' -Force;
-		Set-ItemProperty -LiteralPath "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\ComboBoxAnimation" -Name 'DefaultValue' -Value 0 -Type 'DWord' -Force;
-		Set-ItemProperty -LiteralPath "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\FontSmoothing" -Name 'DefaultValue' -Value 0 -Type 'DWord' -Force;
-		Set-ItemProperty -LiteralPath "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\ListBoxSmoothScrolling" -Name 'DefaultValue' -Value 0 -Type 'DWord' -Force;
-		Set-ItemProperty -LiteralPath "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects\DropShadow" -Name 'DefaultValue' -Value 0 -Type 'DWord' -Force;
-	};
-);
-
-&amp; {
-	[float] $complete = 0;
-	[float] $increment = 100 / $scripts.Count;
-	foreach( $script in $scripts ) {
-		Write-Progress -Activity 'Running scripts to customize your Windows installation. Do not close this window.' -PercentComplete $complete;
-		&amp; $script;
-		$complete += $increment;
-	}
-} *&gt;&amp;1 &gt;&gt; "C:\Windows\Setup\Scripts\Specialize.log";
-		</File>
-		<File path="C:\Windows\Setup\Scripts\UserOnce.ps1">
-$scripts = @(
-	{
-		Get-AppxPackage -Name 'Microsoft.Windows.Ai.Copilot.Provider' | Remove-AppxPackage;
-	};
-	{
-		Set-ItemProperty -LiteralPath 'Registry::HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects' -Name 'VisualFXSetting' -Type 'DWord' -Value 2 -Force;
-	};
-);
-
-&amp; {
-	[float] $complete = 0;
-	[float] $increment = 100 / $scripts.Count;
-	foreach( $script in $scripts ) {
-		Write-Progress -Activity 'Running scripts to configure this user account. Do not close this window.' -PercentComplete $complete;
-		&amp; $script;
-		$complete += $increment;
-	}
-} *&gt;&amp;1 &gt;&gt; "$env:TEMP\UserOnce.log";
-		</File>
-		<File path="C:\Windows\Setup\Scripts\DefaultUser.ps1">
-$scripts = @(
-	{
-		reg.exe add "HKU\DefaultUser\Software\Policies\Microsoft\Windows\WindowsCopilot" /v TurnOffWindowsCopilot /t REG_DWORD /d 1 /f;
-	};
-	{
-		Remove-ItemProperty -LiteralPath 'Registry::HKU\DefaultUser\Software\Microsoft\Windows\CurrentVersion\Run' -Name 'OneDriveSetup' -Force -ErrorAction 'Continue';
-	};
-	{
-		reg.exe add "HKU\DefaultUser\Software\Microsoft\Windows\CurrentVersion\GameDVR" /v AppCaptureEnabled /t REG_DWORD /d 0 /f;
-	};
-	{
-		reg.exe add "HKU\DefaultUser\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "HideFileExt" /t REG_DWORD /d 0 /f;
-	};
-	{
-		reg.exe add "HKU\DefaultUser\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "Hidden" /t REG_DWORD /d 1 /f;
-	};
-	{
-		reg.exe add "HKU\DefaultUser\Software\Microsoft\Edge\SmartScreenEnabled" /ve /t REG_DWORD /d 0 /f;
-		reg.exe add "HKU\DefaultUser\Software\Microsoft\Edge\SmartScreenPuaEnabled" /ve /t REG_DWORD /d 0 /f;
-		reg.exe add "HKU\DefaultUser\Software\Microsoft\Windows\CurrentVersion\AppHost" /v EnableWebContentEvaluation /t REG_DWORD /d 0 /f;
-		reg.exe add "HKU\DefaultUser\Software\Microsoft\Windows\CurrentVersion\AppHost" /v PreventOverride /t REG_DWORD /d 0 /f;
-	};
-	{
-		$names = @(
-		  'ContentDeliveryAllowed';
-		  'FeatureManagementEnabled';
-		  'OEMPreInstalledAppsEnabled';
-		  'PreInstalledAppsEnabled';
-		  'PreInstalledAppsEverEnabled';
-		  'SilentInstalledAppsEnabled';
-		  'SoftLandingEnabled';
-		  'SubscribedContentEnabled';
-		  'SubscribedContent-310093Enabled';
-		  'SubscribedContent-338387Enabled';
-		  'SubscribedContent-338388Enabled';
-		  'SubscribedContent-338389Enabled';
-		  'SubscribedContent-338393Enabled';
-		  'SubscribedContent-353698Enabled';
-		  'SystemPaneSuggestionsEnabled';
-		);
-
-		foreach( $name in $names ) {
-		  reg.exe add "HKU\DefaultUser\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" /v $name /t REG_DWORD /d 0 /f;
-		}
-	};
-	{
-		reg.exe add "HKU\DefaultUser\Software\Policies\Microsoft\Windows\Explorer" /v DisableSearchBoxSuggestions /t REG_DWORD /d 1 /f;
-	};
-	{
-		reg.exe add "HKU\DefaultUser\Software\Microsoft\Windows\CurrentVersion\RunOnce" /v "UnattendedSetup" /t REG_SZ /d "powershell.exe -WindowStyle Normal -NoProfile -Command \""Get-Content -LiteralPath 'C:\Windows\Setup\Scripts\UserOnce.ps1' -Raw | Invoke-Expression;\""" /f;
-	};
-);
-
-&amp; {
-	[float] $complete = 0;
-	[float] $increment = 100 / $scripts.Count;
-	foreach( $script in $scripts ) {
-		Write-Progress -Activity 'Running scripts to modify the default user&#x2019;&#x2019;s registry hive. Do not close this window.' -PercentComplete $complete;
-		&amp; $script;
-		$complete += $increment;
-	}
-} *&gt;&amp;1 &gt;&gt; "C:\Windows\Setup\Scripts\DefaultUser.log";
-		</File>
-		<File path="C:\Windows\Setup\Scripts\FirstLogon.ps1">
-$scripts = @(
-	{
-		Disable-ComputerRestore -Drive 'C:\';
-	};
-	{
-		Get-Content -LiteralPath 'C:\Windows\Setup\Scripts\VBoxGuestAdditions.ps1' -Raw | Invoke-Expression;
-	};
-	{
-		Get-Content -LiteralPath 'C:\Windows\Setup\Scripts\VMwareTools.ps1' -Raw | Invoke-Expression;
-	};
-	{
-		Get-Content -LiteralPath 'C:\Windows\Setup\Scripts\ParallelsTools.ps1' -Raw | Invoke-Expression;
-	};
-	{
-		Get-Content -LiteralPath 'C:\Windows\Setup\Scripts\VirtIoGuestTools.ps1' -Raw | Invoke-Expression;
-	};
-	{
-		Get-Content -LiteralPath 'C:\Windows\Setup\Scripts\unattend-01.ps1' -Raw | Invoke-Expression;
-	};
-
-	{
-		cmd.exe /c "rmdir C:\Windows.old";
-	};
-);
-
-&amp; {
-	[float] $complete = 0;
-	[float] $increment = 100 / $scripts.Count;
-	foreach( $script in $scripts ) {
-		Write-Progress -Activity 'Running scripts to finalize your Windows installation. Do not close this window.' -PercentComplete $complete;
-		&amp; $script;
-		$complete += $increment;
-	}
-} *&gt;&amp;1 &gt;&gt; "C:\Windows\Setup\Scripts\FirstLogon.log";
-		</File>
-	</Extensions>
+                <OSImage>
+                    <InstallFrom>
+                        <MetaData wcm:action="add">
+                            <Key>/IMAGE/NAME</Key>
+                            <Value>Windows 11 Pro</Value>
+                        </MetaData>
+                    </InstallFrom>
+                    <InstallTo>
+                        <DiskID>0</DiskID>
+                        <PartitionID>3</PartitionID>
+                    </InstallTo>
+                    <Compact>true</Compact>
+                </OSImage>
+            </ImageInstall>
+            <UserData>
+                <ProductKey>
+                    %{ if windows_product_key != "" }<Key>${windows_product_key}</Key>%{ endif }
+                    <WillShowUI>Never</WillShowUI>
+                </ProductKey>
+                <AcceptEula>true</AcceptEula>
+                <FullName>vagrant</FullName>
+                <Organization>vagrant</Organization>
+            </UserData>
+            <UseConfigurationSet>false</UseConfigurationSet>
+            <RunSynchronous>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>1</Order>
+                    <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassTPMCheck /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>2</Order>
+                    <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassSecureBootCheck /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>3</Order>
+                    <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassRAMCheck /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>4</Order>
+                    <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassCPUCheck /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>5</Order>
+                    <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassStorageCheck /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>6</Order>
+                    <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassDiskCheck /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>7</Order>
+                    <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassNRO /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>8</Order>
+                    <Path>reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\OOBE" /v BypassNRO /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+            </RunSynchronous>
+        </component>
+    </settings>
+    <settings pass="generalize">
+        <component name="Microsoft-Windows-Security-SPP" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <SkipRearm>1</SkipRearm>
+        </component>
+        <component name="Microsoft-Windows-PnpSysprep" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <PersistAllDeviceInstalls>false</PersistAllDeviceInstalls>
+            <DoNotCleanUpNonPresentDevices>false</DoNotCleanUpNonPresentDevices>
+        </component>
+    </settings>
+    <settings pass="specialize">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <ComputerName>bento</ComputerName>
+            <TimeZone>UTC</TimeZone>
+        </component>
+        <component name="Microsoft-Windows-SystemRestore-Main" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <DisableSR>1</DisableSR>
+        </component>
+        <component name="Microsoft-Windows-SystemSettingsThreshold" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <DisplayNetworkSelection>false</DisplayNetworkSelection>
+        </component>
+        <component name="Networking-MPSSVC-Svc" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <FirewallGroups>
+                <FirewallGroup wcm:action="add" wcm:keyValue="WindowsRemoteManagement">
+                    <Active>true</Active>
+                    <Group>Windows Remote Management</Group>
+                    <Profile>all</Profile>
+                </FirewallGroup>
+                <FirewallGroup wcm:action="add" wcm:keyValue="RemoteAdministration">
+                    <Active>true</Active>
+                    <Group>Remote Administration</Group>
+                    <Profile>all</Profile>
+                </FirewallGroup>
+            </FirewallGroups>
+        </component>
+        <component name="Microsoft-Windows-Security-SPP-UX" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <SkipAutoActivation>true</SkipAutoActivation>
+        </component>
+        <component name="Microsoft-Windows-SQMApi" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <CEIPEnabled>0</CEIPEnabled>
+        </component>
+        <component name="Microsoft-Windows-Deployment" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <RunSynchronous>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>1</Order>
+                    <Path>cmd.exe /c "if not exist C:\Windows\Setup\Scripts mkdir C:\Windows\Setup\Scripts &amp; for %d in (c d e f g) do if exist %d:\SetupComplete.cmd copy /y %d:\SetupComplete.cmd C:\Windows\Setup\Scripts\SetupComplete.cmd"</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>2</Order>
+                    <Path>cmd.exe /c reg.exe add "HKLM\SYSTEM\Setup\MoSetup" /v AllowUpgradesWithUnsupportedTPMOrCPU /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>3</Order>
+                    <Path>cmd.exe /c reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v EnableLUA /t REG_DWORD /d 0 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>4</Order>
+                    <Path>cmd.exe /c reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v LocalAccountTokenFilterPolicy /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>5</Order>
+                    <Path>cmd.exe /c reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v ConsentPromptBehaviorAdmin /t REG_DWORD /d 0 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>6</Order>
+                    <Path>cmd.exe /c reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service" /v AllowBasic /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>7</Order>
+                    <Path>cmd.exe /c reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service" /v AllowUnencryptedTraffic /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>8</Order>
+                    <Path>cmd.exe /c reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client" /v AllowBasic /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>9</Order>
+                    <Path>cmd.exe /c reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client" /v AllowUnencryptedTraffic /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>10</Order>
+                    <Path>cmd.exe /c netsh advfirewall firewall add rule name="Port 5985" dir=in action=allow protocol=TCP localport=5985</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>11</Order>
+                    <Path>cmd.exe /c sc.exe config winrm start= auto</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>12</Order>
+                    <Path>cmd.exe /c net.exe start winrm</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>13</Order>
+                    <Path>cmd.exe /c winrm quickconfig -q</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>14</Order>
+                    <Path>cmd.exe /c winrm quickconfig -transport:http</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>15</Order>
+                    <Path>cmd.exe /c winrm set winrm/config @{MaxTimeoutms="1800000"}</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>16</Order>
+                    <Path>cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="2048"}</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>17</Order>
+                    <Path>cmd.exe /c winrm set winrm/config/service @{AllowUnencrypted="true"}</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>18</Order>
+                    <Path>cmd.exe /c winrm set winrm/config/service/auth @{Basic="true"}</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>19</Order>
+                    <Path>cmd.exe /c winrm set winrm/config/client/auth @{Basic="true"}</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>20</Order>
+                    <Path>cmd.exe /c winrm set "winrm/config/listener?Address=*+Transport=HTTP" @{Port="5985"}</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>21</Order>
+                    <Path>cmd.exe /c powercfg.exe /hibernate off</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>22</Order>
+                    <Path>cmd.exe /c bcdedit.exe /ems {current} off</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>23</Order>
+                    <Path>cmd.exe /c bcdedit.exe /bootems off</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>24</Order>
+                    <Path>cmd.exe /c "echo [WIN11-SERIAL] Specialize Pass WinRM and Serial Ready > COM1"</Path>
+                </RunSynchronousCommand>
+            </RunSynchronous>
+        </component>
+    </settings>
+    <settings pass="oobeSystem">
+        <component name="Microsoft-Windows-International-Core" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <InputLocale>en-US</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UserLocale>en-US</UserLocale>
+        </component>
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <OOBE>
+                <HideEULAPage>true</HideEULAPage>
+                <HideLocalAccountScreen>true</HideLocalAccountScreen>
+                <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+                <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+                <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+                <NetworkLocation>Work</NetworkLocation>
+                <ProtectYourPC>3</ProtectYourPC>
+                <SkipMachineOOBE>true</SkipMachineOOBE>
+                <SkipUserOOBE>true</SkipUserOOBE>
+                <VMModeOptimizations>
+                    <SkipAdministratorProfileRemoval>true</SkipAdministratorProfileRemoval>
+                    <SkipNotifyUILanguageChange>true</SkipNotifyUILanguageChange>
+                    <SkipWinREInitialization>true</SkipWinREInitialization>
+                </VMModeOptimizations>
+            </OOBE>
+            <TimeZone>UTC</TimeZone>
+            <UserAccounts>
+                <AdministratorPassword>
+                    <Value>vagrant</Value>
+                    <PlainText>true</PlainText>
+                </AdministratorPassword>
+                <LocalAccounts>
+                    <LocalAccount wcm:action="add">
+                        <Password>
+                            <Value>vagrant</Value>
+                            <PlainText>true</PlainText>
+                        </Password>
+                        <Description>Vagrant User</Description>
+                        <DisplayName>vagrant</DisplayName>
+                        <Group>Administrators</Group>
+                        <Name>vagrant</Name>
+                    </LocalAccount>
+                </LocalAccounts>
+            </UserAccounts>
+            <AutoLogon>
+                <Password>
+                    <Value>vagrant</Value>
+                    <PlainText>true</PlainText>
+                </Password>
+                <Username>vagrant</Username>
+                <Enabled>true</Enabled>
+            </AutoLogon>
+            <FirstLogonCommands>
+                <SynchronousCommand wcm:action="add">
+                    <Order>1</Order>
+                    <CommandLine>%windir%\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force"</CommandLine>
+                    <Description>Set Execution Policy 64 Bit</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>2</Order>
+                    <CommandLine>%windir%\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference = 'SilentlyContinue'; Get-NetConnectionProfile | Set-NetConnectionProfile -NetworkCategory Private"</CommandLine>
+                    <Description>Set Private Network Category</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>3</Order>
+                    <CommandLine>%windir%\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference = 'SilentlyContinue'; Set-NetFirewallRule -Name 'WINRM-HTTP-In-TCP' -RemoteAddress Any; New-NetFirewallRule -DisplayName 'WinRM HTTP' -Name 'WINRM-HTTP-In-TCP' -Profile Any -LocalPort 5985 -Protocol TCP -Action Allow -Direction Inbound"</CommandLine>
+                    <Description>Allow WinRM firewall rule</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>4</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm quickconfig -q</CommandLine>
+                    <Description>winrm quickconfig -q</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>5</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm quickconfig -transport:http</CommandLine>
+                    <Description>winrm quickconfig -transport:http</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>6</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config @{MaxTimeoutms="1800000"}</CommandLine>
+                    <Description>WinRM MaxTimeoutms</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>7</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="2048"}</CommandLine>
+                    <Description>WinRM MaxMemoryPerShellMB</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>8</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/service @{AllowUnencrypted="true"}</CommandLine>
+                    <Description>WinRM AllowUnencrypted</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>9</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/service/auth @{Basic="true"}</CommandLine>
+                    <Description>WinRM auth Basic</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>10</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/client/auth @{Basic="true"}</CommandLine>
+                    <Description>WinRM client auth Basic</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>11</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/listener?Address=*+Transport=HTTP @{Port="5985"}</CommandLine>
+                    <Description>WinRM listener Address/Port</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>12</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c netsh advfirewall firewall add rule name="Port 5985" dir=in action=allow protocol=TCP localport=5985</CommandLine>
+                    <Description>Open Port 5985 in Firewall</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>13</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c net stop winrm</CommandLine>
+                    <Description>Stop WinRM</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>14</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c sc config winrm start= auto</CommandLine>
+                    <Description>WinRM Autostart</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>15</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c net start winrm</CommandLine>
+                    <Description>Start WinRM</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>16</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c net.exe user vagrant /expires:never</CommandLine>
+                    <Description>Disable password expiration for vagrant user</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v DefaultPassword /t REG_SZ /d "vagrant" /f</CommandLine>
+                    <Order>17</Order>
+                    <Description>Enable AutoLogon DefaultPassword</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v AutoAdminLogon /t REG_SZ /d 1 /f</CommandLine>
+                    <Order>18</Order>
+                    <Description>Enable AutoLogon AutoAdminLogon</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>19</Order>
+                    <CommandLine>%SystemRoot%\System32\reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v LocalAccountTokenFilterPolicy /t REG_DWORD /d 1 /f</CommandLine>
+                    <Description>Enable LocalAccountTokenFilterPolicy</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>20</Order>
+                    <CommandLine>%SystemRoot%\System32\reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service" /v AllowBasic /t REG_DWORD /d 1 /f</CommandLine>
+                    <Description>Allow Basic Auth Service Policy</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>21</Order>
+                    <CommandLine>%SystemRoot%\System32\reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service" /v AllowUnencryptedTraffic /t REG_DWORD /d 1 /f</CommandLine>
+                    <Description>Allow Unencrypted Traffic Service Policy</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>22</Order>
+                    <CommandLine>%SystemRoot%\System32\reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client" /v AllowBasic /t REG_DWORD /d 1 /f</CommandLine>
+                    <Description>Allow Basic Auth Client Policy</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>23</Order>
+                    <CommandLine>%SystemRoot%\System32\reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client" /v AllowUnencryptedTraffic /t REG_DWORD /d 1 /f</CommandLine>
+                    <Description>Allow Unencrypted Traffic Client Policy</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>24</Order>
+                    <CommandLine>%SystemRoot%\System32\bcdedit.exe /ems {current} off</CommandLine>
+                    <Description>Disable Kernel EMS to release COM1</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>25</Order>
+                    <CommandLine>%SystemRoot%\System32\bcdedit.exe /bootems off</CommandLine>
+                    <Description>Disable Boot EMS</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>26</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c "echo [WIN11-SERIAL] WinRM and Serial Ready > COM1"</CommandLine>
+                    <Description>Notify COM1 Serial</Description>
+                </SynchronousCommand>
+            </FirstLogonCommands>
+        </component>
+        <component name="Microsoft-Windows-WinRE-RecoveryAgent" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <UninstallWindowsRE>true</UninstallWindowsRE>
+        </component>
+    </settings>
 </unattend>

--- a/packer_templates/win_answer_files/11/arm64/Autounattend.xml
+++ b/packer_templates/win_answer_files/11/arm64/Autounattend.xml
@@ -4,8 +4,84 @@
         <component name="Microsoft-Windows-LUA-Settings" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
             <EnableLUA>false</EnableLUA>
         </component>
+        <component name="Microsoft-Windows-PnpCustomizationsNonWinPE" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <DriverPaths>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="1"><Path>C:\drivers</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="2"><Path>D:\viostor\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="3"><Path>D:\NetKVM\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="4"><Path>D:\Balloon\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="5"><Path>D:\pvpanic\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="6"><Path>D:\vioscsi\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="7"><Path>D:\vioserial\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="8"><Path>D:\vioinput\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="9"><Path>D:\viorng\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="10"><Path>D:\viofs\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="11"><Path>D:\viogpudo\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="12"><Path>D:\viomem\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="13"><Path>E:\viostor\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="14"><Path>E:\NetKVM\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="15"><Path>E:\Balloon\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="16"><Path>E:\pvpanic\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="17"><Path>E:\vioscsi\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="18"><Path>E:\vioserial\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="19"><Path>E:\vioinput\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="20"><Path>E:\viorng\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="21"><Path>E:\viofs\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="22"><Path>E:\viogpudo\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="23"><Path>E:\viomem\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="24"><Path>F:\viostor\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="25"><Path>F:\NetKVM\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="26"><Path>F:\Balloon\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="27"><Path>F:\pvpanic\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="28"><Path>F:\vioscsi\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="29"><Path>F:\vioserial\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="30"><Path>F:\vioinput\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="31"><Path>F:\viorng\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="32"><Path>F:\viofs\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="33"><Path>F:\viogpudo\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="34"><Path>F:\viomem\w11\ARM64</Path></PathAndCredentials>
+            </DriverPaths>
+        </component>
     </settings>
     <settings pass="windowsPE">
+        <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <DriverPaths>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="1"><Path>C:\drivers</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="2"><Path>D:\viostor\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="3"><Path>D:\NetKVM\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="4"><Path>D:\Balloon\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="5"><Path>D:\pvpanic\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="6"><Path>D:\vioscsi\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="7"><Path>D:\vioserial\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="8"><Path>D:\vioinput\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="9"><Path>D:\viorng\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="10"><Path>D:\viofs\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="11"><Path>D:\viogpudo\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="12"><Path>D:\viomem\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="13"><Path>E:\viostor\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="14"><Path>E:\NetKVM\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="15"><Path>E:\Balloon\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="16"><Path>E:\pvpanic\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="17"><Path>E:\vioscsi\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="18"><Path>E:\vioserial\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="19"><Path>E:\vioinput\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="20"><Path>E:\viorng\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="21"><Path>E:\viofs\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="22"><Path>E:\viogpudo\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="23"><Path>E:\viomem\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="24"><Path>F:\viostor\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="25"><Path>F:\NetKVM\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="26"><Path>F:\Balloon\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="27"><Path>F:\pvpanic\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="28"><Path>F:\vioscsi\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="29"><Path>F:\vioserial\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="30"><Path>F:\vioinput\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="31"><Path>F:\viorng\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="32"><Path>F:\viofs\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="33"><Path>F:\viogpudo\w11\ARM64</Path></PathAndCredentials>
+                <PathAndCredentials wcm:action="add" wcm:keyValue="34"><Path>F:\viomem\w11\ARM64</Path></PathAndCredentials>
+            </DriverPaths>
+        </component>
         <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
             <SetupUILanguage>
                 <UILanguage>en-US</UILanguage>
@@ -16,7 +92,50 @@
             <UILanguageFallback>en-US</UILanguageFallback>
             <UserLocale>en-US</UserLocale>
         </component>
-        <component name="Microsoft-Windows-Setup" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+        
+                <component name="Microsoft-Windows-Setup" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <RunSynchronous>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>1</Order>
+                    <Path>reg.exe add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\HwReqChk" /v HwReqChkVars /t REG_MULTI_SZ /s , /d "SQ_SecureBootCapable=TRUE,SQ_SecureBootEnabled=TRUE,SQ_TpmVersion=2,SQ_RamMB=8192," /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>2</Order>
+                    <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassTPMCheck /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>3</Order>
+                    <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassSecureBootCheck /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>4</Order>
+                    <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassRAMCheck /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>5</Order>
+                    <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassCPUCheck /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>6</Order>
+                    <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassStorageCheck /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>7</Order>
+                    <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassDiskCheck /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>8</Order>
+                    <Path>reg.exe add "HKLM\SYSTEM\Setup\MoSetup" /v AllowUpgradesWithUnsupportedTPMOrCPU /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>9</Order>
+                    <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassNRO /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>10</Order>
+                    <Path>reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\OOBE" /v BypassNRO /t REG_DWORD /d 1 /f</Path>
+                </RunSynchronousCommand>
+            </RunSynchronous>
             <DiskConfiguration>
                 <Disk wcm:action="add">
                     <CreatePartitions>
@@ -47,9 +166,14 @@
                             <Label>System</Label>
                             <Format>FAT32</Format>
                         </ModifyPartition>
-                        <!-- Format the Windows partition -->
+                        <!-- MSR partition - no format but needs entry -->
                         <ModifyPartition wcm:action="add">
                             <Order>2</Order>
+                            <PartitionID>2</PartitionID>
+                        </ModifyPartition>
+                        <!-- Format the Windows partition -->
+                        <ModifyPartition wcm:action="add">
+                            <Order>3</Order>
                             <PartitionID>3</PartitionID>
                             <Label>Windows</Label>
                             <Format>NTFS</Format>
@@ -72,6 +196,7 @@
                         <DiskID>0</DiskID>
                         <PartitionID>3</PartitionID>
                     </InstallTo>
+                    <Compact>true</Compact>
                 </OSImage>
             </ImageInstall>
             <UserData>
@@ -83,41 +208,10 @@
                 <FullName>vagrant</FullName>
                 <Organization>vagrant</Organization>
             </UserData>
-            <UseConfigurationSet>false</UseConfigurationSet>
-            <RunSynchronous>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>1</Order>
-                    <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassTPMCheck /t REG_DWORD /d 1 /f</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>2</Order>
-                    <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassSecureBootCheck /t REG_DWORD /d 1 /f</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>3</Order>
-                    <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassRAMCheck /t REG_DWORD /d 1 /f</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>4</Order>
-                    <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassCPUCheck /t REG_DWORD /d 1 /f</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>5</Order>
-                    <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassStorageCheck /t REG_DWORD /d 1 /f</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>6</Order>
-                    <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassDiskCheck /t REG_DWORD /d 1 /f</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>7</Order>
-                    <Path>reg.exe add "HKLM\SYSTEM\Setup\LabConfig" /v BypassNRO /t REG_DWORD /d 1 /f</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>8</Order>
-                    <Path>reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\OOBE" /v BypassNRO /t REG_DWORD /d 1 /f</Path>
-                </RunSynchronousCommand>
-            </RunSynchronous>
+            <DynamicUpdate>
+                <Enable>false</Enable>
+            </DynamicUpdate>
+                        <UseConfigurationSet>false</UseConfigurationSet>
         </component>
     </settings>
     <settings pass="generalize">
@@ -125,14 +219,20 @@
             <SkipRearm>1</SkipRearm>
         </component>
         <component name="Microsoft-Windows-PnpSysprep" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-            <PersistAllDeviceInstalls>false</PersistAllDeviceInstalls>
-            <DoNotCleanUpNonPresentDevices>false</DoNotCleanUpNonPresentDevices>
+            <PersistAllDeviceInstalls>true</PersistAllDeviceInstalls>
+            <DoNotCleanUpNonPresentDevices>true</DoNotCleanUpNonPresentDevices>
         </component>
     </settings>
     <settings pass="specialize">
         <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-            <ComputerName>bento</ComputerName>
+            <ComputerName>vagrant</ComputerName>
             <TimeZone>UTC</TimeZone>
+        </component>
+        <component name="Microsoft-Windows-TerminalServices-LocalSessionManager" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <fDenyTSConnections>false</fDenyTSConnections>
+        </component>
+        <component name="Microsoft-Windows-TerminalServices-RDP-WinStationExtensions" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <UserAuthentication>0</UserAuthentication>
         </component>
         <component name="Microsoft-Windows-SystemRestore-Main" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
             <DisableSR>1</DisableSR>
@@ -152,113 +252,20 @@
                     <Group>Remote Administration</Group>
                     <Profile>all</Profile>
                 </FirewallGroup>
+                <FirewallGroup wcm:action="add" wcm:keyValue="RemoteDesktop">
+                    <Active>true</Active>
+                    <Group>Remote Desktop</Group>
+                    <Profile>all</Profile>
+                </FirewallGroup>
             </FirewallGroups>
-        </component>
-        <component name="Microsoft-Windows-Security-SPP-UX" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-            <SkipAutoActivation>true</SkipAutoActivation>
         </component>
         <component name="Microsoft-Windows-SQMApi" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
             <CEIPEnabled>0</CEIPEnabled>
         </component>
+        <component name="Microsoft-Windows-Security-SPP-UX" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+            <SkipAutoActivation>true</SkipAutoActivation>
+        </component>
         <component name="Microsoft-Windows-Deployment" processorArchitecture="arm64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
-            <RunSynchronous>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>1</Order>
-                    <Path>cmd.exe /c "if not exist C:\Windows\Setup\Scripts mkdir C:\Windows\Setup\Scripts &amp; for %d in (c d e f g h i) do if exist %d:\SetupComplete.cmd copy /y %d:\SetupComplete.cmd C:\Windows\Setup\Scripts\SetupComplete.cmd"</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>2</Order>
-                    <Path>cmd.exe /c reg.exe add "HKLM\SYSTEM\Setup\MoSetup" /v AllowUpgradesWithUnsupportedTPMOrCPU /t REG_DWORD /d 1 /f</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>3</Order>
-                    <Path>cmd.exe /c reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v EnableLUA /t REG_DWORD /d 0 /f</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>4</Order>
-                    <Path>cmd.exe /c reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v LocalAccountTokenFilterPolicy /t REG_DWORD /d 1 /f</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>5</Order>
-                    <Path>cmd.exe /c reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v ConsentPromptBehaviorAdmin /t REG_DWORD /d 0 /f</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>6</Order>
-                    <Path>cmd.exe /c reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service" /v AllowBasic /t REG_DWORD /d 1 /f</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>7</Order>
-                    <Path>cmd.exe /c reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service" /v AllowUnencryptedTraffic /t REG_DWORD /d 1 /f</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>8</Order>
-                    <Path>cmd.exe /c reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client" /v AllowBasic /t REG_DWORD /d 1 /f</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>9</Order>
-                    <Path>cmd.exe /c reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client" /v AllowUnencryptedTraffic /t REG_DWORD /d 1 /f</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>10</Order>
-                    <Path>cmd.exe /c netsh advfirewall firewall add rule name="Port 5985" dir=in action=allow protocol=TCP localport=5985</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>11</Order>
-                    <Path>cmd.exe /c sc.exe config winrm start= auto</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>12</Order>
-                    <Path>cmd.exe /c net.exe start winrm</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>13</Order>
-                    <Path>cmd.exe /c winrm quickconfig -q</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>14</Order>
-                    <Path>cmd.exe /c winrm quickconfig -transport:http</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>15</Order>
-                    <Path>cmd.exe /c winrm set winrm/config @{MaxTimeoutms="1800000"}</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>16</Order>
-                    <Path>cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="2048"}</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>17</Order>
-                    <Path>cmd.exe /c winrm set winrm/config/service @{AllowUnencrypted="true"}</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>18</Order>
-                    <Path>cmd.exe /c winrm set winrm/config/service/auth @{Basic="true"}</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>19</Order>
-                    <Path>cmd.exe /c winrm set winrm/config/client/auth @{Basic="true"}</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>20</Order>
-                    <Path>cmd.exe /c winrm set "winrm/config/listener?Address=*+Transport=HTTP" @{Port="5985"}</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>21</Order>
-                    <Path>cmd.exe /c powercfg.exe /hibernate off</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>22</Order>
-                    <Path>cmd.exe /c bcdedit.exe /ems {current} off</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>23</Order>
-                    <Path>cmd.exe /c bcdedit.exe /bootems off</Path>
-                </RunSynchronousCommand>
-                <RunSynchronousCommand wcm:action="add">
-                    <Order>24</Order>
-                    <Path>cmd.exe /c "echo [WIN11-SERIAL] Specialize Pass WinRM and Serial Ready > COM1"</Path>
-                </RunSynchronousCommand>
-            </RunSynchronous>
         </component>
     </settings>
     <settings pass="oobeSystem">
@@ -311,151 +318,192 @@
                 </Password>
                 <Username>vagrant</Username>
                 <Enabled>true</Enabled>
+                <LogonCount>5</LogonCount>
             </AutoLogon>
-            <FirstLogonCommands>                <SynchronousCommand wcm:action="add">
+            <FirstLogonCommands>
+                <SynchronousCommand wcm:action="add">
                     <Order>1</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c "for %d in (c d e f g h i) do if exist %d:\NetKVM\w11\ARM64\netkvm.inf pnputil.exe /add-driver %d:\NetKVM\w11\ARM64\netkvm.inf /install"</CommandLine>
+                    <CommandLine>%windir%\System32\cmd.exe /c "for %d in (C D E F G H I J K) do if exist %d:\NetKVM\w11\ARM64\netkvm.inf pnputil.exe /add-driver %d:\NetKVM\w11\ARM64\*.inf /install"</CommandLine>
                     <Description>Install NetKVM Driver</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>2</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c "for %d in (c d e f g h i) do if exist %d:\viostor\w11\ARM64\viostor.inf pnputil.exe /add-driver %d:\viostor\w11\ARM64\viostor.inf /install"</CommandLine>
+                    <CommandLine>%windir%\System32\cmd.exe /c "for %d in (C D E F G H I J K) do if exist %d:\viostor\w11\ARM64\viostor.inf pnputil.exe /add-driver %d:\viostor\w11\ARM64\*.inf /install"</CommandLine>
                     <Description>Install Viostor Driver</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>3</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c "for %d in (c d e f g h i) do if exist %d:\Balloon\w11\ARM64\balloon.inf pnputil.exe /add-driver %d:\Balloon\w11\ARM64\balloon.inf /install"</CommandLine>
-                    <Description>Install Balloon Driver</Description>
+                    <CommandLine>%windir%\System32\cmd.exe /c "for %d in (C D E F G H I J K) do if exist %d:\vioscsi\w11\ARM64\vioscsi.inf pnputil.exe /add-driver %d:\vioscsi\w11\ARM64\*.inf /install"</CommandLine>
+                    <Description>Install Vioscsi Driver</Description>
                 </SynchronousCommand>
-
                 <SynchronousCommand wcm:action="add">
                     <Order>4</Order>
-                    <CommandLine>%windir%\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force"</CommandLine>
-                    <Description>Set Execution Policy 64 Bit</Description>
+                    <CommandLine>%windir%\System32\cmd.exe /c "for %d in (C D E F G H I J K) do if exist %d:\Balloon\w11\ARM64\balloon.inf pnputil.exe /add-driver %d:\Balloon\w11\ARM64\*.inf /install"</CommandLine>
+                    <Description>Install Balloon Driver</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>5</Order>
-                    <CommandLine>%windir%\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference = 'SilentlyContinue'; Get-NetConnectionProfile | Set-NetConnectionProfile -NetworkCategory Private"</CommandLine>
-                    <Description>Set Private Network Category</Description>
+                    <CommandLine>%windir%\System32\cmd.exe /c "for %d in (C D E F G H I J K) do if exist %d:\vioserial\w11\ARM64\vioser.inf pnputil.exe /add-driver %d:\vioserial\w11\ARM64\*.inf /install"</CommandLine>
+                    <Description>Install Vioserial Driver</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>6</Order>
-                    <CommandLine>%windir%\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference = 'SilentlyContinue'; Set-NetFirewallRule -Name 'WINRM-HTTP-In-TCP' -RemoteAddress Any; New-NetFirewallRule -DisplayName 'WinRM HTTP' -Name 'WINRM-HTTP-In-TCP' -Profile Any -LocalPort 5985 -Protocol TCP -Action Allow -Direction Inbound"</CommandLine>
-                    <Description>Allow WinRM firewall rule</Description>
+                    <CommandLine>%windir%\System32\cmd.exe /c net.exe user vagrant /active:yes</CommandLine>
+                    <Description>Enable vagrant user</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>7</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c winrm quickconfig -q</CommandLine>
-                    <Description>winrm quickconfig -q</Description>
+                    <CommandLine>%windir%\System32\cmd.exe /c net.exe user vagrant vagrant</CommandLine>
+                    <Description>Set vagrant password</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>8</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c winrm quickconfig -transport:http</CommandLine>
-                    <Description>winrm quickconfig -transport:http</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <Order>9</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config @{MaxTimeoutms="1800000"}</CommandLine>
-                    <Description>WinRM MaxTimeoutms</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <Order>10</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="2048"}</CommandLine>
-                    <Description>WinRM MaxMemoryPerShellMB</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <Order>11</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/service @{AllowUnencrypted="true"}</CommandLine>
-                    <Description>WinRM AllowUnencrypted</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <Order>12</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/service/auth @{Basic="true"}</CommandLine>
-                    <Description>WinRM auth Basic</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <Order>13</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/client/auth @{Basic="true"}</CommandLine>
-                    <Description>WinRM client auth Basic</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <Order>14</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/listener?Address=*+Transport=HTTP @{Port="5985"}</CommandLine>
-                    <Description>WinRM listener Address/Port</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <Order>15</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c netsh advfirewall firewall add rule name="Port 5985" dir=in action=allow protocol=TCP localport=5985</CommandLine>
-                    <Description>Open Port 5985 in Firewall</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <Order>16</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c net stop winrm</CommandLine>
-                    <Description>Stop WinRM</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <Order>17</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c sc config winrm start= auto</CommandLine>
-                    <Description>WinRM Autostart</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <Order>18</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c net start winrm</CommandLine>
-                    <Description>Start WinRM</Description>
-                </SynchronousCommand>
-                <SynchronousCommand wcm:action="add">
-                    <Order>19</Order>
                     <CommandLine>%windir%\System32\cmd.exe /c net.exe user vagrant /expires:never</CommandLine>
                     <Description>Disable password expiration for vagrant user</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>%SystemRoot%\System32\reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v DefaultPassword /t REG_SZ /d "vagrant" /f</CommandLine>
-                    <Order>20</Order>
-                    <Description>Enable AutoLogon DefaultPassword</Description>
+                    <Order>9</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c net.exe user Administrator /active:yes</CommandLine>
+                    <Description>Enable Administrator user</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <CommandLine>%SystemRoot%\System32\reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v AutoAdminLogon /t REG_SZ /d 1 /f</CommandLine>
+                    <Order>10</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c net.exe user Administrator vagrant</CommandLine>
+                    <Description>Set Administrator password</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>11</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c net.exe user Administrator /expires:never</CommandLine>
+                    <Description>Disable password expiration for Administrator user</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>12</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c net.exe localgroup Administrators vagrant /add</CommandLine>
+                    <Description>Add vagrant to Administrators</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>13</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c net.exe localgroup Administrators Administrator /add</CommandLine>
+                    <Description>Add Administrator to Administrators</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>14</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c net.exe accounts /lockoutthreshold:0</CommandLine>
+                    <Description>Disable Account Lockout</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>15</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v LocalAccountTokenFilterPolicy /t REG_DWORD /d 1 /f</CommandLine>
+                    <Description>Disable Remote UAC</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>16</Order>
+                    <CommandLine>%windir%\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -NoProfile -Command "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force"</CommandLine>
+                    <Description>Set Execution Policy 64 Bit</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>17</Order>
+                    <CommandLine>%windir%\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -NoProfile -Command "$ErrorActionPreference = 'SilentlyContinue'; Get-NetConnectionProfile | Set-NetConnectionProfile -NetworkCategory Private"</CommandLine>
+                    <Description>Sets detected network connections to private</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>18</Order>
+                    <CommandLine>%windir%\System32\WindowsPowerShell\v1.0\powershell.exe -ExecutionPolicy Bypass -NoProfile -Command "$ErrorActionPreference = 'SilentlyContinue'; Set-NetFirewallRule -Name 'WINRM-HTTP-In-TCP' -RemoteAddress Any; New-NetFirewallRule -DisplayName 'WinRM HTTP' -Name 'WINRM-HTTP-In-TCP' -Profile Any -LocalPort 5985 -Protocol TCP -Action Allow -Direction Inbound"</CommandLine>
+                    <Description>Allow WinRM firewall rule</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>19</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c netsh advfirewall firewall add rule name="Port 5985" dir=in action=allow protocol=TCP localport=5985</CommandLine>
+                    <Description>Open Port 5985 in Firewall</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>20</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm quickconfig -q</CommandLine>
+                    <Description>winrm quickconfig</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
                     <Order>21</Order>
-                    <Description>Enable AutoLogon AutoAdminLogon</Description>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm quickconfig -transport:http</CommandLine>
+                    <Description>winrm quickconfig -transport:http</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>22</Order>
-                    <CommandLine>%SystemRoot%\System32\reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v LocalAccountTokenFilterPolicy /t REG_DWORD /d 1 /f</CommandLine>
-                    <Description>Enable LocalAccountTokenFilterPolicy</Description>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config @{MaxTimeoutms="1800000"}</CommandLine>
+                    <Description>WinRM MaxTimeoutms</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>23</Order>
-                    <CommandLine>%SystemRoot%\System32\reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service" /v AllowBasic /t REG_DWORD /d 1 /f</CommandLine>
-                    <Description>Allow Basic Auth Service Policy</Description>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/winrs @{MaxMemoryPerShellMB="2048"}</CommandLine>
+                    <Description>WinRM MaxMemoryPerShellMB</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>24</Order>
-                    <CommandLine>%SystemRoot%\System32\reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service" /v AllowUnencryptedTraffic /t REG_DWORD /d 1 /f</CommandLine>
-                    <Description>Allow Unencrypted Traffic Service Policy</Description>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/service @{AllowUnencrypted="true"}</CommandLine>
+                    <Description>WinRM AllowUnencrypted</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>25</Order>
-                    <CommandLine>%SystemRoot%\System32\reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client" /v AllowBasic /t REG_DWORD /d 1 /f</CommandLine>
-                    <Description>Allow Basic Auth Client Policy</Description>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/service/auth @{Basic="true"}</CommandLine>
+                    <Description>WinRM auth Basic</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>26</Order>
-                    <CommandLine>%SystemRoot%\System32\reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client" /v AllowUnencryptedTraffic /t REG_DWORD /d 1 /f</CommandLine>
-                    <Description>Allow Unencrypted Traffic Client Policy</Description>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/service/auth @{Negotiate="true"}</CommandLine>
+                    <Description>WinRM auth Negotiate</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Order>27</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/client/auth @{Basic="true"}</CommandLine>
+                    <Description>WinRM client auth Basic</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>28</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set winrm/config/client/auth @{Negotiate="true"}</CommandLine>
+                    <Description>WinRM client auth Negotiate</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>29</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c winrm set "winrm/config/listener?Address=*+Transport=HTTP" @{Port="5985"}</CommandLine>
+                    <Description>WinRM listener Address/Port</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>30</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c sc config winrm start= auto</CommandLine>
+                    <Description>WinRM Autostart</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>31</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c "net stop winrm &amp; net start winrm || exit 0"</CommandLine>
+                    <Description>Restart WinRM Service</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>32</Order>
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v DefaultPassword /t REG_SZ /d "vagrant" /f</CommandLine>
+                    <Description>Enable AutoLogon DefaultPassword</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>33</Order>
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v DefaultUsername /t REG_SZ /d "vagrant" /f</CommandLine>
+                    <Description>Enable AutoLogon DefaultUsername</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>34</Order>
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" /v AutoAdminLogon /t REG_SZ /d 1 /f</CommandLine>
+                    <Description>Enable AutoLogon AutoAdminLogon</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <Order>35</Order>
                     <CommandLine>%SystemRoot%\System32\bcdedit.exe /ems {current} off</CommandLine>
                     <Description>Disable Kernel EMS to release COM1</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>28</Order>
+                    <Order>36</Order>
                     <CommandLine>%SystemRoot%\System32\bcdedit.exe /bootems off</CommandLine>
                     <Description>Disable Boot EMS</Description>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
-                    <Order>29</Order>
-                    <CommandLine>%windir%\System32\cmd.exe /c "echo [WIN11-SERIAL] WinRM and Serial Ready > COM1"</CommandLine>
+                    <Order>37</Order>
+                    <CommandLine>%windir%\System32\cmd.exe /c "echo [WIN11-SERIAL] WinRM and Serial Ready > COM1 || exit 0"</CommandLine>
                     <Description>Notify COM1 Serial</Description>
                 </SynchronousCommand>
             </FirstLogonCommands>

--- a/packer_templates/win_answer_files/11/arm64/SetupComplete.cmd
+++ b/packer_templates/win_answer_files/11/arm64/SetupComplete.cmd
@@ -1,0 +1,54 @@
+@echo off
+:: Windows 11 Post-Setup Bootstrap Script (runs as NT AUTHORITY\SYSTEM)
+echo [WIN11-SETUPCOMPLETE] Starting SetupComplete bootstrap... > COM1
+
+:: Ensure Administrator and vagrant accounts are enabled, in Administrators group, with password vagrant
+net.exe user Administrator /active:yes
+net.exe user Administrator vagrant
+net.exe user vagrant /active:yes
+net.exe user vagrant vagrant
+net.exe localgroup Administrators vagrant /add
+net.exe localgroup Administrators Administrator /add
+
+:: Configure registry security policies
+reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v LocalAccountTokenFilterPolicy /t REG_DWORD /d 1 /f
+reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v EnableLUA /t REG_DWORD /d 0 /f
+reg.exe add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v ConsentPromptBehaviorAdmin /t REG_DWORD /d 0 /f
+reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service" /v AllowBasic /t REG_DWORD /d 1 /f
+reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service" /v AllowUnencryptedTraffic /t REG_DWORD /d 1 /f
+reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client" /v AllowBasic /t REG_DWORD /d 1 /f
+reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client" /v AllowUnencryptedTraffic /t REG_DWORD /d 1 /f
+
+:: Set network category to private
+powershell.exe -ExecutionPolicy Bypass -NoProfile -Command "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force"
+powershell.exe -ExecutionPolicy Bypass -NoProfile -Command "Get-NetConnectionProfile | Set-NetConnectionProfile -NetworkCategory Private"
+
+:: Firewall
+netsh advfirewall firewall add rule name="Port 5985" dir=in action=allow protocol=TCP localport=5985
+
+:: WinRM service configuration
+sc.exe config winrm start= auto
+net.exe start winrm
+call %windir%\system32\winrm.cmd quickconfig -q
+call %windir%\system32\winrm.cmd quickconfig -transport:http
+call %windir%\system32\winrm.cmd set winrm/config @{MaxTimeoutms="1800000"}
+call %windir%\system32\winrm.cmd set winrm/config/winrs @{MaxMemoryPerShellMB="2048"}
+call %windir%\system32\winrm.cmd set winrm/config/winrs @{MaxShellsPerUser="50"}
+call %windir%\system32\winrm.cmd set winrm/config/winrs @{MaxConcurrentUsers="50"}
+call %windir%\system32\winrm.cmd set winrm/config/winrs @{MaxProcessesPerShell="50"}
+call %windir%\system32\winrm.cmd set winrm/config/service @{AllowUnencrypted="true"}
+call %windir%\system32\winrm.cmd set winrm/config/service/auth @{Basic="true"}
+call %windir%\system32\winrm.cmd set winrm/config/client/auth @{Basic="true"}
+call %windir%\system32\winrm.cmd set "winrm/config/listener?Address=*+Transport=HTTP" @{Port="5985"}
+
+:: Restart WinRM to apply policies
+sc.exe stop winrm
+timeout /t 2 /nobreak >nul
+sc.exe start winrm
+
+:: Serial Debugging (Release COM1 from kernel EMS for reliable logging)
+bcdedit.exe /ems {current} off
+bcdedit.exe /bootems off
+
+echo [WIN11-SETUPCOMPLETE] SetupComplete complete, WinRM ready on 5985 > COM1
+exit 0

--- a/packer_templates/win_answer_files/11/arm64/SetupComplete.cmd
+++ b/packer_templates/win_answer_files/11/arm64/SetupComplete.cmd
@@ -2,6 +2,19 @@
 :: Windows 11 Post-Setup Bootstrap Script (runs as NT AUTHORITY\SYSTEM)
 echo [WIN11-SETUPCOMPLETE] Starting SetupComplete bootstrap... > COM1
 
+:: Install VirtIO drivers from OEMDRV or attached media
+for %%d in (C D E F G H) do (
+    if exist %%d:\NetKVM\w11\ARM64\netkvm.inf (
+        echo [WIN11-SETUPCOMPLETE] Installing drivers from %%d: > COM1
+        pnputil.exe /add-driver %%d:\NetKVM\w11\ARM64\netkvm.inf /install
+        pnputil.exe /add-driver %%d:\viostor\w11\ARM64\viostor.inf /install
+        pnputil.exe /add-driver %%d:\vioscsi\w11\ARM64\vioscsi.inf /install
+        pnputil.exe /add-driver %%d:\Balloon\w11\ARM64\balloon.inf /install
+        pnputil.exe /add-driver %%d:\vioserial\w11\ARM64\vioser.inf /install
+        pnputil.exe /add-driver %%d:\viofs\w11\ARM64\viofs.inf /install
+    )
+)
+
 :: Ensure Administrator and vagrant accounts are enabled, in Administrators group, with password vagrant
 net.exe user Administrator /active:yes
 net.exe user Administrator vagrant

--- a/packer_templates/win_answer_files/11/arm64/SetupComplete.cmd
+++ b/packer_templates/win_answer_files/11/arm64/SetupComplete.cmd
@@ -1,11 +1,11 @@
 @echo off
 :: Windows 11 Post-Setup Bootstrap Script (runs as NT AUTHORITY\SYSTEM)
-echo [WIN11-SETUPCOMPLETE] Starting SetupComplete bootstrap... > COM1
+echo [WIN11-SETUPCOMPLETE] Starting SetupComplete bootstrap... > COM1 2>nul || ver >nul
 
 :: Install VirtIO drivers from OEMDRV or attached media
-for %%d in (C D E F G H) do (
+for %%d in (C D E F G H I J K) do (
     if exist %%d:\NetKVM\w11\ARM64\netkvm.inf (
-        echo [WIN11-SETUPCOMPLETE] Installing drivers from %%d: > COM1
+        echo [WIN11-SETUPCOMPLETE] Installing drivers from %%d: > COM1 2>nul || ver >nul
         pnputil.exe /add-driver %%d:\NetKVM\w11\ARM64\netkvm.inf /install
         pnputil.exe /add-driver %%d:\viostor\w11\ARM64\viostor.inf /install
         pnputil.exe /add-driver %%d:\vioscsi\w11\ARM64\vioscsi.inf /install
@@ -16,10 +16,13 @@ for %%d in (C D E F G H) do (
 )
 
 :: Ensure Administrator and vagrant accounts are enabled, in Administrators group, with password vagrant
+net.exe accounts /lockoutthreshold:0
 net.exe user Administrator /active:yes
 net.exe user Administrator vagrant
+net.exe user Administrator /expires:never
 net.exe user vagrant /active:yes
 net.exe user vagrant vagrant
+net.exe user vagrant /expires:never
 net.exe localgroup Administrators vagrant /add
 net.exe localgroup Administrators Administrator /add
 
@@ -34,7 +37,7 @@ reg.exe add "HKLM\SOFTWARE\Policies\Microsoft\Windows\WinRM\Client" /v AllowUnen
 
 :: Set network category to private
 powershell.exe -ExecutionPolicy Bypass -NoProfile -Command "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force"
-powershell.exe -ExecutionPolicy Bypass -NoProfile -Command "Get-NetConnectionProfile | Set-NetConnectionProfile -NetworkCategory Private"
+powershell.exe -ExecutionPolicy Bypass -NoProfile -Command "$ErrorActionPreference = 'SilentlyContinue'; Get-NetConnectionProfile | Set-NetConnectionProfile -NetworkCategory Private"
 
 :: Firewall
 netsh advfirewall firewall add rule name="Port 5985" dir=in action=allow protocol=TCP localport=5985
@@ -51,7 +54,9 @@ call %windir%\system32\winrm.cmd set winrm/config/winrs @{MaxConcurrentUsers="50
 call %windir%\system32\winrm.cmd set winrm/config/winrs @{MaxProcessesPerShell="50"}
 call %windir%\system32\winrm.cmd set winrm/config/service @{AllowUnencrypted="true"}
 call %windir%\system32\winrm.cmd set winrm/config/service/auth @{Basic="true"}
+call %windir%\system32\winrm.cmd set winrm/config/service/auth @{Negotiate="true"}
 call %windir%\system32\winrm.cmd set winrm/config/client/auth @{Basic="true"}
+call %windir%\system32\winrm.cmd set winrm/config/client/auth @{Negotiate="true"}
 call %windir%\system32\winrm.cmd set "winrm/config/listener?Address=*+Transport=HTTP" @{Port="5985"}
 
 :: Restart WinRM to apply policies
@@ -63,5 +68,5 @@ sc.exe start winrm
 bcdedit.exe /ems {current} off
 bcdedit.exe /bootems off
 
-echo [WIN11-SETUPCOMPLETE] SetupComplete complete, WinRM ready on 5985 > COM1
+echo [WIN11-SETUPCOMPLETE] SetupComplete complete, WinRM ready on 5985 > COM1 2>nul || ver >nul
 exit 0

--- a/packer_templates/win_answer_files/11/hyperv-gen2/Autounattend.xml
+++ b/packer_templates/win_answer_files/11/hyperv-gen2/Autounattend.xml
@@ -190,7 +190,7 @@
                         </Password>
                         <Description>Vagrant User</Description>
                         <DisplayName>vagrant</DisplayName>
-                        <Group>administrators</Group>
+                        <Group>Administrators</Group>
                         <Name>vagrant</Name>
                     </LocalAccount>
                 </LocalAccounts>

--- a/packer_templates/win_answer_files/2025/Autounattend.xml
+++ b/packer_templates/win_answer_files/2025/Autounattend.xml
@@ -116,6 +116,7 @@
             </ImageInstall>
             <UserData>
                 <ProductKey>
+                    %{ if windows_product_key != "" }<Key>${windows_product_key}</Key>%{ endif }
                     <WillShowUI>OnError</WillShowUI>
                 </ProductKey>
                 <AcceptEula>true</AcceptEula>

--- a/packer_templates/win_answer_files/2025/hyperv-gen2/Autounattend.xml
+++ b/packer_templates/win_answer_files/2025/hyperv-gen2/Autounattend.xml
@@ -122,6 +122,7 @@
             </ImageInstall>
             <UserData>
                 <ProductKey>
+                    %{ if windows_product_key != "" }<Key>${windows_product_key}</Key>%{ endif }
                     <WillShowUI>OnError</WillShowUI>
                 </ProductKey>
                 <AcceptEula>true</AcceptEula>

--- a/serial_proxy.py
+++ b/serial_proxy.py
@@ -51,13 +51,19 @@ def main():
     while running:
         # Try to connect to QEMU serial socket if not connected
         if qemu_conn is None:
-            if os.path.exists(QEMU_SOCK):
+            active_sock = None
+            candidates = [QEMU_SOCK, "/tmp/windows-11-serial.sock", "/tmp/bento-qemu-serial.sock"]
+            for cand in candidates:
+                if cand and os.path.exists(cand):
+                    active_sock = cand
+                    break
+            if active_sock:
                 try:
                     s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-                    s.connect(QEMU_SOCK)
+                    s.connect(active_sock)
                     s.setblocking(False)
                     qemu_conn = s
-                    print("[serial_proxy] Connected to QEMU serial port.", file=sys.stderr)
+                    print(f"[serial_proxy] Connected to QEMU serial port: {active_sock}", file=sys.stderr)
                 except Exception:
                     qemu_conn = None
             if qemu_conn is None:

--- a/serial_proxy.py
+++ b/serial_proxy.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Serial socket multiplexer & logger for Windows 11 Bento builds.
+Connects to QEMU's serial socket (/tmp/windows-11-serial.sock),
+logs all output in real-time to serial.log, and serves an interactive
+client socket (/tmp/windows-11-serial-client.sock) for bidirectional debugging.
+"""
+import os
+import sys
+import time
+import socket
+import select
+import signal
+
+QEMU_SOCK = os.environ.get("SERIAL_SOCK", "/tmp/windows-11-serial.sock")
+CLIENT_SOCK = os.environ.get("SERIAL_CLIENT_SOCK", "/tmp/windows-11-serial-client.sock")
+LOG_FILE = os.environ.get("SERIAL_LOG", "serial.log")
+
+running = True
+
+def handle_sig(sig, frame):
+    global running
+    running = False
+
+signal.signal(signal.SIGINT, handle_sig)
+signal.signal(signal.SIGTERM, handle_sig)
+
+def main():
+    global running
+    # Ensure client socket file is clean
+    if os.path.exists(CLIENT_SOCK):
+        try:
+            os.unlink(CLIENT_SOCK)
+        except OSError:
+            pass
+
+    # Server socket for interactive serial clients
+    server_s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server_s.bind(CLIENT_SOCK)
+    server_s.listen(5)
+    server_s.setblocking(False)
+
+    clients = []
+    qemu_conn = None
+    log_f = open(LOG_FILE, "ab", buffering=0)
+
+    print(f"[serial_proxy] Monitoring QEMU socket: {QEMU_SOCK}", file=sys.stderr)
+    print(f"[serial_proxy] Client socket ready: {CLIENT_SOCK}", file=sys.stderr)
+    print(f"[serial_proxy] Logging to: {LOG_FILE}", file=sys.stderr)
+
+    while running:
+        # Try to connect to QEMU serial socket if not connected
+        if qemu_conn is None:
+            if os.path.exists(QEMU_SOCK):
+                try:
+                    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                    s.connect(QEMU_SOCK)
+                    s.setblocking(False)
+                    qemu_conn = s
+                    print("[serial_proxy] Connected to QEMU serial port.", file=sys.stderr)
+                except Exception:
+                    qemu_conn = None
+            if qemu_conn is None:
+                time.sleep(0.3)
+
+        read_fds = [server_s]
+        if qemu_conn is not None:
+            read_fds.append(qemu_conn)
+        read_fds.extend(clients)
+
+        try:
+            rlist, _, _ = select.select(read_fds, [], [], 0.5)
+        except (select.error, InterruptedError):
+            break
+
+        for fd in rlist:
+            if fd is server_s:
+                try:
+                    client_conn, _ = server_s.accept()
+                    client_conn.setblocking(False)
+                    clients.append(client_conn)
+                    print(f"[serial_proxy] Interactive client connected ({len(clients)} total).", file=sys.stderr)
+                except Exception:
+                    pass
+            elif fd is qemu_conn:
+                try:
+                    data = qemu_conn.recv(4096)
+                    if not data:
+                        print("[serial_proxy] QEMU disconnected (VM rebooting or shutting down).", file=sys.stderr)
+                        qemu_conn.close()
+                        qemu_conn = None
+                    else:
+                        log_f.write(data)
+                        dead_clients = []
+                        for c in clients:
+                            try:
+                                c.sendall(data)
+                            except Exception:
+                                dead_clients.append(c)
+                        for dc in dead_clients:
+                            if dc in clients:
+                                clients.remove(dc)
+                            try:
+                                dc.close()
+                            except Exception:
+                                pass
+                except Exception:
+                    if qemu_conn:
+                        qemu_conn.close()
+                    qemu_conn = None
+            elif fd in clients:
+                try:
+                    data = fd.recv(1024)
+                    if not data:
+                        clients.remove(fd)
+                        fd.close()
+                    else:
+                        if qemu_conn:
+                            try:
+                                qemu_conn.sendall(data)
+                            except Exception:
+                                pass
+                except Exception:
+                    if fd in clients:
+                        clients.remove(fd)
+                    try:
+                        fd.close()
+                    except Exception:
+                        pass
+
+    # Cleanup
+    if qemu_conn:
+        qemu_conn.close()
+    for c in clients:
+        try:
+            c.close()
+        except Exception:
+            pass
+    server_s.close()
+    log_f.close()
+    if os.path.exists(CLIENT_SOCK):
+        try:
+            os.unlink(CLIENT_SOCK)
+        except OSError:
+            pass
+    print("[serial_proxy] Terminated cleanly.", file=sys.stderr)
+
+if __name__ == "__main__":
+    main()

--- a/windows-11-builder.sh
+++ b/windows-11-builder.sh
@@ -32,6 +32,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${SCRIPT_DIR}"
 
+# Load .env if present
+if [ -f "${SCRIPT_DIR}/.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . "${SCRIPT_DIR}/.env"
+  set +a
+fi
+
 # ANSI Colors
 C_RESET="\033[0m"
 C_BOLD="\033[1m"
@@ -46,6 +54,7 @@ log_info()    { echo -e "${C_CYAN}${C_BOLD}==> [INFO]${C_RESET} $*"; }
 log_success() { echo -e "${C_GREEN}${C_BOLD}==> [SUCCESS]${C_RESET} $*"; }
 log_warn()    { echo -e "${C_YELLOW}${C_BOLD}==> [WARN]${C_RESET} $*"; }
 log_error()   { echo -e "${C_RED}${C_BOLD}==> [ERROR]${C_RESET} $*" >&2; }
+get_file_size() { stat -f %z "$1" 2>/dev/null || stat -c %s "$1" 2>/dev/null || wc -c < "$1" | tr -d ' '; }
 
 # Default Parameters
 COMMAND="build"
@@ -77,8 +86,9 @@ VM_MEM="6144"
 VM_CPUS="4"
 VM_VNC=""
 CUSTOM_ISO=""
-SERIAL_SOCK="/tmp/windows-11-serial.sock"
-SERIAL_CLIENT_SOCK="/tmp/windows-11-serial-client.sock"
+TMP_DIR="${TMPDIR:-/tmp}"
+SERIAL_SOCK="${TMP_DIR}/windows-11-serial.sock"
+SERIAL_CLIENT_SOCK="${TMP_DIR}/windows-11-serial-client.sock"
 SERIAL_LOG="${SCRIPT_DIR}/serial.log"
 PROXY_SCRIPT="${SCRIPT_DIR}/serial_proxy.py"
 
@@ -159,23 +169,37 @@ find_iso() {
     echo "${CUSTOM_ISO}"
     return 0
   fi
-  # Check local builds/iso first
-  local local_iso
-  local_iso=$(find "${SCRIPT_DIR}/builds/iso" -maxdepth 1 -name "windows-11-${ARCH}*.iso" 2>/dev/null | head -n 1)
-  if [ -n "${local_iso}" ] && [ -f "${local_iso}" ]; then
-    echo "${local_iso}"
+  if [ -n "${WIN11_TARGET_ISO:-}" ] && [ -f "${WIN11_TARGET_ISO}" ]; then
+    echo "${WIN11_TARGET_ISO}"
     return 0
   fi
-  local_iso=$(find "${SCRIPT_DIR}/builds/iso" -maxdepth 1 -name "*win*11*${ARCH}*.iso" 2>/dev/null | head -n 1)
-  if [ -n "${local_iso}" ] && [ -f "${local_iso}" ]; then
-    echo "${local_iso}"
+  if [ -n "${WIN11_ISO_PATH:-}" ] && [ -f "${WIN11_ISO_PATH}" ]; then
+    echo "${WIN11_ISO_PATH}"
     return 0
   fi
-  local_iso=$(find "${SCRIPT_DIR}/builds/iso" -maxdepth 1 -name "*windows-11*.iso" 2>/dev/null | head -n 1)
-  if [ -n "${local_iso}" ] && [ -f "${local_iso}" ]; then
-    echo "${local_iso}"
-    return 0
+  local search_dirs=()
+  if [ -n "${ISO_DIR:-}" ] && [ -d "${ISO_DIR}" ]; then
+    search_dirs+=("${ISO_DIR}")
   fi
+  search_dirs+=("${SCRIPT_DIR}/builds/iso")
+  for sdir in "${search_dirs[@]}"; do
+    local local_iso
+    local_iso=$(find "${sdir}" -maxdepth 1 -name "windows-11-${ARCH}*.iso" 2>/dev/null | head -n 1)
+    if [ -n "${local_iso}" ] && [ -f "${local_iso}" ]; then
+      echo "${local_iso}"
+      return 0
+    fi
+    local_iso=$(find "${sdir}" -maxdepth 1 \( -name "*win*11*${ARCH}*.iso" -o -name "*Win*11*${ARCH}*.iso" -o -name "*Win*11*Arm64*.iso" -o -name "*Win11*${ARCH}*.iso" -o -name "*Win11*Arm64*.iso" \) 2>/dev/null | head -n 1)
+    if [ -n "${local_iso}" ] && [ -f "${local_iso}" ]; then
+      echo "${local_iso}"
+      return 0
+    fi
+    local_iso=$(find "${sdir}" -maxdepth 1 -name "*windows-11*.iso" 2>/dev/null | head -n 1)
+    if [ -n "${local_iso}" ] && [ -f "${local_iso}" ]; then
+      echo "${local_iso}"
+      return 0
+    fi
+  done
   echo ""
 }
 
@@ -424,7 +448,7 @@ cmd_status() {
       local dsz
       dsz=$(du -h "$d" | cut -f1)
       local dbytes
-      dbytes=$(stat -c %s "$d")
+      dbytes=$(get_file_size "$d")
       echo -e "  - $(basename "$(dirname "$d")")/$(basename "$d") : ${C_CYAN}${dsz}${C_RESET} (${dbytes} bytes)"
       found_disks=1
     fi
@@ -444,7 +468,7 @@ cmd_status() {
       local bsz
       bsz=$(du -h "$b" | cut -f1)
       local bsz_bytes
-      bsz_bytes=$(stat -c %s "$b")
+      bsz_bytes=$(get_file_size "$b")
       echo -e "  - $(basename "$b") : ${C_GREEN}${C_BOLD}${bsz}${C_RESET} (${bsz_bytes} bytes)"
     done
   else
@@ -490,38 +514,87 @@ cmd_run() {
   fi
 
   # Find UEFI firmware code and vars
+  local brew_prefix=""
+  if command -v brew >/dev/null 2>&1; then
+    brew_prefix="$(brew --prefix 2>/dev/null)"
+  fi
+
   local efi_code=""
   local efi_vars=""
   if [ "${ARCH}" = "x86_64" ]; then
     local efi_candidates=(
-      "/usr/local/share/qemu/edk2-x86_64-code.fd"
+      "${QEMU_EDK2_CODE:-}"
+      "${QEMU_BIOS:-}"
       "/usr/share/OVMF/OVMF_CODE.fd"
+      "/usr/share/OVMF/OVMF_CODE_4M.fd"
       "/usr/share/ovmf/OVMF.fd"
+      "/usr/share/edk2/ovmf/OVMF_CODE.fd"
+      "/usr/share/edk2-ovmf/x64/OVMF_CODE.fd"
+      ${brew_prefix:+"${brew_prefix}/share/qemu/edk2-x86_64-code.fd"}
+      "/opt/homebrew/share/qemu/edk2-x86_64-code.fd"
+      "/usr/local/share/qemu/edk2-x86_64-code.fd"
+      "/opt/local/share/qemu/edk2-x86_64-code.fd"
+      "/usr/share/qemu/edk2-x86_64-code.fd"
+      "/usr/share/qemu/OVMF.fd"
+      "C:/Program Files/qemu/share/edk2-x86_64-code.fd"
+      "C:/msys64/mingw64/share/qemu/edk2-x86_64-code.fd"
     )
     for c in "${efi_candidates[@]}"; do
-      if [ -f "$c" ]; then efi_code="$c"; break; fi
+      if [ -n "$c" ] && [ -f "$c" ]; then efi_code="$c"; break; fi
     done
     local var_candidates=(
-      "/usr/local/share/qemu/edk2-i386-vars.fd"
+      "${QEMU_EDK2_VARS:-}"
       "/usr/share/OVMF/OVMF_VARS.fd"
+      "/usr/share/OVMF/OVMF_VARS_4M.fd"
+      "/usr/share/ovmf/OVMF_VARS.fd"
+      "/usr/share/edk2/ovmf/OVMF_VARS.fd"
+      "/usr/share/edk2-ovmf/x64/OVMF_VARS.fd"
+      ${brew_prefix:+"${brew_prefix}/share/qemu/edk2-i386-vars.fd"}
+      "/opt/homebrew/share/qemu/edk2-i386-vars.fd"
+      "/usr/local/share/qemu/edk2-i386-vars.fd"
+      "/opt/local/share/qemu/edk2-i386-vars.fd"
+      "/usr/share/qemu/edk2-i386-vars.fd"
+      "C:/Program Files/qemu/share/edk2-i386-vars.fd"
+      "C:/msys64/mingw64/share/qemu/edk2-i386-vars.fd"
     )
     for v in "${var_candidates[@]}"; do
-      if [ -f "$v" ]; then efi_vars="$v"; break; fi
+      if [ -n "$v" ] && [ -f "$v" ]; then efi_vars="$v"; break; fi
     done
   else
     local efi_candidates=(
-      "/usr/local/share/qemu/edk2-aarch64-code.fd"
+      "${QEMU_EDK2_CODE:-}"
+      "${QEMU_BIOS:-}"
+      ${brew_prefix:+"${brew_prefix}/share/qemu/edk2-aarch64-code.fd"}
+      "/opt/homebrew/share/qemu/edk2-aarch64-code.fd"
       "/usr/share/AAVMF/AAVMF_CODE.fd"
+      "/usr/share/AAVMF/AAVMF32_CODE.fd"
+      "/usr/share/qemu/edk2-aarch64-code.fd"
+      "/usr/share/edk2/aarch64/QEMU_EFI-pflash.raw"
+      "/usr/share/edk2/aarch64/QEMU_EFI.fd"
+      "/usr/share/edk2-armvirt/aarch64/QEMU_EFI.fd"
+      "/usr/local/share/qemu/edk2-aarch64-code.fd"
+      "/opt/local/share/qemu/edk2-aarch64-code.fd"
+      "C:/Program Files/qemu/share/edk2-aarch64-code.fd"
+      "C:/msys64/mingw64/share/qemu/edk2-aarch64-code.fd"
     )
     for c in "${efi_candidates[@]}"; do
-      if [ -f "$c" ]; then efi_code="$c"; break; fi
+      if [ -n "$c" ] && [ -f "$c" ]; then efi_code="$c"; break; fi
     done
     local var_candidates=(
-      "/usr/local/share/qemu/edk2-arm-vars.fd"
+      "${QEMU_EDK2_VARS:-}"
+      ${brew_prefix:+"${brew_prefix}/share/qemu/edk2-arm-vars.fd"}
+      "/opt/homebrew/share/qemu/edk2-arm-vars.fd"
       "/usr/share/AAVMF/AAVMF_VARS.fd"
+      "/usr/share/qemu/edk2-arm-vars.fd"
+      "/usr/share/edk2/aarch64/vars-template-pflash.raw"
+      "/usr/share/edk2-armvirt/aarch64/QEMU_VARS.fd"
+      "/usr/local/share/qemu/edk2-arm-vars.fd"
+      "/opt/local/share/qemu/edk2-arm-vars.fd"
+      "C:/Program Files/qemu/share/edk2-arm-vars.fd"
+      "C:/msys64/mingw64/share/qemu/edk2-arm-vars.fd"
     )
     for v in "${var_candidates[@]}"; do
-      if [ -f "$v" ]; then efi_vars="$v"; break; fi
+      if [ -n "$v" ] && [ -f "$v" ]; then efi_vars="$v"; break; fi
     done
   fi
 
@@ -542,10 +615,29 @@ cmd_run() {
 
   echo -e "${C_GREEN}${C_BOLD}VM is starting. In another terminal, run './windows-11-builder.sh serial' to connect.${C_RESET}"
 
+  local host_os="linux"
+  case "$(uname -s)" in
+    Darwin*) host_os="darwin" ;;
+    Linux*)  host_os="linux" ;;
+    CYGWIN*|MINGW*|MSYS*) host_os="windows" ;;
+  esac
+
+  local qemu_accel="kvm"
+  if [ "${host_os}" = "darwin" ]; then
+    qemu_accel="hvf"
+  elif [ "${host_os}" = "windows" ]; then
+    qemu_accel="whpx"
+  fi
+
+  local qemu_mach="q35,accel=${qemu_accel}"
+  if [ "${ARCH}" = "aarch64" ]; then
+    qemu_mach="virt,highmem=on,accel=${qemu_accel}"
+  fi
+
   local qemu_cmd=(
     "qemu-system-${ARCH}"
     "-name" "windows-11-${ARCH}"
-    "-machine" "q35,accel=kvm"
+    "-machine" "${qemu_mach}"
     "-cpu" "host"
     "-smp" "${VM_CPUS}"
     "-m" "${VM_MEM}"
@@ -567,16 +659,29 @@ cmd_run() {
     qemu_cmd+=("-drive" "if=pflash,format=raw,file=${run_vars}")
   fi
 
-  qemu_cmd+=(
-    "-drive" "file=${disk_img},if=none,id=disk0,cache=writeback,discard=unmap"
-    "-device" "ide-hd,drive=disk0,bus=ide.0"
-    "-netdev" "user,id=user.0,hostfwd=tcp::5985-:5985,hostfwd=tcp::3389-:3389,hostfwd=tcp::2222-:22"
-    "-device" "virtio-net-pci,netdev=user.0"
-    "-device" "qemu-xhci"
-    "-device" "usb-kbd"
-    "-device" "usb-tablet"
-    "-vga" "std"
-  )
+  if [ "${ARCH}" = "aarch64" ]; then
+    qemu_cmd+=(
+      "-drive" "file=${disk_img},if=none,id=disk0,cache=writeback,discard=unmap"
+      "-device" "nvme,serial=nvme0,drive=disk0"
+      "-netdev" "user,id=user.0,hostfwd=tcp::5985-:5985,hostfwd=tcp::3389-:3389,hostfwd=tcp::2222-:22"
+      "-device" "virtio-net-pci,netdev=user.0"
+      "-device" "qemu-xhci"
+      "-device" "usb-kbd"
+      "-device" "usb-tablet"
+      "-device" "ramfb"
+    )
+  else
+    qemu_cmd+=(
+      "-drive" "file=${disk_img},if=none,id=disk0,cache=writeback,discard=unmap"
+      "-device" "ide-hd,drive=disk0,bus=ide.0"
+      "-netdev" "user,id=user.0,hostfwd=tcp::5985-:5985,hostfwd=tcp::3389-:3389,hostfwd=tcp::2222-:22"
+      "-device" "virtio-net-pci,netdev=user.0"
+      "-device" "qemu-xhci"
+      "-device" "usb-kbd"
+      "-device" "usb-tablet"
+      "-vga" "std"
+    )
+  fi
 
   if [ -n "${VM_VNC}" ]; then
     qemu_cmd+=("-vnc" ":${VM_VNC}")
@@ -600,8 +705,9 @@ cmd_box() {
   log_info "  AGGRESSIVE VAGRANT .BOX SIZE REDUCTION PIPELINE (${ARCH}, ${provider})"
   log_info "================================================================"
 
-  local build_files_dir="${SCRIPT_DIR}/builds/build_files/packer-windows-11-${ARCH}-${provider}"
-  local complete_dir="${SCRIPT_DIR}/builds/build_complete"
+  local base_files_dir="${BENTO_BUILD_FILES_DIR:-${SCRIPT_DIR}/builds/build_files}"
+  local build_files_dir="${base_files_dir}/packer-windows-11-${ARCH}-${provider}"
+  local complete_dir="${BENTO_BUILD_COMPLETE_DIR:-${SCRIPT_DIR}/builds/build_complete}"
   mkdir -p "${complete_dir}"
 
   local box_name="windows-11-${ARCH}.${provider}.box"
@@ -629,7 +735,10 @@ cmd_box() {
       if [ -n "${existing_box}" ]; then
         log_info "Extracting disk image from existing box (${existing_box}) for optimization..."
         mkdir -p "${build_files_dir}"
-        tar -xf "${existing_box}" -C "${build_files_dir}" box.img 2>/dev/null || true
+        tar -xf "${existing_box}" -C "${build_files_dir}" box_0.img 2>/dev/null || tar -xf "${existing_box}" -C "${build_files_dir}" box.img 2>/dev/null || true
+        if [ -f "${build_files_dir}/box_0.img" ]; then
+          mv -f "${build_files_dir}/box_0.img" "${build_files_dir}/box.img"
+        fi
         if [ -f "${build_files_dir}/box.img" ]; then
           src_img="${build_files_dir}/box.img"
         fi
@@ -642,7 +751,7 @@ cmd_box() {
     fi
 
     local orig_bytes
-    orig_bytes=$(stat -c %s "${src_img}")
+    orig_bytes=$(get_file_size "${src_img}")
     local orig_mb=$((orig_bytes / 1024 / 1024))
     log_info "Step 1: Input disk image: ${src_img}"
     log_info "        Original disk image size: ${orig_mb} MB ($((orig_mb / 1024)) GB)"
@@ -658,7 +767,7 @@ cmd_box() {
     qemu-img convert -p -m 16 -W -O qcow2 -c -S 4k "${src_img}" "${opt_img}"
 
     local opt_bytes
-    opt_bytes=$(stat -c %s "${opt_img}")
+    opt_bytes=$(get_file_size "${opt_img}")
     local opt_mb=$((opt_bytes / 1024 / 1024))
     local saved_mb=$((orig_mb - opt_mb))
     log_success "Compressed disk image size: ${opt_mb} MB (Direct disk savings: ${saved_mb} MB)"
@@ -669,10 +778,15 @@ cmd_box() {
     virt_gb=$(qemu-img info --output=json "${src_img}" | python3 -c "import sys, json; print(int(json.load(sys.stdin).get('virtual-size', 68719476736) / (1024**3)))" 2>/dev/null || echo "64")
 
     # Step 3: Generate Vagrant metadata and template
-    log_info "Step 3: Generating Vagrant metadata (virtual_size: ${virt_gb} GB) and Vagrantfile template..."
+    # vagrant-qemu uses box_format: "libvirt" (v1 format)
+    local meta_provider="${provider}"
+    if [ "${provider}" = "qemu" ]; then
+      meta_provider="libvirt"
+    fi
+    log_info "Step 3: Generating Vagrant metadata (${meta_provider}, virtual_size: ${virt_gb} GB) and Vagrantfile template..."
     cat << EOF > "${build_files_dir}/metadata.json"
 {
-  "provider": "libvirt",
+  "provider": "${meta_provider}",
   "format": "qcow2",
   "virtual_size": ${virt_gb}
 }
@@ -688,14 +802,16 @@ Vagrant.configure("2") do |config|
   config.winrm.retry_limit = 30
   config.winrm.retry_delay = 10
   config.ssh.username = "vagrant"
-  config.ssh.password = "vagrant"
+  config.ssh.insert_key = false
+  config.ssh.private_key_path = File.expand_path("~/.vagrant.d/insecure_private_key")
+  config.ssh.shell = "powershell"
 
   config.vm.network :forwarded_port, guest: 22, host: 2222, id: 'ssh', auto_correct: true
   config.vm.network :forwarded_port, guest: 3389, host: 3389, id: 'rdp', auto_correct: true
   config.vm.network :forwarded_port, guest: 5985, host: 5985, id: 'winrm', auto_correct: true
 
-  # On Windows with libvirt, 9p is not natively supported. Synced folder is disabled by default unless SMB/rsync is configured.
-  config.vm.synced_folder ".", "/vagrant", disabled: true
+  # Synced folder: rsync works without host privileges or password prompts
+  config.vm.synced_folder ".", "/vagrant", type: "rsync"
 
   config.vm.provider :libvirt do |lv|
     lv.cpus = 4
@@ -704,6 +820,91 @@ Vagrant.configure("2") do |config|
     lv.nic_model_type = "virtio"
     lv.driver = "kvm"
   end
+
+  is_darwin = /darwin/ =~ RUBY_PLATFORM
+  is_windows = /mswin|mingw|cygwin/ =~ RUBY_PLATFORM
+  accel = is_darwin ? "hvf" : (is_windows ? "whpx" : "kvm")
+
+  host_cpu = (RbConfig::CONFIG["host_cpu"] || RUBY_PLATFORM).downcase
+  is_arm = host_cpu =~ /aarch64|arm64/
+
+  config.vm.provider :qemu do |qe|
+    if is_arm
+      qe.arch = "aarch64"
+      qe.machine = "virt,highmem=on,accel=#{accel}"
+      qe.cpu = "host"
+      qe.smp = "4"
+      qe.memory = "4096M"
+      qe.firmware_format = nil
+      qe.drive_interface = "none"
+      qe.net_device = "virtio-net-pci"
+      qe.ssh_auto_correct = true
+
+      bios_candidates = [
+        ENV["QEMU_EDK2_PATH"],
+        ENV["QEMU_BIOS"],
+        "/opt/homebrew/share/qemu/edk2-aarch64-code.fd",
+        "/usr/share/AAVMF/AAVMF_CODE.fd",
+        "/usr/share/AAVMF/AAVMF32_CODE.fd",
+        "/usr/share/qemu/edk2-aarch64-code.fd",
+        "/usr/share/edk2/aarch64/QEMU_EFI-pflash.raw",
+        "/usr/share/edk2/aarch64/QEMU_EFI.fd",
+        "/usr/share/edk2-armvirt/aarch64/QEMU_EFI.fd",
+        "/usr/local/share/qemu/edk2-aarch64-code.fd",
+        "/opt/local/share/qemu/edk2-aarch64-code.fd",
+        "C:/Program Files/qemu/share/edk2-aarch64-code.fd",
+        "C:/msys64/mingw64/share/qemu/edk2-aarch64-code.fd"
+      ].compact
+      bios_path = bios_candidates.find { |path| File.exist?(path) }
+
+      extra_args = []
+      extra_args.push("-bios", bios_path) if bios_path
+      extra_args.push(
+        "-device", "nvme,serial=nvme0,drive=disk0",
+        "-device", "ramfb",
+        "-device", "qemu-xhci",
+        "-device", "usb-kbd",
+        "-device", "usb-tablet"
+      )
+      qe.extra_qemu_args = extra_args
+    else
+      qe.arch = "x86_64"
+      qe.machine = "q35,accel=#{accel}"
+      qe.cpu = "host"
+      qe.smp = "4"
+      qe.memory = "4096M"
+      qe.drive_interface = "ide"
+      qe.net_device = "virtio-net-pci"
+      qe.ssh_auto_correct = true
+
+      ovmf_candidates = [
+        ENV["QEMU_EDK2_PATH"],
+        ENV["QEMU_BIOS"],
+        "/usr/share/OVMF/OVMF_CODE.fd",
+        "/usr/share/OVMF/OVMF_CODE_4M.fd",
+        "/usr/share/ovmf/OVMF.fd",
+        "/usr/share/edk2/ovmf/OVMF_CODE.fd",
+        "/usr/share/edk2-ovmf/x64/OVMF_CODE.fd",
+        "/opt/homebrew/share/qemu/edk2-x86_64-code.fd",
+        "/usr/local/share/qemu/edk2-x86_64-code.fd",
+        "/opt/local/share/qemu/edk2-x86_64-code.fd",
+        "/usr/share/qemu/edk2-x86_64-code.fd",
+        "C:/Program Files/qemu/share/edk2-x86_64-code.fd",
+        "C:/msys64/mingw64/share/qemu/edk2-x86_64-code.fd"
+      ].compact
+      ovmf_path = ovmf_candidates.find { |path| File.exist?(path) }
+
+      extra_args = []
+      extra_args.push("-bios", ovmf_path) if ovmf_path
+      extra_args.push(
+        "-device", "qemu-xhci",
+        "-device", "usb-kbd",
+        "-device", "usb-tablet",
+        "-vga", "std"
+      )
+      qe.extra_qemu_args = extra_args
+    end
+  end
 end
 EOF
 
@@ -711,17 +912,25 @@ EOF
     log_info "Step 4: Compacting into .box with sparse block preservation & level-9 compression..."
     local tmp_box="${target_box}.tmp"
 
+    local tar_cmd="tar"
+    local tar_sparse="--sparse"
+    if command -v gtar >/dev/null 2>&1; then
+      tar_cmd="gtar"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+      tar_sparse=""
+    fi
+
     if command -v pigz >/dev/null 2>&1; then
       log_info "Using parallel pigz for maximum compression (-9) across all CPU cores..."
       (
         cd "${build_files_dir}"
-        tar --sparse -I 'pigz -9' -cf "${tmp_box}" metadata.json Vagrantfile box.img
+        ${tar_cmd} ${tar_sparse} -I 'pigz -9' -cf "${tmp_box}" metadata.json Vagrantfile box.img
       )
     else
       log_info "Using gzip -9 for maximum compression..."
       (
         cd "${build_files_dir}"
-        GZIP="-9" tar --sparse -czf "${tmp_box}" metadata.json Vagrantfile box.img
+        GZIP="-9" ${tar_cmd} ${tar_sparse} -czf "${tmp_box}" metadata.json Vagrantfile box.img
       )
     fi
 
@@ -734,7 +943,7 @@ EOF
     fi
 
     local box_bytes
-    box_bytes=$(stat -c %s "${target_box}")
+    box_bytes=$(get_file_size "${target_box}")
     local box_mb=$((box_bytes / 1024 / 1024))
     local total_saved_mb=$((orig_mb - box_mb))
 
@@ -772,7 +981,7 @@ EOF
     fi
     mv -f "${tmp_box}" "${target_box}"
     local box_bytes
-    box_bytes=$(stat -c %s "${target_box}")
+    box_bytes=$(get_file_size "${target_box}")
     log_success "Created optimized box: ${target_box} ($((box_bytes / 1024 / 1024)) MB)"
   fi
 }
@@ -815,14 +1024,28 @@ cmd_build() {
     exit 1
   fi
 
+  if [ "${ARCH}" = "aarch64" ] && [ "${PROVIDER}" = "qemu" ] && [ -f "${SCRIPT_DIR}/windows-11-arm64-packer/build.sh" ]; then
+    log_info "Executing dedicated Windows 11 ARM64 QEMU build pipeline..."
+    "${SCRIPT_DIR}/windows-11-arm64-packer/build.sh"
+    cmd_box "${PROVIDER}"
+    log_success "Windows 11 build and box creation completed successfully!"
+    return 0
+  fi
+
   log_info "Validating Packer templates..."
   packer validate -var-file="${pkrvars}" "${SCRIPT_DIR}/packer_templates"
 
   log_info "Executing Packer Build for Windows 11 (${PROVIDER})..."
   local pkr_opts=("-timestamp-ui" "-force" "-var-file=${pkrvars}")
 
-  if [ -n "${CUSTOM_ISO}" ]; then
-    pkr_opts+=("-var" "iso_url=file://${CUSTOM_ISO}")
+  local effective_iso="${CUSTOM_ISO:-${iso_path}}"
+  if [ -n "${effective_iso}" ]; then
+    pkr_opts+=("-var" "iso_url=file://${effective_iso}")
+    if [ -f "${effective_iso}.sha256" ]; then
+      pkr_opts+=("-var" "iso_checksum=$(cat "${effective_iso}.sha256")")
+    elif [ -n "${PKR_VAR_iso_checksum:-}" ]; then
+      pkr_opts+=("-var" "iso_checksum=${PKR_VAR_iso_checksum}")
+    fi
   fi
 
   if [ "${PROVIDER}" = "qemu" ]; then

--- a/windows-11-builder.sh
+++ b/windows-11-builder.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # ==============================================================================
 # Windows 11 Automated Builder, Runner & Minimal Box Creation Tool for Bento
 #
@@ -18,7 +18,9 @@
 #   --arch         x86_64 | aarch64  (default: auto-detected host arch)
 #   --iso          Path to Windows 11 ISO (default: auto-detected)
 #   --headless     true | false (default: true)
-#   --debug        Enable Packer and hypervisor debug output
+#   --gui          Display GUI window for VM (shortcut for --headless false)
+#   --debug        Enable Packer and hypervisor debug logging & display VM window
+#   --step         Pause interactively after each Packer build step
 #   --serial       Stream serial output to terminal during build
 #   --watch        Watch live serial log streaming (for serial command)
 #   --tail [N]     Display last N lines of serial log (default: 50)
@@ -27,9 +29,9 @@
 #   --cpus <N>     CPUs for runner (default: 4)
 #   --vnc <PORT>   VNC display port for runner (default: none / headless)
 # ==============================================================================
-set -euo pipefail
+set -eu
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 cd "${SCRIPT_DIR}"
 
 # Load .env if present
@@ -40,20 +42,68 @@ if [ -f "${SCRIPT_DIR}/.env" ]; then
   set +a
 fi
 
+# Ensure storage directory is mounted, created, and writable with automatic fallback
+ensure_storage_dir() {
+  _target="$1"
+  _fallback_sub="$2"
+
+  case "${_target}" in
+    /Volumes/*)
+      _vol_name=$(printf '%s\n' "${_target}" | awk -F/ '{print $3}')
+      if [ -n "${_vol_name}" ] && [ ! -d "/Volumes/${_vol_name}" ] && command -v hdiutil >/dev/null 2>&1; then
+        for _bundle in \
+          "${EXTERNAL_STATE_SPARSEBUNDLE:-}" \
+          ${EXTERNAL_STORAGE_DIR:+"${EXTERNAL_STORAGE_DIR}/${_vol_name}.sparsebundle"} \
+          "/Volumes/"*"/${_vol_name}.sparsebundle" \
+          "${HOME}/${_vol_name}.sparsebundle"
+        do
+          if [ -n "${_bundle}" ] && [ -e "${_bundle}" ]; then
+            hdiutil attach -nobrowse "${_bundle}" >/dev/null 2>&1 || true
+            break
+          fi
+        done
+      fi
+      ;;
+  esac
+
+  if [ -n "${_target}" ] && mkdir -p "${_target}" 2>/dev/null && [ -w "${_target}" ]; then
+    printf '%s\n' "${_target}"
+    return 0
+  fi
+
+  if [ -n "${EXTERNAL_VAGRANT_DIR:-}" ] && [ -d "${EXTERNAL_VAGRANT_DIR}" ] && [ -w "${EXTERNAL_VAGRANT_DIR}" ]; then
+    _fb="${EXTERNAL_VAGRANT_DIR}/${_fallback_sub}"
+  elif [ -n "${EXTERNAL_STORAGE_DIR:-}" ] && [ -d "${EXTERNAL_STORAGE_DIR}/vagrant" ] && [ -w "${EXTERNAL_STORAGE_DIR}/vagrant" ]; then
+    _fb="${EXTERNAL_STORAGE_DIR}/vagrant/${_fallback_sub}"
+  else
+    _fb="${SCRIPT_DIR}/builds/${_fallback_sub}"
+  fi
+
+  mkdir -p "${_fb}" 2>/dev/null || true
+  printf '%s\n' "${_fb}"
+}
+
+BENTO_BUILD_FILES_DIR="$(ensure_storage_dir "${BENTO_BUILD_FILES_DIR:-}" "build_files")"
+BENTO_BUILD_COMPLETE_DIR="$(ensure_storage_dir "${BENTO_BUILD_COMPLETE_DIR:-}" "build_complete")"
+export BENTO_BUILD_FILES_DIR
+export BENTO_BUILD_COMPLETE_DIR
+
 # ANSI Colors
 C_RESET="\033[0m"
 C_BOLD="\033[1m"
 C_RED="\033[31m"
 C_GREEN="\033[32m"
 C_YELLOW="\033[33m"
-C_BLUE="\033[34m"
 C_CYAN="\033[36m"
-C_MAGENTA="\033[35m"
 
-log_info()    { echo -e "${C_CYAN}${C_BOLD}==> [INFO]${C_RESET} $*"; }
-log_success() { echo -e "${C_GREEN}${C_BOLD}==> [SUCCESS]${C_RESET} $*"; }
-log_warn()    { echo -e "${C_YELLOW}${C_BOLD}==> [WARN]${C_RESET} $*"; }
-log_error()   { echo -e "${C_RED}${C_BOLD}==> [ERROR]${C_RESET} $*" >&2; }
+log_info()    { printf "%b==> [INFO]%b %s
+" "${C_CYAN}${C_BOLD}" "${C_RESET}" "$*"; }
+log_success() { printf "%b==> [SUCCESS]%b %s
+" "${C_GREEN}${C_BOLD}" "${C_RESET}" "$*"; }
+log_warn()    { printf "%b==> [WARN]%b %s
+" "${C_YELLOW}${C_BOLD}" "${C_RESET}" "$*"; }
+log_error()   { printf "%b==> [ERROR]%b %s
+" "${C_RED}${C_BOLD}" "${C_RESET}" "$*" >&2; }
 get_file_size() { stat -f %z "$1" 2>/dev/null || stat -c %s "$1" 2>/dev/null || wc -c < "$1" | tr -d ' '; }
 
 # Default Parameters
@@ -70,14 +120,15 @@ if [ -e "/dev/kvm" ] && [ -w "/dev/kvm" ]; then
   PROVIDER="qemu"
 elif command -v VBoxManage >/dev/null 2>&1; then
   PROVIDER="virtualbox"
-elif command -v qemu-system-${ARCH} >/dev/null 2>&1; then
+elif command -v "qemu-system-${ARCH}" >/dev/null 2>&1; then
   PROVIDER="qemu"
 else
   PROVIDER="qemu"
 fi
 
-HEADLESS="true"
+HEADLESS=""
 DEBUG_MODE="false"
+STEP_MODE="false"
 STREAM_SERIAL="false"
 SERIAL_WATCH="false"
 SERIAL_TAIL_LINES=""
@@ -87,8 +138,8 @@ VM_CPUS="4"
 VM_VNC=""
 CUSTOM_ISO=""
 TMP_DIR="${TMPDIR:-/tmp}"
-SERIAL_SOCK="${TMP_DIR}/windows-11-serial.sock"
-SERIAL_CLIENT_SOCK="${TMP_DIR}/windows-11-serial-client.sock"
+SERIAL_SOCK="/tmp/windows-11-serial.sock"
+SERIAL_CLIENT_SOCK="/tmp/windows-11-serial-client.sock"
 SERIAL_LOG="${SCRIPT_DIR}/serial.log"
 PROXY_SCRIPT="${SCRIPT_DIR}/serial_proxy.py"
 
@@ -115,8 +166,16 @@ while [ $# -gt 0 ]; do
       HEADLESS="$2"
       shift 2
       ;;
+    --gui|--no-headless)
+      HEADLESS="false"
+      shift
+      ;;
     --debug)
       DEBUG_MODE="true"
+      shift
+      ;;
+    --step)
+      STEP_MODE="true"
       shift
       ;;
     --serial)
@@ -128,9 +187,17 @@ while [ $# -gt 0 ]; do
       shift
       ;;
     --tail)
-      if [ $# -ge 2 ] && [[ "$2" =~ ^[0-9]+$ ]]; then
-        SERIAL_TAIL_LINES="$2"
-        shift 2
+      if [ $# -ge 2 ]; then
+        case "$2" in
+          ''|*[!0-9]*)
+            SERIAL_TAIL_LINES="50"
+            shift
+            ;;
+          *)
+            SERIAL_TAIL_LINES="$2"
+            shift 2
+            ;;
+        esac
       else
         SERIAL_TAIL_LINES="50"
         shift
@@ -153,7 +220,7 @@ while [ $# -gt 0 ]; do
       shift 2
       ;;
     -h|--help)
-      sed -n '/^# Usage:/,/^# ====/p' "${BASH_SOURCE[0]}" | head -n -1 | sed 's/^# //g' | sed 's/^#//g'
+      sed -n '/^# Usage:/,/^# ====/ { /^# ====/d; s/^# //; s/^#//; p; }' "$0"
       exit 0
       ;;
     *)
@@ -163,71 +230,210 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+# Resolve default headless state
+if [ -z "${HEADLESS}" ]; then
+  if [ "${DEBUG_MODE}" = "true" ]; then
+    HEADLESS="false"
+  else
+    HEADLESS="true"
+  fi
+fi
+
 # Resolve ISO Path
 find_iso() {
-  if [ -n "${CUSTOM_ISO}" ] && [ -f "${CUSTOM_ISO}" ]; then
-    echo "${CUSTOM_ISO}"
+  if [ -n "${CUSTOM_ISO:-}" ] && [ -f "${CUSTOM_ISO}" ]; then
+    printf '%s\n' "${CUSTOM_ISO}"
     return 0
   fi
   if [ -n "${WIN11_TARGET_ISO:-}" ] && [ -f "${WIN11_TARGET_ISO}" ]; then
-    echo "${WIN11_TARGET_ISO}"
+    printf '%s\n' "${WIN11_TARGET_ISO}"
     return 0
   fi
   if [ -n "${WIN11_ISO_PATH:-}" ] && [ -f "${WIN11_ISO_PATH}" ]; then
-    echo "${WIN11_ISO_PATH}"
+    printf '%s\n' "${WIN11_ISO_PATH}"
     return 0
   fi
-  local search_dirs=()
-  if [ -n "${ISO_DIR:-}" ] && [ -d "${ISO_DIR}" ]; then
-    search_dirs+=("${ISO_DIR}")
+
+  for _sdir in "${ISO_DIR:-}" ${EXTRA_ISO_SEARCH_DIRS:-} "${SCRIPT_DIR}/builds/iso" "${HOME}/isos"; do
+    if [ -n "${_sdir}" ] && [ -d "${_sdir}" ]; then
+      _found_iso=$(find "${_sdir}" -maxdepth 1 -name "windows-11-${ARCH}*.iso" 2>/dev/null | head -n 1)
+      if [ -n "${_found_iso}" ] && [ -f "${_found_iso}" ]; then
+        printf '%s\n' "${_found_iso}"
+        return 0
+      fi
+      _found_iso=$(find "${_sdir}" -maxdepth 1 \( -name "*win*11*${ARCH}*.iso" -o -name "*Win*11*${ARCH}*.iso" -o -name "*Win*11*Arm64*.iso" -o -name "*Win11*${ARCH}*.iso" -o -name "*Win11*Arm64*.iso" \) 2>/dev/null | head -n 1)
+      if [ -n "${_found_iso}" ] && [ -f "${_found_iso}" ]; then
+        printf '%s\n' "${_found_iso}"
+        return 0
+      fi
+      _found_iso=$(find "${_sdir}" -maxdepth 1 -name "*windows-11*.iso" 2>/dev/null | head -n 1)
+      if [ -n "${_found_iso}" ] && [ -f "${_found_iso}" ]; then
+        printf '%s\n' "${_found_iso}"
+        return 0
+      fi
+    fi
+  done
+  printf ''
+}
+
+# Ensure CRLF line endings for Windows driver INFs, answer files, and batch scripts
+ensure_crlf() {
+  _target_dir="$1"
+  [ -d "${_target_dir}" ] || return 0
+  if command -v unix2dos >/dev/null 2>&1; then
+    find "${_target_dir}" -type f \( -name "*.inf" -o -name "*.xml" -o -name "*.cmd" -o -name "*.bat" -o -name "*.nsh" \) -exec unix2dos -q {} + 2>/dev/null || true
+  else
+    find "${_target_dir}" -type f \( -name "*.inf" -o -name "*.xml" -o -name "*.cmd" -o -name "*.bat" -o -name "*.nsh" \) -exec perl -pi -e 's/\r?\n/\r\n/' {} + 2>/dev/null || true
   fi
-  search_dirs+=("${SCRIPT_DIR}/builds/iso")
-  for sdir in "${search_dirs[@]}"; do
-    local local_iso
-    local_iso=$(find "${sdir}" -maxdepth 1 -name "windows-11-${ARCH}*.iso" 2>/dev/null | head -n 1)
-    if [ -n "${local_iso}" ] && [ -f "${local_iso}" ]; then
-      echo "${local_iso}"
-      return 0
-    fi
-    local_iso=$(find "${sdir}" -maxdepth 1 \( -name "*win*11*${ARCH}*.iso" -o -name "*Win*11*${ARCH}*.iso" -o -name "*Win*11*Arm64*.iso" -o -name "*Win11*${ARCH}*.iso" -o -name "*Win11*Arm64*.iso" \) 2>/dev/null | head -n 1)
-    if [ -n "${local_iso}" ] && [ -f "${local_iso}" ]; then
-      echo "${local_iso}"
-      return 0
-    fi
-    local_iso=$(find "${sdir}" -maxdepth 1 -name "*windows-11*.iso" 2>/dev/null | head -n 1)
-    if [ -n "${local_iso}" ] && [ -f "${local_iso}" ]; then
-      echo "${local_iso}"
+}
+
+# Ensure VirtIO drivers are present in packer_templates/cidata
+ensure_cidata() {
+  _cidata_target="${SCRIPT_DIR}/packer_templates/cidata"
+  if [ -d "${_cidata_target}/viostor" ]; then
+    ensure_crlf "${_cidata_target}"
+    ensure_crlf "${SCRIPT_DIR}/windows-11-arm64-packer/packer_templates/cidata"
+    ensure_crlf "${SCRIPT_DIR}/packer_templates/win_answer_files"
+    ensure_crlf "${SCRIPT_DIR}/windows-11-arm64-packer/packer_templates/win_answer_files"
+    return 0
+  fi
+  log_info "VirtIO drivers not found in packer_templates/cidata. Searching..."
+  for _cand in "${SCRIPT_DIR}/../windows-11-arm64-packer/packer_templates/cidata" "${SCRIPT_DIR}/windows-11-arm64-packer/packer_templates/cidata" "${HOME}/repos/bento/windows-11-arm64-packer/packer_templates/cidata"; do
+    if [ -d "${_cand}/viostor" ]; then
+      log_info "Copying pre-extracted VirtIO drivers from ${_cand}..."
+      mkdir -p "${_cidata_target}"
+      cp -R "${_cand}/"* "${_cidata_target}/"
+      ensure_crlf "${_cidata_target}"
       return 0
     fi
   done
-  echo ""
+
+  # Try extracting from virtio-win.iso if available
+  _v_iso=""
+  for _idir in "${ISO_DIR:-}" ${EXTRA_VIRTIO_SEARCH_DIRS:-} ${EXTRA_ISO_SEARCH_DIRS:-} "${SCRIPT_DIR}/builds/iso" "${HOME}/isos"; do
+    if [ -n "${_idir}" ] && [ -f "${_idir}/virtio-win.iso" ]; then
+      _v_iso="${_idir}/virtio-win.iso"
+      break
+    fi
+  done
+
+  if [ -n "${_v_iso}" ] && command -v 7z >/dev/null 2>&1; then
+    log_info "Extracting VirtIO drivers from ${_v_iso} into ${_cidata_target}..."
+    mkdir -p "${_cidata_target}"
+    7z x -y -o"${_cidata_target}" "${_v_iso}" Balloon NetKVM pvpanic viofs viogpudo vioinput viomem viorng vioscsi vioserial viostor virtio-win-guest-tools.exe >/dev/null 2>&1 || true
+    ensure_crlf "${_cidata_target}"
+    return 0
+  fi
+  log_warn "VirtIO drivers not found. Windows installer may fail to detect virtual disk without storage drivers."
+}
+
+# Generate OEM FAT32 volume with answer file and drivers for unattended Windows installation
+ensure_oem_iso() {
+  [ "${ARCH}" = "aarch64" ] || return 0
+
+  _oem_iso="${WIN11_OEM_ISO:-${PKR_VAR_win11_oem_iso:-}}"
+  if [ -z "${_oem_iso}" ]; then
+    _oem_dir="${ISO_DIR:-${SCRIPT_DIR}/builds/iso}"
+    mkdir -p "${_oem_dir}"
+    _oem_iso="${_oem_dir}/bento_win11_arm64_unattend.iso"
+  fi
+  export WIN11_OEM_ISO="${_oem_iso}"
+  export PKR_VAR_win11_oem_iso="${_oem_iso}"
+
+  log_info "Preparing Windows 11 ARM64 OEM volume (${_oem_iso})..."
+  _work_dir=$(mktemp -d "${TMP_DIR}/bento_oem.XXXXXX")
+
+  # 1. Copy VirtIO drivers
+  if [ -d "${SCRIPT_DIR}/packer_templates/cidata" ]; then
+    cp -R "${SCRIPT_DIR}/packer_templates/cidata/"* "${_work_dir}/"
+  fi
+
+  # 2. Render Autounattend.xml from answer file template
+  _ans_src="${SCRIPT_DIR}/packer_templates/win_answer_files/11/arm64/Autounattend.xml"
+  _key="${WIN11_PRODUCT_KEY:-W269N-WFGWX-YVC9B-4J6C9-T83GX}"
+  python3 -c "
+import re
+c = open('${_ans_src}', 'r', encoding='utf-8', errors='ignore').read()
+c = re.sub(r'%\{\s*if\s+windows_product_key\s*!=\s*\"\"\s*\}.*?%\{\s*endif\s*\}', f'<Key>${_key}</Key>', c, flags=re.DOTALL)
+with open('${_work_dir}/Autounattend.xml', 'w', encoding='utf-8') as f:
+    f.write(c)
+"
+  # Copy SetupComplete.cmd
+  if [ -f "${SCRIPT_DIR}/packer_templates/win_answer_files/11/arm64/SetupComplete.cmd" ]; then
+    cp -f "${SCRIPT_DIR}/packer_templates/win_answer_files/11/arm64/SetupComplete.cmd" "${_work_dir}/SetupComplete.cmd"
+  fi
+
+  # 3. Create startup.nsh for seamless automatic UEFI boot
+  cat << 'NSH_EOF' > "${_work_dir}/startup.nsh"
+@echo -off
+for %i in 0 1 2 3 4 5 6 7 8 9
+  if exist fs%i:\efi\microsoft\boot\bootmgfw.efi then
+    fs%i:\efi\microsoft\boot\bootmgfw.efi
+    goto DONE
+  endif
+endfor
+
+for %i in 0 1 2 3 4 5 6 7 8 9
+  if exist fs%i:\efi\boot\bootaa64.efi then
+    fs%i:\efi\boot\bootaa64.efi
+    goto DONE
+  endif
+endfor
+:DONE
+NSH_EOF
+
+  # 4. Remove any macOS AppleDouble ._* files
+  find "${_work_dir}" -name "._*" -delete 2>/dev/null || true
+  ensure_crlf "${_work_dir}"
+
+  # 5. Build FAT32 OEMDRV image
+  _oem_target_dir=$(dirname "${_oem_iso}")
+  mkdir -p "${_oem_target_dir}"
+
+  if command -v hdiutil >/dev/null 2>&1; then
+    _tmp_img=$(mktemp "${TMP_DIR}/bento_oem_img.XXXXXX")
+    rm -f "${_tmp_img}" "${_tmp_img}.dmg"
+    COPYFILE_DISABLE=1 hdiutil create -size 140m -fs "MS-DOS FAT32" -volname "OEMDRV" -srcfolder "${_work_dir}" -format UDRW "${_tmp_img}.dmg" >/dev/null 2>&1
+    hdiutil attach "${_tmp_img}.dmg" >/dev/null 2>&1 || true
+    find "/Volumes/OEMDRV" -name "._*" -delete 2>/dev/null || true
+    hdiutil detach "/Volumes/OEMDRV" >/dev/null 2>&1 || true
+    mv -f "${_tmp_img}.dmg" "${_oem_iso}"
+    rm -f "${_tmp_img}"
+  elif command -v mkfs.vfat >/dev/null 2>&1; then
+    dd if=/dev/zero of="${_oem_iso}" bs=1M count=140 >/dev/null 2>&1
+    mkfs.vfat -n "OEMDRV" "${_oem_iso}" >/dev/null 2>&1
+    mcopy -i "${_oem_iso}" -s "${_work_dir}/"* ::/ >/dev/null 2>&1 || true
+  fi
+
+  rm -rf "${_work_dir}"
+  log_success "Prepared OEM unattended volume at: ${_oem_iso}"
 }
 
 # Clean stale locks and background processes
 cmd_clean() {
   log_info "Cleaning up stale locks, temporary build files, and processes..."
   rm -f "${SCRIPT_DIR}/builds/iso/"*.iso.lock 2>/dev/null || true
-  rm -f "${SERIAL_SOCK}" "${SERIAL_CLIENT_SOCK}" 2>/dev/null || true
+  rm -f "${SERIAL_SOCK}" "${SERIAL_CLIENT_SOCK}" "/tmp/windows-11-serial.sock" "/tmp/windows-11-serial-client.sock" "/tmp/bento-qemu-serial.sock" 2>/dev/null || true
 
   # Kill background serial proxy
   pkill -f "serial_proxy.py" 2>/dev/null || true
 
   # Kill running packer instances for windows-11
-  pkill -f "packer build.*windows-11" 2>/dev/null || true
+  pkill -f "packer.*windows-11" 2>/dev/null || true
 
   # Kill running QEMU instances for windows-11
   pkill -f "qemu-system-.*windows-11" 2>/dev/null || true
 
   # Clean VirtualBox VM if present
   if command -v VBoxManage >/dev/null 2>&1; then
-    for vm in $(VBoxManage list runningvms 2>/dev/null | grep -i "windows-11" | cut -d'"' -f2); do
-      log_warn "Stopping running VirtualBox Windows 11 VM ($vm)..."
-      VBoxManage controlvm "$vm" poweroff 2>/dev/null || true
+    for _vm in $(VBoxManage list runningvms 2>/dev/null | grep -i "windows-11" | cut -d'"' -f2); do
+      log_warn "Stopping running VirtualBox Windows 11 VM (${_vm})..."
+      VBoxManage controlvm "${_vm}" poweroff 2>/dev/null || true
       sleep 1
     done
-    for vm in $(VBoxManage list vms 2>/dev/null | grep -i "windows-11" | cut -d'"' -f2); do
-      log_info "Unregistering VirtualBox Windows 11 VM ($vm)..."
-      VBoxManage unregistervm "$vm" --delete 2>/dev/null || true
+    for _vm in $(VBoxManage list vms 2>/dev/null | grep -i "windows-11" | cut -d'"' -f2); do
+      log_info "Unregistering VirtualBox Windows 11 VM (${_vm})..."
+      VBoxManage unregistervm "${_vm}" --delete 2>/dev/null || true
     done
   fi
   log_success "Cleanup complete."
@@ -239,10 +445,7 @@ start_serial_proxy() {
   pkill -f "serial_proxy.py" 2>/dev/null || true
   rm -f "${SERIAL_CLIENT_SOCK}"
 
-  export SERIAL_SOCK="${SERIAL_SOCK}"
-  export SERIAL_CLIENT_SOCK="${SERIAL_CLIENT_SOCK}"
-  export SERIAL_LOG="${SERIAL_LOG}"
-
+  export SERIAL_SOCK SERIAL_CLIENT_SOCK SERIAL_LOG
   python3 "${PROXY_SCRIPT}" >/dev/null 2>&1 &
   PROXY_PID=$!
   sleep 0.5
@@ -278,29 +481,29 @@ cmd_serial() {
     return 0
   fi
 
-  local target_sock="${SERIAL_CLIENT_SOCK}"
-  local waited=0
-  while [ ! -S "${target_sock}" ] && [ ! -S "${SERIAL_SOCK}" ]; do
-    if [ ${waited} -ge 5 ]; then
+  _target_sock="${SERIAL_CLIENT_SOCK}"
+  _waited=0
+  while [ ! -S "${_target_sock}" ] && [ ! -S "${SERIAL_SOCK}" ]; do
+    if [ "${_waited}" -ge 5 ]; then
       break
     fi
     sleep 1
-    waited=$((waited + 1))
+    _waited=$((_waited + 1))
   done
 
   if [ -S "${SERIAL_CLIENT_SOCK}" ]; then
-    target_sock="${SERIAL_CLIENT_SOCK}"
+    _target_sock="${SERIAL_CLIENT_SOCK}"
   elif [ -S "${SERIAL_SOCK}" ]; then
-    target_sock="${SERIAL_SOCK}"
+    _target_sock="${SERIAL_SOCK}"
   fi
 
-  if [ ! -S "${target_sock}" ]; then
+  if [ ! -S "${_target_sock}" ]; then
     log_warn "Active serial socket (${SERIAL_SOCK}) is not currently open."
     if [ -f "${SERIAL_LOG}" ] && [ -s "${SERIAL_LOG}" ]; then
       log_info "Recent serial activity from ${SERIAL_LOG}:"
-      echo -e "${C_CYAN}----------------------------------------------------------------${C_RESET}"
+      printf "%b----------------------------------------------------------------%b\n" "${C_CYAN}" "${C_RESET}"
       tail -n 30 "${SERIAL_LOG}" 2>/dev/null || true
-      echo -e "${C_CYAN}----------------------------------------------------------------${C_RESET}"
+      printf "%b----------------------------------------------------------------%b\n" "${C_CYAN}" "${C_RESET}"
       log_info "To stream live serial output once the VM starts, use: ./windows-11-builder.sh serial --watch"
       return 0
     else
@@ -312,7 +515,7 @@ cmd_serial() {
   # Handle --send option for non-interactive command execution
   if [ -n "${SERIAL_SEND_CMD}" ]; then
     log_info "Sending command to Windows 11 serial console: ${SERIAL_SEND_CMD}"
-    SERIAL_TARGET_SOCK="${target_sock}" CMD_TO_SEND="${SERIAL_SEND_CMD}" python3 -c '
+    SERIAL_TARGET_SOCK="${_target_sock}" CMD_TO_SEND="${SERIAL_SEND_CMD}" python3 -c '
 import socket, sys, os, time, select
 
 sock_path = os.environ.get("SERIAL_TARGET_SOCK", "/tmp/windows-11-serial-client.sock")
@@ -343,13 +546,13 @@ sys.stdout.flush()
   fi
 
   # Interactive serial console session
-  echo -e "${C_YELLOW}${C_BOLD}================================================================${C_RESET}"
-  echo -e "${C_YELLOW}${C_BOLD}  CONNECTED TO WINDOWS 11 SERIAL CONSOLE (COM1)                ${C_RESET}"
-  echo -e "${C_YELLOW}  - Live terminal stream connected to VM COM1 serial port       ${C_RESET}"
-  echo -e "${C_YELLOW}  - To exit this console session: Press Ctrl+C                  ${C_RESET}"
-  echo -e "${C_YELLOW}${C_BOLD}================================================================${C_RESET}"
+  printf "%b================================================================%b\n" "${C_YELLOW}${C_BOLD}" "${C_RESET}"
+  printf "%b  CONNECTED TO WINDOWS 11 SERIAL CONSOLE (COM1)                %b\n" "${C_YELLOW}${C_BOLD}" "${C_RESET}"
+  printf "%b  - Live terminal stream connected to VM COM1 serial port       %b\n" "${C_YELLOW}" "${C_RESET}"
+  printf "%b  - To exit this console session: Press Ctrl+C                  %b\n" "${C_YELLOW}" "${C_RESET}"
+  printf "%b================================================================%b\n" "${C_YELLOW}${C_BOLD}" "${C_RESET}"
 
-  SERIAL_TARGET_SOCK="${target_sock}" python3 -c '
+  SERIAL_TARGET_SOCK="${_target_sock}" python3 -c '
 import socket, sys, select, os, tty, termios
 
 sock_path = os.environ.get("SERIAL_TARGET_SOCK", "/tmp/windows-11-serial-client.sock")
@@ -409,203 +612,135 @@ finally:
 # Show status
 cmd_status() {
   log_info "Windows 11 Bento Environment Status:"
-  echo "  Architecture   : ${ARCH}"
-  echo "  Provider       : ${PROVIDER}"
-  echo "  Serial Socket  : ${SERIAL_SOCK} (exists: $([ -S "${SERIAL_SOCK}" ] && echo yes || echo no))"
-  echo "  Client Socket  : ${SERIAL_CLIENT_SOCK} (exists: $([ -S "${SERIAL_CLIENT_SOCK}" ] && echo yes || echo no))"
+  printf "  Architecture   : %s\n" "${ARCH}"
+  printf "  Provider       : %s\n" "${PROVIDER}"
+  printf "  Files Dir      : %s\n" "${BENTO_BUILD_FILES_DIR}"
+  printf "  Complete Dir   : %s\n" "${BENTO_BUILD_COMPLETE_DIR}"
+  printf "  Serial Socket  : %s (exists: %s)\n" "${SERIAL_SOCK}" "$([ -S "${SERIAL_SOCK}" ] && echo yes || echo no)"
+  printf "  Client Socket  : %s (exists: %s)\n" "${SERIAL_CLIENT_SOCK}" "$([ -S "${SERIAL_CLIENT_SOCK}" ] && echo yes || echo no)"
 
   if [ -f "${SERIAL_LOG}" ]; then
-    local log_lines
-    log_lines=$(wc -l < "${SERIAL_LOG}")
-    local log_bytes
-    log_bytes=$(wc -c < "${SERIAL_LOG}")
-    echo "  Serial Log     : ${SERIAL_LOG} (${log_bytes} bytes, ${log_lines} lines)"
-    if [ "${log_lines}" -gt 0 ]; then
-      local last_entry
-      last_entry=$(tail -n 1 "${SERIAL_LOG}" | tr '
+    _log_lines=$(wc -l < "${SERIAL_LOG}")
+    _log_bytes=$(wc -c < "${SERIAL_LOG}")
+    printf "  Serial Log     : %s (%s bytes, %s lines)\n" "${SERIAL_LOG}" "${_log_bytes}" "${_log_lines}"
+    if [ "${_log_lines}" -gt 0 ]; then
+      _last_entry=$(tail -n 1 "${SERIAL_LOG}" | tr '
 ' ' ')
-      echo "  Last Log Entry : ${last_entry}"
+      printf "  Last Log Entry : %s\n" "${_last_entry}"
     fi
   else
-    echo "  Serial Log     : Not yet created"
+    printf "  Serial Log     : Not yet created\n"
   fi
 
-  local iso_path
-  iso_path="$(find_iso)"
-  if [ -n "${iso_path}" ]; then
-    local iso_sz
-    iso_sz=$(du -h "${iso_path}" | cut -f1)
-    echo "  ISO Located    : ${iso_path} (${iso_sz})"
+  _iso_path="$(find_iso)"
+  if [ -n "${_iso_path}" ]; then
+    _iso_sz=$(du -h "${_iso_path}" | cut -f1)
+    printf "  ISO Located    : %s (%s)\n" "${_iso_path}" "${_iso_sz}"
   else
-    echo "  ISO Located    : None found in builds/iso"
+    printf "  ISO Located    : None found in ISO directory\n"
   fi
 
-  echo ""
-  echo "Disk Images (builds/build_files/):"
-  local found_disks=0
-  for d in "${SCRIPT_DIR}/builds/build_files"/*/*windows-11* "${SCRIPT_DIR}/builds/build_files"/*/box*.img; do
-    if [ -f "$d" ]; then
-      local dsz
-      dsz=$(du -h "$d" | cut -f1)
-      local dbytes
-      dbytes=$(get_file_size "$d")
-      echo -e "  - $(basename "$(dirname "$d")")/$(basename "$d") : ${C_CYAN}${dsz}${C_RESET} (${dbytes} bytes)"
-      found_disks=1
+  printf "
+Disk Images (%s):
+" "${BENTO_BUILD_FILES_DIR}"
+  _found_disks=0
+  for _d in "${BENTO_BUILD_FILES_DIR}"/*/*windows-11* "${BENTO_BUILD_FILES_DIR}"/*/box*.img "${SCRIPT_DIR}/builds/build_files"/*/*windows-11* "${SCRIPT_DIR}/builds/build_files"/*/box*.img; do
+    if [ -f "${_d}" ]; then
+      _dsz=$(du -h "${_d}" | cut -f1)
+      _dbytes=$(get_file_size "${_d}")
+      _dir_base=$(basename "$(dirname "${_d}")")
+      _f_base=$(basename "${_d}")
+      printf "  - %s/%s : %b%s%b (%s bytes)\n" "${_dir_base}" "${_f_base}" "${C_CYAN}" "${_dsz}" "${C_RESET}" "${_dbytes}"
+      _found_disks=1
     fi
   done
-  if [ ${found_disks} -eq 0 ]; then
-    echo "  (None found)"
+  if [ "${_found_disks}" -eq 0 ]; then
+    printf "  (None found)\n"
   fi
 
-  echo ""
-  echo "Running Processes:"
-  ps aux | grep -E "packer.*windows-11|qemu-system-.*windows-11|serial_proxy.py" | grep -v grep || echo "  (None)"
+  printf "
+Running Processes:
+"
+  pgrep -fl "packer.*windows-11|qemu-system-.*windows-11|serial_proxy.py" 2>/dev/null || printf "  (None)\n"
 
-  echo ""
-  echo "Built Boxes (builds/build_complete/):"
-  if ls "${SCRIPT_DIR}/builds/build_complete/"*windows-11*.box 1>/dev/null 2>&1; then
-    for b in "${SCRIPT_DIR}/builds/build_complete/"*windows-11*.box; do
-      local bsz
-      bsz=$(du -h "$b" | cut -f1)
-      local bsz_bytes
-      bsz_bytes=$(get_file_size "$b")
-      echo -e "  - $(basename "$b") : ${C_GREEN}${C_BOLD}${bsz}${C_RESET} (${bsz_bytes} bytes)"
-    done
-  else
-    echo "  (No .box files built yet)"
+  printf "
+Built Boxes (%s):
+" "${BENTO_BUILD_COMPLETE_DIR}"
+  _found_boxes=0
+  for _b in "${BENTO_BUILD_COMPLETE_DIR}"/*windows-11*.box "${SCRIPT_DIR}/builds/build_complete/"*windows-11*.box; do
+    if [ -f "${_b}" ]; then
+      _bsz=$(du -h "${_b}" | cut -f1)
+      _bsz_bytes=$(get_file_size "${_b}")
+      printf "  - %s : %b%s%b (%s bytes)\n" "$(basename "${_b}")" "${C_GREEN}${C_BOLD}" "${_bsz}" "${C_RESET}" "${_bsz_bytes}"
+      _found_boxes=1
+    fi
+  done
+  if [ "${_found_boxes}" -eq 0 ]; then
+    printf "  (No .box files built yet)\n"
   fi
 }
 
 # Run built box/disk directly with KVM, serial and port forwards
 cmd_run() {
-  local disk_img=""
-  local candidates=(
-    "${SCRIPT_DIR}/builds/build_files/packer-windows-11-${ARCH}-qemu/windows-11-amd64"
-    "${SCRIPT_DIR}/builds/build_files/packer-windows-11-${ARCH}-qemu/windows-11-${ARCH}"
-    "${SCRIPT_DIR}/builds/build_files/packer-windows-11-${ARCH}-qemu/box.img"
-    "${SCRIPT_DIR}/builds/build_files/packer-windows-11-${ARCH}-qemu/box_optimized.img"
-  )
-
-  for candidate in "${candidates[@]}"; do
-    if [ -f "${candidate}" ]; then
-      disk_img="${candidate}"
+  _disk_img=""
+  for _cand in "${BENTO_BUILD_FILES_DIR}/packer-windows-11-${ARCH}-qemu/windows-11-amd64" "${BENTO_BUILD_FILES_DIR}/packer-windows-11-${ARCH}-qemu/windows-11-${ARCH}" "${BENTO_BUILD_FILES_DIR}/packer-windows-11-${ARCH}-qemu/box.img" "${BENTO_BUILD_FILES_DIR}/packer-windows-11-${ARCH}-qemu/box_optimized.img" "${SCRIPT_DIR}/builds/build_files/packer-windows-11-${ARCH}-qemu/windows-11-amd64" "${SCRIPT_DIR}/builds/build_files/packer-windows-11-${ARCH}-qemu/windows-11-${ARCH}" "${SCRIPT_DIR}/builds/build_files/packer-windows-11-${ARCH}-qemu/box.img" "${SCRIPT_DIR}/builds/build_files/packer-windows-11-${ARCH}-qemu/box_optimized.img"; do
+    if [ -f "${_cand}" ]; then
+      _disk_img="${_cand}"
       break
     fi
   done
 
   # Also check if box exists and extract if necessary
-  if [ -z "${disk_img}" ]; then
-    local box_file
-    box_file=$(find "${SCRIPT_DIR}/builds/build_complete" -name "*windows-11*.box" 2>/dev/null | head -n 1)
-    if [ -n "${box_file}" ]; then
-      log_info "Extracting box.img from ${box_file}..."
-      local extract_dir="${SCRIPT_DIR}/builds/build_files/packer-windows-11-${ARCH}-qemu"
-      mkdir -p "${extract_dir}"
-      tar -xf "${box_file}" -C "${extract_dir}" box.img 2>/dev/null || true
-      if [ -f "${extract_dir}/box.img" ]; then
-        disk_img="${extract_dir}/box.img"
+  if [ -z "${_disk_img}" ]; then
+    _box_file=$(find "${BENTO_BUILD_COMPLETE_DIR}" "${SCRIPT_DIR}/builds/build_complete" -name "*windows-11*.box" 2>/dev/null | head -n 1)
+    if [ -n "${_box_file}" ]; then
+      log_info "Extracting box.img from ${_box_file}..."
+      _extract_dir="${BENTO_BUILD_FILES_DIR}/packer-windows-11-${ARCH}-qemu"
+      mkdir -p "${_extract_dir}"
+      tar -xf "${_box_file}" -C "${_extract_dir}" box.img 2>/dev/null || true
+      if [ -f "${_extract_dir}/box.img" ]; then
+        _disk_img="${_extract_dir}/box.img"
       fi
     fi
   fi
 
-  if [ -z "${disk_img}" ]; then
+  if [ -z "${_disk_img}" ]; then
     log_error "No built disk image found. Run './windows-11-builder.sh build' first."
     exit 1
   fi
 
   # Find UEFI firmware code and vars
-  local brew_prefix=""
+  _brew_prefix=""
   if command -v brew >/dev/null 2>&1; then
-    brew_prefix="$(brew --prefix 2>/dev/null)"
+    _brew_prefix="$(brew --prefix 2>/dev/null || true)"
   fi
 
-  local efi_code=""
-  local efi_vars=""
+  _efi_code=""
+  _efi_vars=""
   if [ "${ARCH}" = "x86_64" ]; then
-    local efi_candidates=(
-      "${QEMU_EDK2_CODE:-}"
-      "${QEMU_BIOS:-}"
-      "/usr/share/OVMF/OVMF_CODE.fd"
-      "/usr/share/OVMF/OVMF_CODE_4M.fd"
-      "/usr/share/ovmf/OVMF.fd"
-      "/usr/share/edk2/ovmf/OVMF_CODE.fd"
-      "/usr/share/edk2-ovmf/x64/OVMF_CODE.fd"
-      ${brew_prefix:+"${brew_prefix}/share/qemu/edk2-x86_64-code.fd"}
-      "/opt/homebrew/share/qemu/edk2-x86_64-code.fd"
-      "/usr/local/share/qemu/edk2-x86_64-code.fd"
-      "/opt/local/share/qemu/edk2-x86_64-code.fd"
-      "/usr/share/qemu/edk2-x86_64-code.fd"
-      "/usr/share/qemu/OVMF.fd"
-      "C:/Program Files/qemu/share/edk2-x86_64-code.fd"
-      "C:/msys64/mingw64/share/qemu/edk2-x86_64-code.fd"
-    )
-    for c in "${efi_candidates[@]}"; do
-      if [ -n "$c" ] && [ -f "$c" ]; then efi_code="$c"; break; fi
+    for _c in "${QEMU_EDK2_CODE:-}" "${QEMU_BIOS:-}" "/usr/share/OVMF/OVMF_CODE.fd" "/usr/share/OVMF/OVMF_CODE_4M.fd" "/usr/share/ovmf/OVMF.fd" "/usr/share/edk2/ovmf/OVMF_CODE.fd" "/usr/share/edk2-ovmf/x64/OVMF_CODE.fd" "${_brew_prefix}/share/qemu/edk2-x86_64-code.fd" "/opt/homebrew/share/qemu/edk2-x86_64-code.fd" "/usr/local/share/qemu/edk2-x86_64-code.fd" "/opt/local/share/qemu/edk2-x86_64-code.fd" "/usr/share/qemu/edk2-x86_64-code.fd" "/usr/share/qemu/OVMF.fd" "C:/Program Files/qemu/share/edk2-x86_64-code.fd" "C:/msys64/mingw64/share/qemu/edk2-x86_64-code.fd"; do
+      if [ -n "${_c}" ] && [ -f "${_c}" ]; then _efi_code="${_c}"; break; fi
     done
-    local var_candidates=(
-      "${QEMU_EDK2_VARS:-}"
-      "/usr/share/OVMF/OVMF_VARS.fd"
-      "/usr/share/OVMF/OVMF_VARS_4M.fd"
-      "/usr/share/ovmf/OVMF_VARS.fd"
-      "/usr/share/edk2/ovmf/OVMF_VARS.fd"
-      "/usr/share/edk2-ovmf/x64/OVMF_VARS.fd"
-      ${brew_prefix:+"${brew_prefix}/share/qemu/edk2-i386-vars.fd"}
-      "/opt/homebrew/share/qemu/edk2-i386-vars.fd"
-      "/usr/local/share/qemu/edk2-i386-vars.fd"
-      "/opt/local/share/qemu/edk2-i386-vars.fd"
-      "/usr/share/qemu/edk2-i386-vars.fd"
-      "C:/Program Files/qemu/share/edk2-i386-vars.fd"
-      "C:/msys64/mingw64/share/qemu/edk2-i386-vars.fd"
-    )
-    for v in "${var_candidates[@]}"; do
-      if [ -n "$v" ] && [ -f "$v" ]; then efi_vars="$v"; break; fi
+    for _v in "${QEMU_EDK2_VARS:-}" "/usr/share/OVMF/OVMF_VARS.fd" "/usr/share/OVMF/OVMF_VARS_4M.fd" "/usr/share/ovmf/OVMF_VARS.fd" "/usr/share/edk2/ovmf/OVMF_VARS.fd" "/usr/share/edk2-ovmf/x64/OVMF_VARS.fd" "${_brew_prefix}/share/qemu/edk2-i386-vars.fd" "/opt/homebrew/share/qemu/edk2-i386-vars.fd" "/usr/local/share/qemu/edk2-i386-vars.fd" "/opt/local/share/qemu/edk2-i386-vars.fd" "/usr/share/qemu/edk2-i386-vars.fd" "C:/Program Files/qemu/share/edk2-i386-vars.fd" "C:/msys64/mingw64/share/qemu/edk2-i386-vars.fd"; do
+      if [ -n "${_v}" ] && [ -f "${_v}" ]; then _efi_vars="${_v}"; break; fi
     done
   else
-    local efi_candidates=(
-      "${QEMU_EDK2_CODE:-}"
-      "${QEMU_BIOS:-}"
-      ${brew_prefix:+"${brew_prefix}/share/qemu/edk2-aarch64-code.fd"}
-      "/opt/homebrew/share/qemu/edk2-aarch64-code.fd"
-      "/usr/share/AAVMF/AAVMF_CODE.fd"
-      "/usr/share/AAVMF/AAVMF32_CODE.fd"
-      "/usr/share/qemu/edk2-aarch64-code.fd"
-      "/usr/share/edk2/aarch64/QEMU_EFI-pflash.raw"
-      "/usr/share/edk2/aarch64/QEMU_EFI.fd"
-      "/usr/share/edk2-armvirt/aarch64/QEMU_EFI.fd"
-      "/usr/local/share/qemu/edk2-aarch64-code.fd"
-      "/opt/local/share/qemu/edk2-aarch64-code.fd"
-      "C:/Program Files/qemu/share/edk2-aarch64-code.fd"
-      "C:/msys64/mingw64/share/qemu/edk2-aarch64-code.fd"
-    )
-    for c in "${efi_candidates[@]}"; do
-      if [ -n "$c" ] && [ -f "$c" ]; then efi_code="$c"; break; fi
+    for _c in "${QEMU_EDK2_CODE:-}" "${QEMU_BIOS:-}" "${_brew_prefix}/share/qemu/edk2-aarch64-code.fd" "/opt/homebrew/share/qemu/edk2-aarch64-code.fd" "/usr/share/AAVMF/AAVMF_CODE.fd" "/usr/share/AAVMF/AAVMF32_CODE.fd" "/usr/share/qemu/edk2-aarch64-code.fd" "/usr/share/edk2/aarch64/QEMU_EFI-pflash.raw" "/usr/share/edk2/aarch64/QEMU_EFI.fd" "/usr/share/edk2-armvirt/aarch64/QEMU_EFI.fd" "/usr/local/share/qemu/edk2-aarch64-code.fd" "/opt/local/share/qemu/edk2-aarch64-code.fd" "C:/Program Files/qemu/share/edk2-aarch64-code.fd" "C:/msys64/mingw64/share/qemu/edk2-aarch64-code.fd"; do
+      if [ -n "${_c}" ] && [ -f "${_c}" ]; then _efi_code="${_c}"; break; fi
     done
-    local var_candidates=(
-      "${QEMU_EDK2_VARS:-}"
-      ${brew_prefix:+"${brew_prefix}/share/qemu/edk2-arm-vars.fd"}
-      "/opt/homebrew/share/qemu/edk2-arm-vars.fd"
-      "/usr/share/AAVMF/AAVMF_VARS.fd"
-      "/usr/share/qemu/edk2-arm-vars.fd"
-      "/usr/share/edk2/aarch64/vars-template-pflash.raw"
-      "/usr/share/edk2-armvirt/aarch64/QEMU_VARS.fd"
-      "/usr/local/share/qemu/edk2-arm-vars.fd"
-      "/opt/local/share/qemu/edk2-arm-vars.fd"
-      "C:/Program Files/qemu/share/edk2-arm-vars.fd"
-      "C:/msys64/mingw64/share/qemu/edk2-arm-vars.fd"
-    )
-    for v in "${var_candidates[@]}"; do
-      if [ -n "$v" ] && [ -f "$v" ]; then efi_vars="$v"; break; fi
+    for _v in "${QEMU_EDK2_VARS:-}" "${_brew_prefix}/share/qemu/edk2-arm-vars.fd" "/opt/homebrew/share/qemu/edk2-arm-vars.fd" "/usr/share/AAVMF/AAVMF_VARS.fd" "/usr/share/qemu/edk2-arm-vars.fd" "/usr/share/edk2/aarch64/vars-template-pflash.raw" "/usr/share/edk2-armvirt/aarch64/QEMU_VARS.fd" "/usr/local/share/qemu/edk2-arm-vars.fd" "/opt/local/share/qemu/edk2-arm-vars.fd" "C:/Program Files/qemu/share/edk2-arm-vars.fd" "C:/msys64/mingw64/share/qemu/edk2-arm-vars.fd"; do
+      if [ -n "${_v}" ] && [ -f "${_v}" ]; then _efi_vars="${_v}"; break; fi
     done
   fi
 
   log_info "Starting Windows 11 VM directly with QEMU (${ARCH})..."
-  echo "  Disk Image     : ${disk_img}"
-  echo "  UEFI Firmware  : ${efi_code:-'(none)'}"
-  echo "  CPUs / Memory  : ${VM_CPUS} CPUs, ${VM_MEM} MB RAM"
-  echo "  WinRM Forward  : 127.0.0.1:5985"
-  echo "  RDP Forward    : 127.0.0.1:3389"
-  echo "  SSH Forward    : 127.0.0.1:2222"
-  echo "  Serial Console : ${SERIAL_SOCK}"
+  printf "  Disk Image     : %s\n" "${_disk_img}"
+  printf "  UEFI Firmware  : %s\n" "${_efi_code:-'(none)'}"
+  printf "  CPUs / Memory  : %s CPUs, %s MB RAM\n" "${VM_CPUS}" "${VM_MEM}"
+  printf "  WinRM Forward  : 127.0.0.1:5985\n"
+  printf "  RDP Forward    : 127.0.0.1:3389\n"
+  printf "  SSH Forward    : 127.0.0.1:2222\n"
+  printf "  Serial Console : %s\n" "${SERIAL_SOCK}"
 
   # Clean stale socket
   rm -f "${SERIAL_SOCK}"
@@ -613,186 +748,163 @@ cmd_run() {
   # Start serial multiplexer
   start_serial_proxy
 
-  echo -e "${C_GREEN}${C_BOLD}VM is starting. In another terminal, run './windows-11-builder.sh serial' to connect.${C_RESET}"
+  printf "%bVM is starting. In another terminal, run './windows-11-builder.sh serial' to connect.%b\n" "${C_GREEN}${C_BOLD}" "${C_RESET}"
 
-  local host_os="linux"
+  _host_os="linux"
   case "$(uname -s)" in
-    Darwin*) host_os="darwin" ;;
-    Linux*)  host_os="linux" ;;
-    CYGWIN*|MINGW*|MSYS*) host_os="windows" ;;
+    Darwin*) _host_os="darwin" ;;
+    Linux*)  _host_os="linux" ;;
+    CYGWIN*|MINGW*|MSYS*) _host_os="windows" ;;
   esac
 
-  local qemu_accel="kvm"
-  if [ "${host_os}" = "darwin" ]; then
-    qemu_accel="hvf"
-  elif [ "${host_os}" = "windows" ]; then
-    qemu_accel="whpx"
+  _qemu_accel="kvm"
+  if [ "${_host_os}" = "darwin" ]; then
+    _qemu_accel="hvf"
+  elif [ "${_host_os}" = "windows" ]; then
+    _qemu_accel="whpx"
   fi
 
-  local qemu_mach="q35,accel=${qemu_accel}"
+  _qemu_mach="q35,accel=${_qemu_accel}"
   if [ "${ARCH}" = "aarch64" ]; then
-    qemu_mach="virt,highmem=on,accel=${qemu_accel}"
+    _qemu_mach="virt,highmem=on,accel=${_qemu_accel}"
   fi
 
-  local qemu_cmd=(
-    "qemu-system-${ARCH}"
-    "-name" "windows-11-${ARCH}"
-    "-machine" "${qemu_mach}"
-    "-cpu" "host"
-    "-smp" "${VM_CPUS}"
+  set -- "qemu-system-${ARCH}" \
+    "-name" "windows-11-${ARCH}" \
+    "-machine" "${_qemu_mach}" \
+    "-cpu" "host" \
+    "-smp" "${VM_CPUS}" \
     "-m" "${VM_MEM}"
-  )
 
-  if [ -n "${efi_code}" ]; then
-    qemu_cmd+=("-drive" "if=pflash,format=raw,readonly=on,file=${efi_code}")
+  if [ -n "${_efi_code}" ]; then
+    set -- "$@" "-drive" "if=pflash,format=raw,readonly=on,file=${_efi_code}"
   fi
 
   # Setup writable NVRAM efivars
-  local disk_dir
-  disk_dir="$(dirname "${disk_img}")"
-  local run_vars="${disk_dir}/efivars_run.fd"
-  if [ -f "${disk_dir}/efivars.fd" ]; then
-    cp -f "${disk_dir}/efivars.fd" "${run_vars}"
-    qemu_cmd+=("-drive" "if=pflash,format=raw,file=${run_vars}")
-  elif [ -n "${efi_vars}" ]; then
-    cp -f "${efi_vars}" "${run_vars}"
-    qemu_cmd+=("-drive" "if=pflash,format=raw,file=${run_vars}")
+  _disk_dir="$(dirname "${_disk_img}")"
+  _run_vars="${_disk_dir}/efivars_run.fd"
+  if [ -f "${_disk_dir}/efivars.fd" ]; then
+    cp -f "${_disk_dir}/efivars.fd" "${_run_vars}"
+    set -- "$@" "-drive" "if=pflash,format=raw,file=${_run_vars}"
+  elif [ -n "${_efi_vars}" ]; then
+    cp -f "${_efi_vars}" "${_run_vars}"
+    set -- "$@" "-drive" "if=pflash,format=raw,file=${_run_vars}"
   fi
 
   if [ "${ARCH}" = "aarch64" ]; then
-    qemu_cmd+=(
-      "-drive" "file=${disk_img},if=none,id=disk0,cache=writeback,discard=unmap"
-      "-device" "nvme,serial=nvme0,drive=disk0"
-      "-netdev" "user,id=user.0,hostfwd=tcp::5985-:5985,hostfwd=tcp::3389-:3389,hostfwd=tcp::2222-:22"
-      "-device" "virtio-net-pci,netdev=user.0"
-      "-device" "qemu-xhci"
-      "-device" "usb-kbd"
-      "-device" "usb-tablet"
+    set -- "$@" \
+      "-device" "pcie-root-port,id=pcie.1,chassis=1,slot=1" \
+      "-drive" "file=${_disk_img},if=none,id=disk0,cache=writeback,discard=unmap" \
+      "-device" "nvme,serial=nvme0,drive=disk0,bus=pcie.1" \
+      "-netdev" "user,id=user.0,hostfwd=tcp::5985-:5985,hostfwd=tcp::3389-:3389,hostfwd=tcp::2222-:22" \
+      "-device" "virtio-net-pci,netdev=user.0" \
+      "-device" "qemu-xhci" \
+      "-device" "usb-kbd" \
+      "-device" "usb-tablet" \
       "-device" "ramfb"
-    )
   else
-    qemu_cmd+=(
-      "-drive" "file=${disk_img},if=none,id=disk0,cache=writeback,discard=unmap"
-      "-device" "ide-hd,drive=disk0,bus=ide.0"
-      "-netdev" "user,id=user.0,hostfwd=tcp::5985-:5985,hostfwd=tcp::3389-:3389,hostfwd=tcp::2222-:22"
-      "-device" "virtio-net-pci,netdev=user.0"
-      "-device" "qemu-xhci"
-      "-device" "usb-kbd"
-      "-device" "usb-tablet"
+    set -- "$@" \
+      "-drive" "file=${_disk_img},if=none,id=disk0,cache=writeback,discard=unmap" \
+      "-device" "ide-hd,drive=disk0,bus=ide.0" \
+      "-netdev" "user,id=user.0,hostfwd=tcp::5985-:5985,hostfwd=tcp::3389-:3389,hostfwd=tcp::2222-:22" \
+      "-device" "virtio-net-pci,netdev=user.0" \
+      "-device" "qemu-xhci" \
+      "-device" "usb-kbd" \
+      "-device" "usb-tablet" \
       "-vga" "std"
-    )
   fi
 
   if [ -n "${VM_VNC}" ]; then
-    qemu_cmd+=("-vnc" ":${VM_VNC}")
+    set -- "$@" "-vnc" ":${VM_VNC}"
     log_info "VNC display accessible on port 590${VM_VNC}"
   elif [ "${HEADLESS}" = "true" ]; then
-    qemu_cmd+=("-display" "none")
+    set -- "$@" "-display" "none"
   fi
 
-  qemu_cmd+=(
-    "-chardev" "socket,id=ser0,path=${SERIAL_SOCK},server=on,wait=off"
+  set -- "$@" \
+    "-chardev" "socket,id=ser0,path=${SERIAL_SOCK},server=on,wait=off" \
     "-serial" "chardev:ser0"
-  )
 
-  exec "${qemu_cmd[@]}"
+  exec "$@"
 }
 
 # Multi-stage aggressive box size reduction pipeline
 cmd_box() {
-  local provider="${1:-${PROVIDER}}"
+  _provider="${1:-${PROVIDER}}"
   log_info "================================================================"
-  log_info "  AGGRESSIVE VAGRANT .BOX SIZE REDUCTION PIPELINE (${ARCH}, ${provider})"
+  log_info "  AGGRESSIVE VAGRANT .BOX SIZE REDUCTION PIPELINE (${ARCH}, ${_provider})"
   log_info "================================================================"
 
-  local base_files_dir="${BENTO_BUILD_FILES_DIR:-${SCRIPT_DIR}/builds/build_files}"
-  local build_files_dir="${base_files_dir}/packer-windows-11-${ARCH}-${provider}"
-  local complete_dir="${BENTO_BUILD_COMPLETE_DIR:-${SCRIPT_DIR}/builds/build_complete}"
-  mkdir -p "${complete_dir}"
+  _build_files_dir="${BENTO_BUILD_FILES_DIR}/packer-windows-11-${ARCH}-${_provider}"
+  mkdir -p "${BENTO_BUILD_COMPLETE_DIR}"
 
-  local box_name="windows-11-${ARCH}.${provider}.box"
-  local target_box="${complete_dir}/${box_name}"
+  _box_name="windows-11-${ARCH}.${_provider}.box"
+  _target_box="${BENTO_BUILD_COMPLETE_DIR}/${_box_name}"
 
-  if [ "${provider}" = "qemu" ]; then
-    local src_img=""
-    local candidates=(
-      "${build_files_dir}/windows-11-amd64"
-      "${build_files_dir}/windows-11-${ARCH}"
-      "${build_files_dir}/box.img"
-    )
-
-    for candidate in "${candidates[@]}"; do
-      if [ -f "${candidate}" ]; then
-        src_img="${candidate}"
+  if [ "${_provider}" = "qemu" ]; then
+    _src_img=""
+    for _cand in "${_build_files_dir}/windows-11-amd64" "${_build_files_dir}/windows-11-${ARCH}" "${_build_files_dir}/box.img"; do
+      if [ -f "${_cand}" ]; then
+        _src_img="${_cand}"
         break
       fi
     done
 
     # Check builds/build_complete if packer's vagrant post-processor already built a base box
-    if [ -z "${src_img}" ]; then
-      local existing_box
-      existing_box=$(find "${complete_dir}" -name "*windows-11*.box" 2>/dev/null | head -n 1)
-      if [ -n "${existing_box}" ]; then
-        log_info "Extracting disk image from existing box (${existing_box}) for optimization..."
-        mkdir -p "${build_files_dir}"
-        tar -xf "${existing_box}" -C "${build_files_dir}" box_0.img 2>/dev/null || tar -xf "${existing_box}" -C "${build_files_dir}" box.img 2>/dev/null || true
-        if [ -f "${build_files_dir}/box_0.img" ]; then
-          mv -f "${build_files_dir}/box_0.img" "${build_files_dir}/box.img"
+    if [ -z "${_src_img}" ]; then
+      _existing_box=$(find "${BENTO_BUILD_COMPLETE_DIR}" "${SCRIPT_DIR}/builds/build_complete" -name "*windows-11*.box" 2>/dev/null | head -n 1)
+      if [ -n "${_existing_box}" ]; then
+        log_info "Extracting disk image from existing box (${_existing_box}) for optimization..."
+        mkdir -p "${_build_files_dir}"
+        tar -xf "${_existing_box}" -C "${_build_files_dir}" box_0.img 2>/dev/null || tar -xf "${_existing_box}" -C "${_build_files_dir}" box.img 2>/dev/null || true
+        if [ -f "${_build_files_dir}/box_0.img" ]; then
+          mv -f "${_build_files_dir}/box_0.img" "${_build_files_dir}/box.img"
         fi
-        if [ -f "${build_files_dir}/box.img" ]; then
-          src_img="${build_files_dir}/box.img"
+        if [ -f "${_build_files_dir}/box.img" ]; then
+          _src_img="${_build_files_dir}/box.img"
         fi
       fi
     fi
 
-    if [ -z "${src_img}" ]; then
-      log_error "Could not find QEMU disk image in ${build_files_dir}"
+    if [ -z "${_src_img}" ]; then
+      log_error "Could not find QEMU disk image in ${_build_files_dir}"
       exit 1
     fi
 
-    local orig_bytes
-    orig_bytes=$(get_file_size "${src_img}")
-    local orig_mb=$((orig_bytes / 1024 / 1024))
-    log_info "Step 1: Input disk image: ${src_img}"
-    log_info "        Original disk image size: ${orig_mb} MB ($((orig_mb / 1024)) GB)"
+    _orig_bytes=$(get_file_size "${_src_img}")
+    _orig_mb=$((_orig_bytes / 1024 / 1024))
+    log_info "Step 1: Input disk image: ${_src_img}"
+    log_info "        Original disk image size: ${_orig_mb} MB ($((_orig_mb / 1024)) GB)"
 
     # Step 2: Multi-threaded zero-block sparsification and cluster compression
-    # -c enables zlib cluster compression
-    # -S 4k unmaps and discards every 4KB block containing only zeroes
-    # -m 16 uses 16 parallel coroutines for high-speed conversion
-    # -W allows out-of-order writes
-    # -p shows real-time progress
-    local opt_img="${build_files_dir}/box_optimized.img"
+    _opt_img="${_build_files_dir}/box_optimized.img"
     log_info "Step 2: Multi-threaded sparsification (-S 4k) & zlib cluster compression (-c)..."
-    qemu-img convert -p -m 16 -W -O qcow2 -c -S 4k "${src_img}" "${opt_img}"
+    qemu-img convert -p -m 16 -W -O qcow2 -c -S 4k "${_src_img}" "${_opt_img}"
 
-    local opt_bytes
-    opt_bytes=$(get_file_size "${opt_img}")
-    local opt_mb=$((opt_bytes / 1024 / 1024))
-    local saved_mb=$((orig_mb - opt_mb))
-    log_success "Compressed disk image size: ${opt_mb} MB (Direct disk savings: ${saved_mb} MB)"
+    _opt_bytes=$(get_file_size "${_opt_img}")
+    _opt_mb=$((_opt_bytes / 1024 / 1024))
+    _saved_mb=$((_orig_mb - _opt_mb))
+    log_success "Compressed disk image size: ${_opt_mb} MB (Direct disk savings: ${_saved_mb} MB)"
 
-    mv -f "${opt_img}" "${build_files_dir}/box.img"
+    mv -f "${_opt_img}" "${_build_files_dir}/box.img"
 
-    local virt_gb
-    virt_gb=$(qemu-img info --output=json "${src_img}" | python3 -c "import sys, json; print(int(json.load(sys.stdin).get('virtual-size', 68719476736) / (1024**3)))" 2>/dev/null || echo "64")
+    _virt_gb=$(qemu-img info --output=json "${_src_img}" | python3 -c "import sys, json; print(int(json.load(sys.stdin).get('virtual-size', 68719476736) / (1024**3)))" 2>/dev/null || echo "64")
 
     # Step 3: Generate Vagrant metadata and template
-    # vagrant-qemu uses box_format: "libvirt" (v1 format)
-    local meta_provider="${provider}"
-    if [ "${provider}" = "qemu" ]; then
-      meta_provider="libvirt"
+    _meta_provider="${_provider}"
+    if [ "${_provider}" = "qemu" ]; then
+      _meta_provider="libvirt"
     fi
-    log_info "Step 3: Generating Vagrant metadata (${meta_provider}, virtual_size: ${virt_gb} GB) and Vagrantfile template..."
-    cat << EOF > "${build_files_dir}/metadata.json"
+    log_info "Step 3: Generating Vagrant metadata (${_meta_provider}, virtual_size: ${_virt_gb} GB) and Vagrantfile template..."
+    cat << EOF > "${_build_files_dir}/metadata.json"
 {
-  "provider": "${meta_provider}",
+  "provider": "${_meta_provider}",
   "format": "qcow2",
-  "virtual_size": ${virt_gb}
+  "virtual_size": ${_virt_gb}
 }
 EOF
 
-    cat << 'EOF' > "${build_files_dir}/Vagrantfile"
+    cat << 'EOF' > "${_build_files_dir}/Vagrantfile"
 Vagrant.configure("2") do |config|
   config.vm.guest = :windows
   config.vm.communicator = "winrm"
@@ -860,7 +972,8 @@ Vagrant.configure("2") do |config|
       extra_args = []
       extra_args.push("-bios", bios_path) if bios_path
       extra_args.push(
-        "-device", "nvme,serial=nvme0,drive=disk0",
+        "-device", "pcie-root-port,id=pcie.1,chassis=1,slot=1",
+        "-device", "nvme,serial=nvme0,drive=disk0,bus=pcie.1",
         "-device", "ramfb",
         "-device", "qemu-xhci",
         "-device", "usb-kbd",
@@ -910,100 +1023,117 @@ EOF
 
     # Step 4: Archive into .box with maximum level-9 compression and sparse support
     log_info "Step 4: Compacting into .box with sparse block preservation & level-9 compression..."
-    local tmp_box="${target_box}.tmp"
+    _tmp_box="${_target_box}.tmp"
 
-    local tar_cmd="tar"
-    local tar_sparse="--sparse"
+    _tar_cmd="tar"
+    _tar_sparse="--sparse"
     if command -v gtar >/dev/null 2>&1; then
-      tar_cmd="gtar"
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
-      tar_sparse=""
+      _tar_cmd="gtar"
+    else
+      case "$(uname -s)" in
+        Darwin*) _tar_sparse="" ;;
+      esac
     fi
 
     if command -v pigz >/dev/null 2>&1; then
       log_info "Using parallel pigz for maximum compression (-9) across all CPU cores..."
       (
-        cd "${build_files_dir}"
-        ${tar_cmd} ${tar_sparse} -I 'pigz -9' -cf "${tmp_box}" metadata.json Vagrantfile box.img
+        cd "${_build_files_dir}"
+        if [ -n "${_tar_sparse}" ]; then
+          ${_tar_cmd} "${_tar_sparse}" -I 'pigz -9' -cf "${_tmp_box}" metadata.json Vagrantfile box.img
+        else
+          ${_tar_cmd} -I 'pigz -9' -cf "${_tmp_box}" metadata.json Vagrantfile box.img
+        fi
       )
     else
       log_info "Using gzip -9 for maximum compression..."
       (
-        cd "${build_files_dir}"
-        GZIP="-9" ${tar_cmd} ${tar_sparse} -czf "${tmp_box}" metadata.json Vagrantfile box.img
+        cd "${_build_files_dir}"
+        if [ -n "${_tar_sparse}" ]; then
+          GZIP="-9" ${_tar_cmd} "${_tar_sparse}" -czf "${_tmp_box}" metadata.json Vagrantfile box.img
+        else
+          GZIP="-9" ${_tar_cmd} -czf "${_tmp_box}" metadata.json Vagrantfile box.img
+        fi
       )
     fi
 
-    mv -f "${tmp_box}" "${target_box}"
+    mv -f "${_tmp_box}" "${_target_box}"
 
     # Also link libvirt box to match vagrant provider convention
-    local libvirt_box="${complete_dir}/windows-11-${ARCH}.libvirt.box"
-    if [ "${target_box}" != "${libvirt_box}" ]; then
-      cp -f "${target_box}" "${libvirt_box}"
+    _libvirt_box="${BENTO_BUILD_COMPLETE_DIR}/windows-11-${ARCH}.libvirt.box"
+    if [ "${_target_box}" != "${_libvirt_box}" ]; then
+      cp -f "${_target_box}" "${_libvirt_box}"
     fi
 
-    local box_bytes
-    box_bytes=$(get_file_size "${target_box}")
-    local box_mb=$((box_bytes / 1024 / 1024))
-    local total_saved_mb=$((orig_mb - box_mb))
+    _box_bytes=$(get_file_size "${_target_box}")
+    _box_mb=$((_box_bytes / 1024 / 1024))
+    _total_saved_mb=$((_orig_mb - _box_mb))
 
-    echo ""
-    echo -e "${C_GREEN}${C_BOLD}================================================================${C_RESET}"
-    echo -e "${C_GREEN}${C_BOLD}  WINDOWS 11 VAGRANT .BOX OPTIMIZATION SUMMARY                 ${C_RESET}"
-    echo -e "${C_GREEN}${C_BOLD}================================================================${C_RESET}"
-    echo -e "  Target Box Path  : ${target_box}"
-    echo -e "  Libvirt Box Path : ${libvirt_box}"
-    echo -e "  Uncompressed Disk: ${orig_mb} MB ($((orig_mb / 1024)) GB)"
-    echo -e "  Optimized Disk   : ${opt_mb} MB ($((opt_mb / 1024)) GB)"
-    echo -e "  FINAL .BOX SIZE  : ${C_GREEN}${C_BOLD}${box_mb} MB ($((box_bytes / 1024 / 1024 / 1024)) GB)${C_RESET}"
-    echo -e "  Total Reduction  : ${C_GREEN}${C_BOLD}${total_saved_mb} MB reclaimed${C_RESET}"
-    echo -e "${C_GREEN}${C_BOLD}================================================================${C_RESET}"
+    printf "\n"
+    printf "%b================================================================%b\n" "${C_GREEN}${C_BOLD}" "${C_RESET}"
+    printf "%b  WINDOWS 11 VAGRANT .BOX OPTIMIZATION SUMMARY                 %b\n" "${C_GREEN}${C_BOLD}" "${C_RESET}"
+    printf "%b================================================================%b\n" "${C_GREEN}${C_BOLD}" "${C_RESET}"
+    printf "  Target Box Path  : %s\n" "${_target_box}"
+    printf "  Libvirt Box Path : %s\n" "${_libvirt_box}"
+    printf "  Uncompressed Disk: %s MB (%s GB)\n" "${_orig_mb}" "$((_orig_mb / 1024))"
+    printf "  Optimized Disk   : %s MB (%s GB)\n" "${_opt_mb}" "$((_opt_mb / 1024))"
+    printf "  FINAL .BOX SIZE  : %b%s MB (%s GB)%b\n" "${C_GREEN}${C_BOLD}" "${_box_mb}" "$((_box_bytes / 1024 / 1024 / 1024))" "${C_RESET}"
+    printf "  Total Reduction  : %b%s MB reclaimed%b\n" "${C_GREEN}${C_BOLD}" "${_total_saved_mb}" "${C_RESET}"
+    printf "%b================================================================%b\n" "${C_GREEN}${C_BOLD}" "${C_RESET}"
 
-  elif [ "${provider}" = "virtualbox" ]; then
-    local vdi_path
-    vdi_path=$(find "${build_files_dir}" -name "*.vdi" 2>/dev/null | head -n 1)
-    if [ -n "${vdi_path}" ]; then
+  elif [ "${_provider}" = "virtualbox" ]; then
+    _vdi_path=$(find "${_build_files_dir}" -name "*.vdi" 2>/dev/null | head -n 1)
+    if [ -n "${_vdi_path}" ]; then
       log_info "Compacting VirtualBox VDI disk to reclaim zeroed sectors..."
-      VBoxManage modifymedium disk "${vdi_path}" --compact
+      VBoxManage modifymedium disk "${_vdi_path}" --compact
     fi
     log_info "Packaging VirtualBox .box with maximum level-9 compression..."
-    local tmp_box="${target_box}.tmp"
+    _tmp_box="${_target_box}.tmp"
     if command -v pigz >/dev/null 2>&1; then
       (
-        cd "${build_files_dir}"
-        tar --sparse -I 'pigz -9' -cf "${tmp_box}" *
+        cd "${_build_files_dir}"
+        tar --sparse -I 'pigz -9' -cf "${_tmp_box}" ./*
       )
     else
       (
-        cd "${build_files_dir}"
-        GZIP="-9" tar --sparse -czf "${tmp_box}" *
+        cd "${_build_files_dir}"
+        GZIP="-9" tar --sparse -czf "${_tmp_box}" ./*
       )
     fi
-    mv -f "${tmp_box}" "${target_box}"
-    local box_bytes
-    box_bytes=$(get_file_size "${target_box}")
-    log_success "Created optimized box: ${target_box} ($((box_bytes / 1024 / 1024)) MB)"
+    mv -f "${_tmp_box}" "${_target_box}"
+    _box_bytes=$(get_file_size "${_target_box}")
+    log_success "Created optimized box: ${_target_box} ($((_box_bytes / 1024 / 1024)) MB)"
   fi
 }
 
 # Main build execution
 cmd_build() {
   log_info "Starting Windows 11 Build Pipeline:"
-  echo "  Architecture : ${ARCH}"
-  echo "  Provider     : ${PROVIDER}"
-  echo "  Headless     : ${HEADLESS}"
-  echo "  Debug        : ${DEBUG_MODE}"
+  printf "  Architecture : %s\n" "${ARCH}"
+  printf "  Provider     : %s\n" "${PROVIDER}"
+  printf "  Headless     : %s\n" "${HEADLESS}"
+  printf "  Debug        : %s\n" "${DEBUG_MODE}"
+  if [ "${HEADLESS}" = "false" ]; then
+    log_info "GUI Mode     : Active (QEMU graphical window will open automatically)"
+  else
+    log_info "GUI Mode     : Headless (view live via 'open vnc://127.0.0.1:<port>')"
+  fi
 
   # 1. Clean prior locks and processes
   cmd_clean
 
+  # Ensure VirtIO drivers are present for Windows guest
+  ensure_cidata
+
+  # Ensure OEM unattended volume is prepared
+  ensure_oem_iso
+
   # 2. Check and locate ISO
-  local iso_path
-  iso_path="$(find_iso)"
-  if [ -z "${iso_path}" ]; then
+  _iso_path="$(find_iso)"
+  if [ -z "${_iso_path}" ]; then
     log_warn "No Windows 11 ISO found locally. Packer will use the remote URL in pkrvars."
   else
-    log_info "Using local Windows 11 ISO: ${iso_path} ($(du -h "${iso_path}" | cut -f1))"
+    log_info "Using local Windows 11 ISO: ${_iso_path} ($(du -h "${_iso_path}" | cut -f1))"
   fi
 
   # 3. Setup background serial port multiplexer and logger
@@ -1014,56 +1144,62 @@ cmd_build() {
     log_info "Live serial output streaming enabled. Displaying serial log:"
     tail -f "${SERIAL_LOG}" &
     TAIL_PID=$!
-    trap 'kill "${TAIL_PID}" 2>/dev/null || true' EXIT
+    trap 'kill "${TAIL_PID}" 2>/dev/null || true' EXIT INT TERM
   fi
 
-  # 5. Locate pkrvars
-  local pkrvars="${SCRIPT_DIR}/os_pkrvars/windows/windows-11-${ARCH}.pkrvars.hcl"
-  if [ ! -f "${pkrvars}" ]; then
-    log_error "Configuration file ${pkrvars} does not exist."
-    exit 1
-  fi
-
+  # 5. Dedicated Windows 11 ARM64 build pipeline if available
   if [ "${ARCH}" = "aarch64" ] && [ "${PROVIDER}" = "qemu" ] && [ -f "${SCRIPT_DIR}/windows-11-arm64-packer/build.sh" ]; then
     log_info "Executing dedicated Windows 11 ARM64 QEMU build pipeline..."
-    "${SCRIPT_DIR}/windows-11-arm64-packer/build.sh"
+    HEADLESS="${HEADLESS}" DEBUG_MODE="${DEBUG_MODE}" STEP_MODE="${STEP_MODE}" "${SCRIPT_DIR}/windows-11-arm64-packer/build.sh"
     cmd_box "${PROVIDER}"
     log_success "Windows 11 build and box creation completed successfully!"
     return 0
   fi
 
+  # 6. Locate pkrvars for generic pipeline
+  _pkrvars="${SCRIPT_DIR}/os_pkrvars/windows/windows-11-${ARCH}.pkrvars.hcl"
+  if [ ! -f "${_pkrvars}" ]; then
+    log_error "Configuration file ${_pkrvars} does not exist."
+    exit 1
+  fi
+
   log_info "Validating Packer templates..."
-  packer validate -var-file="${pkrvars}" "${SCRIPT_DIR}/packer_templates"
+  packer validate -var-file="${_pkrvars}" "${SCRIPT_DIR}/packer_templates"
 
   log_info "Executing Packer Build for Windows 11 (${PROVIDER})..."
-  local pkr_opts=("-timestamp-ui" "-force" "-var-file=${pkrvars}")
+  set -- -timestamp-ui -force -var-file="${_pkrvars}"
 
-  local effective_iso="${CUSTOM_ISO:-${iso_path}}"
-  if [ -n "${effective_iso}" ]; then
-    pkr_opts+=("-var" "iso_url=file://${effective_iso}")
-    if [ -f "${effective_iso}.sha256" ]; then
-      pkr_opts+=("-var" "iso_checksum=$(cat "${effective_iso}.sha256")")
+  _effective_iso="${CUSTOM_ISO:-${_iso_path}}"
+  if [ -n "${_effective_iso}" ]; then
+    set -- "$@" -var "iso_url=file://${_effective_iso}"
+    if [ -s "${_effective_iso}.sha256" ]; then
+      set -- "$@" -var "iso_checksum=$(cat "${_effective_iso}.sha256")"
     elif [ -n "${PKR_VAR_iso_checksum:-}" ]; then
-      pkr_opts+=("-var" "iso_checksum=${PKR_VAR_iso_checksum}")
+      set -- "$@" -var "iso_checksum=${PKR_VAR_iso_checksum}"
     fi
   fi
 
   if [ "${PROVIDER}" = "qemu" ]; then
-    pkr_opts+=("-only=qemu.vm")
+    set -- "$@" "-only=qemu.vm"
+    if [ -n "${PKR_VAR_win11_oem_iso:-}" ]; then
+      set -- "$@" -var "win11_oem_iso=${PKR_VAR_win11_oem_iso}"
+    fi
   elif [ "${PROVIDER}" = "virtualbox" ]; then
-    pkr_opts+=("-only=virtualbox-iso.vm")
+    set -- "$@" "-only=virtualbox-iso.vm"
   fi
 
-  pkr_opts+=("-var" "headless=${HEADLESS}")
+  set -- "$@" -var "headless=${HEADLESS}"
   if [ "${DEBUG_MODE}" = "true" ]; then
-    pkr_opts+=("-debug")
     export PACKER_LOG=1
   fi
+  if [ "${STEP_MODE}" = "true" ]; then
+    set -- "$@" -debug
+  fi
 
-  log_info "Running: packer build ${pkr_opts[*]} ${SCRIPT_DIR}/packer_templates"
-  packer build "${pkr_opts[@]}" "${SCRIPT_DIR}/packer_templates"
+  log_info "Running: packer build $* ${SCRIPT_DIR}/packer_templates"
+  packer build "$@" "${SCRIPT_DIR}/packer_templates"
 
-  # 6. Apply post-build multi-stage size optimizations
+  # 7. Apply post-build multi-stage size optimizations
   cmd_box "${PROVIDER}"
 
   log_success "Windows 11 build and box creation completed successfully!"

--- a/windows-11-builder.sh
+++ b/windows-11-builder.sh
@@ -1,0 +1,861 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Windows 11 Automated Builder, Runner & Minimal Box Creation Tool for Bento
+#
+# Usage:
+#   ./windows-11-builder.sh [COMMAND] [OPTIONS]
+#
+# Commands:
+#   build          Build the Windows 11 box using Packer + auto-box compression (default)
+#   box            Compress, sparsify, and package VM disk into minimal .box
+#   run            Run the built VM / box directly with KVM, serial & networking
+#   serial         Connect via serial to debug the running VM in real time
+#   status         Show status of ISOs, build files, and running processes
+#   clean          Kill running VMs/Packer instances and clean temporary locks
+#
+# Options:
+#   --provider     qemu | virtualbox (default: auto-detected based on KVM)
+#   --arch         x86_64 | aarch64  (default: auto-detected host arch)
+#   --iso          Path to Windows 11 ISO (default: auto-detected)
+#   --headless     true | false (default: true)
+#   --debug        Enable Packer and hypervisor debug output
+#   --serial       Stream serial output to terminal during build
+#   --watch        Watch live serial log streaming (for serial command)
+#   --tail [N]     Display last N lines of serial log (default: 50)
+#   --send <CMD>   Send command string to serial console
+#   --memory <MB>  Memory for runner in MB (default: 6144)
+#   --cpus <N>     CPUs for runner (default: 4)
+#   --vnc <PORT>   VNC display port for runner (default: none / headless)
+# ==============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}"
+
+# ANSI Colors
+C_RESET="\033[0m"
+C_BOLD="\033[1m"
+C_RED="\033[31m"
+C_GREEN="\033[32m"
+C_YELLOW="\033[33m"
+C_BLUE="\033[34m"
+C_CYAN="\033[36m"
+C_MAGENTA="\033[35m"
+
+log_info()    { echo -e "${C_CYAN}${C_BOLD}==> [INFO]${C_RESET} $*"; }
+log_success() { echo -e "${C_GREEN}${C_BOLD}==> [SUCCESS]${C_RESET} $*"; }
+log_warn()    { echo -e "${C_YELLOW}${C_BOLD}==> [WARN]${C_RESET} $*"; }
+log_error()   { echo -e "${C_RED}${C_BOLD}==> [ERROR]${C_RESET} $*" >&2; }
+
+# Default Parameters
+COMMAND="build"
+ARCH="$(uname -m)"
+case "${ARCH}" in
+  x86_64|amd64) ARCH="x86_64" ;;
+  aarch64|arm64) ARCH="aarch64" ;;
+  *) log_error "Unsupported host architecture: ${ARCH}"; exit 1 ;;
+esac
+
+# Auto-detect hypervisor provider
+if [ -e "/dev/kvm" ] && [ -w "/dev/kvm" ]; then
+  PROVIDER="qemu"
+elif command -v VBoxManage >/dev/null 2>&1; then
+  PROVIDER="virtualbox"
+elif command -v qemu-system-${ARCH} >/dev/null 2>&1; then
+  PROVIDER="qemu"
+else
+  PROVIDER="qemu"
+fi
+
+HEADLESS="true"
+DEBUG_MODE="false"
+STREAM_SERIAL="false"
+SERIAL_WATCH="false"
+SERIAL_TAIL_LINES=""
+SERIAL_SEND_CMD=""
+VM_MEM="6144"
+VM_CPUS="4"
+VM_VNC=""
+CUSTOM_ISO=""
+SERIAL_SOCK="/tmp/windows-11-serial.sock"
+SERIAL_CLIENT_SOCK="/tmp/windows-11-serial-client.sock"
+SERIAL_LOG="${SCRIPT_DIR}/serial.log"
+PROXY_SCRIPT="${SCRIPT_DIR}/serial_proxy.py"
+
+# Parse CLI arguments
+while [ $# -gt 0 ]; do
+  case "$1" in
+    build|box|run|serial|status|clean)
+      COMMAND="$1"
+      shift
+      ;;
+    --provider)
+      PROVIDER="$2"
+      shift 2
+      ;;
+    --arch)
+      ARCH="$2"
+      shift 2
+      ;;
+    --iso)
+      CUSTOM_ISO="$2"
+      shift 2
+      ;;
+    --headless)
+      HEADLESS="$2"
+      shift 2
+      ;;
+    --debug)
+      DEBUG_MODE="true"
+      shift
+      ;;
+    --serial)
+      STREAM_SERIAL="true"
+      shift
+      ;;
+    --watch)
+      SERIAL_WATCH="true"
+      shift
+      ;;
+    --tail)
+      if [ $# -ge 2 ] && [[ "$2" =~ ^[0-9]+$ ]]; then
+        SERIAL_TAIL_LINES="$2"
+        shift 2
+      else
+        SERIAL_TAIL_LINES="50"
+        shift
+      fi
+      ;;
+    --send)
+      SERIAL_SEND_CMD="$2"
+      shift 2
+      ;;
+    --memory)
+      VM_MEM="$2"
+      shift 2
+      ;;
+    --cpus)
+      VM_CPUS="$2"
+      shift 2
+      ;;
+    --vnc)
+      VM_VNC="$2"
+      shift 2
+      ;;
+    -h|--help)
+      sed -n '/^# Usage:/,/^# ====/p' "${BASH_SOURCE[0]}" | head -n -1 | sed 's/^# //g' | sed 's/^#//g'
+      exit 0
+      ;;
+    *)
+      log_error "Unknown argument: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# Resolve ISO Path
+find_iso() {
+  if [ -n "${CUSTOM_ISO}" ] && [ -f "${CUSTOM_ISO}" ]; then
+    echo "${CUSTOM_ISO}"
+    return 0
+  fi
+  # Check local builds/iso first
+  local local_iso
+  local_iso=$(find "${SCRIPT_DIR}/builds/iso" -maxdepth 1 -name "windows-11-${ARCH}*.iso" 2>/dev/null | head -n 1)
+  if [ -n "${local_iso}" ] && [ -f "${local_iso}" ]; then
+    echo "${local_iso}"
+    return 0
+  fi
+  local_iso=$(find "${SCRIPT_DIR}/builds/iso" -maxdepth 1 -name "*win*11*${ARCH}*.iso" 2>/dev/null | head -n 1)
+  if [ -n "${local_iso}" ] && [ -f "${local_iso}" ]; then
+    echo "${local_iso}"
+    return 0
+  fi
+  local_iso=$(find "${SCRIPT_DIR}/builds/iso" -maxdepth 1 -name "*windows-11*.iso" 2>/dev/null | head -n 1)
+  if [ -n "${local_iso}" ] && [ -f "${local_iso}" ]; then
+    echo "${local_iso}"
+    return 0
+  fi
+  echo ""
+}
+
+# Clean stale locks and background processes
+cmd_clean() {
+  log_info "Cleaning up stale locks, temporary build files, and processes..."
+  rm -f "${SCRIPT_DIR}/builds/iso/"*.iso.lock 2>/dev/null || true
+  rm -f "${SERIAL_SOCK}" "${SERIAL_CLIENT_SOCK}" 2>/dev/null || true
+
+  # Kill background serial proxy
+  pkill -f "serial_proxy.py" 2>/dev/null || true
+
+  # Kill running packer instances for windows-11
+  pkill -f "packer build.*windows-11" 2>/dev/null || true
+
+  # Kill running QEMU instances for windows-11
+  pkill -f "qemu-system-.*windows-11" 2>/dev/null || true
+
+  # Clean VirtualBox VM if present
+  if command -v VBoxManage >/dev/null 2>&1; then
+    for vm in $(VBoxManage list runningvms 2>/dev/null | grep -i "windows-11" | cut -d'"' -f2); do
+      log_warn "Stopping running VirtualBox Windows 11 VM ($vm)..."
+      VBoxManage controlvm "$vm" poweroff 2>/dev/null || true
+      sleep 1
+    done
+    for vm in $(VBoxManage list vms 2>/dev/null | grep -i "windows-11" | cut -d'"' -f2); do
+      log_info "Unregistering VirtualBox Windows 11 VM ($vm)..."
+      VBoxManage unregistervm "$vm" --delete 2>/dev/null || true
+    done
+  fi
+  log_success "Cleanup complete."
+}
+
+# Start the serial multiplexer daemon
+start_serial_proxy() {
+  log_info "Starting serial console multiplexer daemon..."
+  pkill -f "serial_proxy.py" 2>/dev/null || true
+  rm -f "${SERIAL_CLIENT_SOCK}"
+
+  export SERIAL_SOCK="${SERIAL_SOCK}"
+  export SERIAL_CLIENT_SOCK="${SERIAL_CLIENT_SOCK}"
+  export SERIAL_LOG="${SERIAL_LOG}"
+
+  python3 "${PROXY_SCRIPT}" >/dev/null 2>&1 &
+  PROXY_PID=$!
+  sleep 0.5
+  if kill -0 "${PROXY_PID}" 2>/dev/null; then
+    log_success "Serial multiplexer running (PID: ${PROXY_PID})"
+    log_info "Serial logging active at: ${SERIAL_LOG}"
+  else
+    log_warn "Serial multiplexer could not start. Direct socket mode will be used."
+  fi
+}
+
+# Connect via serial to debug
+cmd_serial() {
+  # Handle --tail option
+  if [ -n "${SERIAL_TAIL_LINES}" ]; then
+    if [ -f "${SERIAL_LOG}" ]; then
+      log_info "Displaying last ${SERIAL_TAIL_LINES} lines of ${SERIAL_LOG}:"
+      tail -n "${SERIAL_TAIL_LINES}" "${SERIAL_LOG}"
+    else
+      log_warn "No serial log file found at ${SERIAL_LOG}"
+    fi
+    return 0
+  fi
+
+  # Handle --watch option
+  if [ "${SERIAL_WATCH}" = "true" ]; then
+    if [ -f "${SERIAL_LOG}" ]; then
+      log_info "Watching live serial log ${SERIAL_LOG} (Press Ctrl+C to exit):"
+      tail -f "${SERIAL_LOG}"
+    else
+      log_warn "No serial log file found at ${SERIAL_LOG}. Start build or run first."
+    fi
+    return 0
+  fi
+
+  local target_sock="${SERIAL_CLIENT_SOCK}"
+  local waited=0
+  while [ ! -S "${target_sock}" ] && [ ! -S "${SERIAL_SOCK}" ]; do
+    if [ ${waited} -ge 5 ]; then
+      break
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+
+  if [ -S "${SERIAL_CLIENT_SOCK}" ]; then
+    target_sock="${SERIAL_CLIENT_SOCK}"
+  elif [ -S "${SERIAL_SOCK}" ]; then
+    target_sock="${SERIAL_SOCK}"
+  fi
+
+  if [ ! -S "${target_sock}" ]; then
+    log_warn "Active serial socket (${SERIAL_SOCK}) is not currently open."
+    if [ -f "${SERIAL_LOG}" ] && [ -s "${SERIAL_LOG}" ]; then
+      log_info "Recent serial activity from ${SERIAL_LOG}:"
+      echo -e "${C_CYAN}----------------------------------------------------------------${C_RESET}"
+      tail -n 30 "${SERIAL_LOG}" 2>/dev/null || true
+      echo -e "${C_CYAN}----------------------------------------------------------------${C_RESET}"
+      log_info "To stream live serial output once the VM starts, use: ./windows-11-builder.sh serial --watch"
+      return 0
+    else
+      log_error "No active socket or serial log found. Run './windows-11-builder.sh build' or 'run' first."
+      return 1
+    fi
+  fi
+
+  # Handle --send option for non-interactive command execution
+  if [ -n "${SERIAL_SEND_CMD}" ]; then
+    log_info "Sending command to Windows 11 serial console: ${SERIAL_SEND_CMD}"
+    SERIAL_TARGET_SOCK="${target_sock}" CMD_TO_SEND="${SERIAL_SEND_CMD}" python3 -c '
+import socket, sys, os, time, select
+
+sock_path = os.environ.get("SERIAL_TARGET_SOCK", "/tmp/windows-11-serial-client.sock")
+cmd = os.environ.get("CMD_TO_SEND", "") + "
+"
+
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.connect(sock_path)
+s.setblocking(False)
+
+s.sendall(cmd.encode("utf-8"))
+
+end_time = time.time() + 3.0
+output = b""
+while time.time() < end_time:
+    r, _, _ = select.select([s], [], [], 0.2)
+    if s in r:
+        data = s.recv(4096)
+        if not data:
+            break
+        output += data
+
+s.close()
+sys.stdout.buffer.write(output)
+sys.stdout.flush()
+'
+    return 0
+  fi
+
+  # Interactive serial console session
+  echo -e "${C_YELLOW}${C_BOLD}================================================================${C_RESET}"
+  echo -e "${C_YELLOW}${C_BOLD}  CONNECTED TO WINDOWS 11 SERIAL CONSOLE (COM1)                ${C_RESET}"
+  echo -e "${C_YELLOW}  - Live terminal stream connected to VM COM1 serial port       ${C_RESET}"
+  echo -e "${C_YELLOW}  - To exit this console session: Press Ctrl+C                  ${C_RESET}"
+  echo -e "${C_YELLOW}${C_BOLD}================================================================${C_RESET}"
+
+  SERIAL_TARGET_SOCK="${target_sock}" python3 -c '
+import socket, sys, select, os, tty, termios
+
+sock_path = os.environ.get("SERIAL_TARGET_SOCK", "/tmp/windows-11-serial-client.sock")
+if not os.path.exists(sock_path):
+    sock_path = "/tmp/windows-11-serial.sock"
+
+try:
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.connect(sock_path)
+except Exception as e:
+    print(f"\033[31mError connecting to {sock_path}: {e}\033[0m")
+    sys.exit(1)
+
+old_settings = None
+is_tty = sys.stdin.isatty()
+
+try:
+    if is_tty:
+        old_settings = termios.tcgetattr(sys.stdin)
+        tty.setraw(sys.stdin.fileno())
+
+    try:
+        s.sendall(b"
+")
+    except Exception:
+        pass
+
+    while True:
+        watch_list = [s]
+        if is_tty:
+            watch_list.append(sys.stdin)
+
+        r, _, _ = select.select(watch_list, [], [], 0.5)
+        if s in r:
+            data = s.recv(4096)
+            if not data:
+                break
+            sys.stdout.buffer.write(data)
+            sys.stdout.flush()
+
+        if is_tty and sys.stdin in r:
+            user_input = sys.stdin.buffer.read(1)
+            if not user_input or user_input == b"\x03":
+                break
+            s.sendall(user_input)
+except KeyboardInterrupt:
+    pass
+finally:
+    if old_settings:
+        termios.tcsetattr(sys.stdin, termios.TCSADRAIN, old_settings)
+    s.close()
+    print("
+\033[33m[Serial connection closed]\033[0m")
+'
+}
+
+# Show status
+cmd_status() {
+  log_info "Windows 11 Bento Environment Status:"
+  echo "  Architecture   : ${ARCH}"
+  echo "  Provider       : ${PROVIDER}"
+  echo "  Serial Socket  : ${SERIAL_SOCK} (exists: $([ -S "${SERIAL_SOCK}" ] && echo yes || echo no))"
+  echo "  Client Socket  : ${SERIAL_CLIENT_SOCK} (exists: $([ -S "${SERIAL_CLIENT_SOCK}" ] && echo yes || echo no))"
+
+  if [ -f "${SERIAL_LOG}" ]; then
+    local log_lines
+    log_lines=$(wc -l < "${SERIAL_LOG}")
+    local log_bytes
+    log_bytes=$(wc -c < "${SERIAL_LOG}")
+    echo "  Serial Log     : ${SERIAL_LOG} (${log_bytes} bytes, ${log_lines} lines)"
+    if [ "${log_lines}" -gt 0 ]; then
+      local last_entry
+      last_entry=$(tail -n 1 "${SERIAL_LOG}" | tr '
+' ' ')
+      echo "  Last Log Entry : ${last_entry}"
+    fi
+  else
+    echo "  Serial Log     : Not yet created"
+  fi
+
+  local iso_path
+  iso_path="$(find_iso)"
+  if [ -n "${iso_path}" ]; then
+    local iso_sz
+    iso_sz=$(du -h "${iso_path}" | cut -f1)
+    echo "  ISO Located    : ${iso_path} (${iso_sz})"
+  else
+    echo "  ISO Located    : None found in builds/iso"
+  fi
+
+  echo ""
+  echo "Disk Images (builds/build_files/):"
+  local found_disks=0
+  for d in "${SCRIPT_DIR}/builds/build_files"/*/*windows-11* "${SCRIPT_DIR}/builds/build_files"/*/box*.img; do
+    if [ -f "$d" ]; then
+      local dsz
+      dsz=$(du -h "$d" | cut -f1)
+      local dbytes
+      dbytes=$(stat -c %s "$d")
+      echo -e "  - $(basename "$(dirname "$d")")/$(basename "$d") : ${C_CYAN}${dsz}${C_RESET} (${dbytes} bytes)"
+      found_disks=1
+    fi
+  done
+  if [ ${found_disks} -eq 0 ]; then
+    echo "  (None found)"
+  fi
+
+  echo ""
+  echo "Running Processes:"
+  ps aux | grep -E "packer.*windows-11|qemu-system-.*windows-11|serial_proxy.py" | grep -v grep || echo "  (None)"
+
+  echo ""
+  echo "Built Boxes (builds/build_complete/):"
+  if ls "${SCRIPT_DIR}/builds/build_complete/"*windows-11*.box 1>/dev/null 2>&1; then
+    for b in "${SCRIPT_DIR}/builds/build_complete/"*windows-11*.box; do
+      local bsz
+      bsz=$(du -h "$b" | cut -f1)
+      local bsz_bytes
+      bsz_bytes=$(stat -c %s "$b")
+      echo -e "  - $(basename "$b") : ${C_GREEN}${C_BOLD}${bsz}${C_RESET} (${bsz_bytes} bytes)"
+    done
+  else
+    echo "  (No .box files built yet)"
+  fi
+}
+
+# Run built box/disk directly with KVM, serial and port forwards
+cmd_run() {
+  local disk_img=""
+  local candidates=(
+    "${SCRIPT_DIR}/builds/build_files/packer-windows-11-${ARCH}-qemu/windows-11-amd64"
+    "${SCRIPT_DIR}/builds/build_files/packer-windows-11-${ARCH}-qemu/windows-11-${ARCH}"
+    "${SCRIPT_DIR}/builds/build_files/packer-windows-11-${ARCH}-qemu/box.img"
+    "${SCRIPT_DIR}/builds/build_files/packer-windows-11-${ARCH}-qemu/box_optimized.img"
+  )
+
+  for candidate in "${candidates[@]}"; do
+    if [ -f "${candidate}" ]; then
+      disk_img="${candidate}"
+      break
+    fi
+  done
+
+  # Also check if box exists and extract if necessary
+  if [ -z "${disk_img}" ]; then
+    local box_file
+    box_file=$(find "${SCRIPT_DIR}/builds/build_complete" -name "*windows-11*.box" 2>/dev/null | head -n 1)
+    if [ -n "${box_file}" ]; then
+      log_info "Extracting box.img from ${box_file}..."
+      local extract_dir="${SCRIPT_DIR}/builds/build_files/packer-windows-11-${ARCH}-qemu"
+      mkdir -p "${extract_dir}"
+      tar -xf "${box_file}" -C "${extract_dir}" box.img 2>/dev/null || true
+      if [ -f "${extract_dir}/box.img" ]; then
+        disk_img="${extract_dir}/box.img"
+      fi
+    fi
+  fi
+
+  if [ -z "${disk_img}" ]; then
+    log_error "No built disk image found. Run './windows-11-builder.sh build' first."
+    exit 1
+  fi
+
+  # Find UEFI firmware code and vars
+  local efi_code=""
+  local efi_vars=""
+  if [ "${ARCH}" = "x86_64" ]; then
+    local efi_candidates=(
+      "/usr/local/share/qemu/edk2-x86_64-code.fd"
+      "/usr/share/OVMF/OVMF_CODE.fd"
+      "/usr/share/ovmf/OVMF.fd"
+    )
+    for c in "${efi_candidates[@]}"; do
+      if [ -f "$c" ]; then efi_code="$c"; break; fi
+    done
+    local var_candidates=(
+      "/usr/local/share/qemu/edk2-i386-vars.fd"
+      "/usr/share/OVMF/OVMF_VARS.fd"
+    )
+    for v in "${var_candidates[@]}"; do
+      if [ -f "$v" ]; then efi_vars="$v"; break; fi
+    done
+  else
+    local efi_candidates=(
+      "/usr/local/share/qemu/edk2-aarch64-code.fd"
+      "/usr/share/AAVMF/AAVMF_CODE.fd"
+    )
+    for c in "${efi_candidates[@]}"; do
+      if [ -f "$c" ]; then efi_code="$c"; break; fi
+    done
+    local var_candidates=(
+      "/usr/local/share/qemu/edk2-arm-vars.fd"
+      "/usr/share/AAVMF/AAVMF_VARS.fd"
+    )
+    for v in "${var_candidates[@]}"; do
+      if [ -f "$v" ]; then efi_vars="$v"; break; fi
+    done
+  fi
+
+  log_info "Starting Windows 11 VM directly with QEMU (${ARCH})..."
+  echo "  Disk Image     : ${disk_img}"
+  echo "  UEFI Firmware  : ${efi_code:-'(none)'}"
+  echo "  CPUs / Memory  : ${VM_CPUS} CPUs, ${VM_MEM} MB RAM"
+  echo "  WinRM Forward  : 127.0.0.1:5985"
+  echo "  RDP Forward    : 127.0.0.1:3389"
+  echo "  SSH Forward    : 127.0.0.1:2222"
+  echo "  Serial Console : ${SERIAL_SOCK}"
+
+  # Clean stale socket
+  rm -f "${SERIAL_SOCK}"
+
+  # Start serial multiplexer
+  start_serial_proxy
+
+  echo -e "${C_GREEN}${C_BOLD}VM is starting. In another terminal, run './windows-11-builder.sh serial' to connect.${C_RESET}"
+
+  local qemu_cmd=(
+    "qemu-system-${ARCH}"
+    "-name" "windows-11-${ARCH}"
+    "-machine" "q35,accel=kvm"
+    "-cpu" "host"
+    "-smp" "${VM_CPUS}"
+    "-m" "${VM_MEM}"
+  )
+
+  if [ -n "${efi_code}" ]; then
+    qemu_cmd+=("-drive" "if=pflash,format=raw,readonly=on,file=${efi_code}")
+  fi
+
+  # Setup writable NVRAM efivars
+  local disk_dir
+  disk_dir="$(dirname "${disk_img}")"
+  local run_vars="${disk_dir}/efivars_run.fd"
+  if [ -f "${disk_dir}/efivars.fd" ]; then
+    cp -f "${disk_dir}/efivars.fd" "${run_vars}"
+    qemu_cmd+=("-drive" "if=pflash,format=raw,file=${run_vars}")
+  elif [ -n "${efi_vars}" ]; then
+    cp -f "${efi_vars}" "${run_vars}"
+    qemu_cmd+=("-drive" "if=pflash,format=raw,file=${run_vars}")
+  fi
+
+  qemu_cmd+=(
+    "-drive" "file=${disk_img},if=none,id=disk0,cache=writeback,discard=unmap"
+    "-device" "ide-hd,drive=disk0,bus=ide.0"
+    "-netdev" "user,id=user.0,hostfwd=tcp::5985-:5985,hostfwd=tcp::3389-:3389,hostfwd=tcp::2222-:22"
+    "-device" "virtio-net-pci,netdev=user.0"
+    "-device" "qemu-xhci"
+    "-device" "usb-kbd"
+    "-device" "usb-tablet"
+    "-vga" "std"
+  )
+
+  if [ -n "${VM_VNC}" ]; then
+    qemu_cmd+=("-vnc" ":${VM_VNC}")
+    log_info "VNC display accessible on port 590${VM_VNC}"
+  elif [ "${HEADLESS}" = "true" ]; then
+    qemu_cmd+=("-display" "none")
+  fi
+
+  qemu_cmd+=(
+    "-chardev" "socket,id=ser0,path=${SERIAL_SOCK},server=on,wait=off"
+    "-serial" "chardev:ser0"
+  )
+
+  exec "${qemu_cmd[@]}"
+}
+
+# Multi-stage aggressive box size reduction pipeline
+cmd_box() {
+  local provider="${1:-${PROVIDER}}"
+  log_info "================================================================"
+  log_info "  AGGRESSIVE VAGRANT .BOX SIZE REDUCTION PIPELINE (${ARCH}, ${provider})"
+  log_info "================================================================"
+
+  local build_files_dir="${SCRIPT_DIR}/builds/build_files/packer-windows-11-${ARCH}-${provider}"
+  local complete_dir="${SCRIPT_DIR}/builds/build_complete"
+  mkdir -p "${complete_dir}"
+
+  local box_name="windows-11-${ARCH}.${provider}.box"
+  local target_box="${complete_dir}/${box_name}"
+
+  if [ "${provider}" = "qemu" ]; then
+    local src_img=""
+    local candidates=(
+      "${build_files_dir}/windows-11-amd64"
+      "${build_files_dir}/windows-11-${ARCH}"
+      "${build_files_dir}/box.img"
+    )
+
+    for candidate in "${candidates[@]}"; do
+      if [ -f "${candidate}" ]; then
+        src_img="${candidate}"
+        break
+      fi
+    done
+
+    # Check builds/build_complete if packer's vagrant post-processor already built a base box
+    if [ -z "${src_img}" ]; then
+      local existing_box
+      existing_box=$(find "${complete_dir}" -name "*windows-11*.box" 2>/dev/null | head -n 1)
+      if [ -n "${existing_box}" ]; then
+        log_info "Extracting disk image from existing box (${existing_box}) for optimization..."
+        mkdir -p "${build_files_dir}"
+        tar -xf "${existing_box}" -C "${build_files_dir}" box.img 2>/dev/null || true
+        if [ -f "${build_files_dir}/box.img" ]; then
+          src_img="${build_files_dir}/box.img"
+        fi
+      fi
+    fi
+
+    if [ -z "${src_img}" ]; then
+      log_error "Could not find QEMU disk image in ${build_files_dir}"
+      exit 1
+    fi
+
+    local orig_bytes
+    orig_bytes=$(stat -c %s "${src_img}")
+    local orig_mb=$((orig_bytes / 1024 / 1024))
+    log_info "Step 1: Input disk image: ${src_img}"
+    log_info "        Original disk image size: ${orig_mb} MB ($((orig_mb / 1024)) GB)"
+
+    # Step 2: Multi-threaded zero-block sparsification and cluster compression
+    # -c enables zlib cluster compression
+    # -S 4k unmaps and discards every 4KB block containing only zeroes
+    # -m 16 uses 16 parallel coroutines for high-speed conversion
+    # -W allows out-of-order writes
+    # -p shows real-time progress
+    local opt_img="${build_files_dir}/box_optimized.img"
+    log_info "Step 2: Multi-threaded sparsification (-S 4k) & zlib cluster compression (-c)..."
+    qemu-img convert -p -m 16 -W -O qcow2 -c -S 4k "${src_img}" "${opt_img}"
+
+    local opt_bytes
+    opt_bytes=$(stat -c %s "${opt_img}")
+    local opt_mb=$((opt_bytes / 1024 / 1024))
+    local saved_mb=$((orig_mb - opt_mb))
+    log_success "Compressed disk image size: ${opt_mb} MB (Direct disk savings: ${saved_mb} MB)"
+
+    mv -f "${opt_img}" "${build_files_dir}/box.img"
+
+    local virt_gb
+    virt_gb=$(qemu-img info --output=json "${src_img}" | python3 -c "import sys, json; print(int(json.load(sys.stdin).get('virtual-size', 68719476736) / (1024**3)))" 2>/dev/null || echo "64")
+
+    # Step 3: Generate Vagrant metadata and template
+    log_info "Step 3: Generating Vagrant metadata (virtual_size: ${virt_gb} GB) and Vagrantfile template..."
+    cat << EOF > "${build_files_dir}/metadata.json"
+{
+  "provider": "libvirt",
+  "format": "qcow2",
+  "virtual_size": ${virt_gb}
+}
+EOF
+
+    cat << 'EOF' > "${build_files_dir}/Vagrantfile"
+Vagrant.configure("2") do |config|
+  config.vm.guest = :windows
+  config.vm.communicator = "winrm"
+  config.vm.boot_timeout = 600
+  config.winrm.username = "vagrant"
+  config.winrm.password = "vagrant"
+  config.winrm.retry_limit = 30
+  config.winrm.retry_delay = 10
+  config.ssh.username = "vagrant"
+  config.ssh.password = "vagrant"
+
+  config.vm.network :forwarded_port, guest: 22, host: 2222, id: 'ssh', auto_correct: true
+  config.vm.network :forwarded_port, guest: 3389, host: 3389, id: 'rdp', auto_correct: true
+  config.vm.network :forwarded_port, guest: 5985, host: 5985, id: 'winrm', auto_correct: true
+
+  # On Windows with libvirt, 9p is not natively supported. Synced folder is disabled by default unless SMB/rsync is configured.
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  config.vm.provider :libvirt do |lv|
+    lv.cpus = 4
+    lv.memory = 6144
+    lv.video_type = "virtio"
+    lv.nic_model_type = "virtio"
+    lv.driver = "kvm"
+  end
+end
+EOF
+
+    # Step 4: Archive into .box with maximum level-9 compression and sparse support
+    log_info "Step 4: Compacting into .box with sparse block preservation & level-9 compression..."
+    local tmp_box="${target_box}.tmp"
+
+    if command -v pigz >/dev/null 2>&1; then
+      log_info "Using parallel pigz for maximum compression (-9) across all CPU cores..."
+      (
+        cd "${build_files_dir}"
+        tar --sparse -I 'pigz -9' -cf "${tmp_box}" metadata.json Vagrantfile box.img
+      )
+    else
+      log_info "Using gzip -9 for maximum compression..."
+      (
+        cd "${build_files_dir}"
+        GZIP="-9" tar --sparse -czf "${tmp_box}" metadata.json Vagrantfile box.img
+      )
+    fi
+
+    mv -f "${tmp_box}" "${target_box}"
+
+    # Also link libvirt box to match vagrant provider convention
+    local libvirt_box="${complete_dir}/windows-11-${ARCH}.libvirt.box"
+    if [ "${target_box}" != "${libvirt_box}" ]; then
+      cp -f "${target_box}" "${libvirt_box}"
+    fi
+
+    local box_bytes
+    box_bytes=$(stat -c %s "${target_box}")
+    local box_mb=$((box_bytes / 1024 / 1024))
+    local total_saved_mb=$((orig_mb - box_mb))
+
+    echo ""
+    echo -e "${C_GREEN}${C_BOLD}================================================================${C_RESET}"
+    echo -e "${C_GREEN}${C_BOLD}  WINDOWS 11 VAGRANT .BOX OPTIMIZATION SUMMARY                 ${C_RESET}"
+    echo -e "${C_GREEN}${C_BOLD}================================================================${C_RESET}"
+    echo -e "  Target Box Path  : ${target_box}"
+    echo -e "  Libvirt Box Path : ${libvirt_box}"
+    echo -e "  Uncompressed Disk: ${orig_mb} MB ($((orig_mb / 1024)) GB)"
+    echo -e "  Optimized Disk   : ${opt_mb} MB ($((opt_mb / 1024)) GB)"
+    echo -e "  FINAL .BOX SIZE  : ${C_GREEN}${C_BOLD}${box_mb} MB ($((box_bytes / 1024 / 1024 / 1024)) GB)${C_RESET}"
+    echo -e "  Total Reduction  : ${C_GREEN}${C_BOLD}${total_saved_mb} MB reclaimed${C_RESET}"
+    echo -e "${C_GREEN}${C_BOLD}================================================================${C_RESET}"
+
+  elif [ "${provider}" = "virtualbox" ]; then
+    local vdi_path
+    vdi_path=$(find "${build_files_dir}" -name "*.vdi" 2>/dev/null | head -n 1)
+    if [ -n "${vdi_path}" ]; then
+      log_info "Compacting VirtualBox VDI disk to reclaim zeroed sectors..."
+      VBoxManage modifymedium disk "${vdi_path}" --compact
+    fi
+    log_info "Packaging VirtualBox .box with maximum level-9 compression..."
+    local tmp_box="${target_box}.tmp"
+    if command -v pigz >/dev/null 2>&1; then
+      (
+        cd "${build_files_dir}"
+        tar --sparse -I 'pigz -9' -cf "${tmp_box}" *
+      )
+    else
+      (
+        cd "${build_files_dir}"
+        GZIP="-9" tar --sparse -czf "${tmp_box}" *
+      )
+    fi
+    mv -f "${tmp_box}" "${target_box}"
+    local box_bytes
+    box_bytes=$(stat -c %s "${target_box}")
+    log_success "Created optimized box: ${target_box} ($((box_bytes / 1024 / 1024)) MB)"
+  fi
+}
+
+# Main build execution
+cmd_build() {
+  log_info "Starting Windows 11 Build Pipeline:"
+  echo "  Architecture : ${ARCH}"
+  echo "  Provider     : ${PROVIDER}"
+  echo "  Headless     : ${HEADLESS}"
+  echo "  Debug        : ${DEBUG_MODE}"
+
+  # 1. Clean prior locks and processes
+  cmd_clean
+
+  # 2. Check and locate ISO
+  local iso_path
+  iso_path="$(find_iso)"
+  if [ -z "${iso_path}" ]; then
+    log_warn "No Windows 11 ISO found locally. Packer will use the remote URL in pkrvars."
+  else
+    log_info "Using local Windows 11 ISO: ${iso_path} ($(du -h "${iso_path}" | cut -f1))"
+  fi
+
+  # 3. Setup background serial port multiplexer and logger
+  start_serial_proxy
+
+  # 4. If stream serial requested, tail serial.log in background
+  if [ "${STREAM_SERIAL}" = "true" ]; then
+    log_info "Live serial output streaming enabled. Displaying serial log:"
+    tail -f "${SERIAL_LOG}" &
+    TAIL_PID=$!
+    trap 'kill "${TAIL_PID}" 2>/dev/null || true' EXIT
+  fi
+
+  # 5. Locate pkrvars
+  local pkrvars="${SCRIPT_DIR}/os_pkrvars/windows/windows-11-${ARCH}.pkrvars.hcl"
+  if [ ! -f "${pkrvars}" ]; then
+    log_error "Configuration file ${pkrvars} does not exist."
+    exit 1
+  fi
+
+  log_info "Validating Packer templates..."
+  packer validate -var-file="${pkrvars}" "${SCRIPT_DIR}/packer_templates"
+
+  log_info "Executing Packer Build for Windows 11 (${PROVIDER})..."
+  local pkr_opts=("-timestamp-ui" "-force" "-var-file=${pkrvars}")
+
+  if [ -n "${CUSTOM_ISO}" ]; then
+    pkr_opts+=("-var" "iso_url=file://${CUSTOM_ISO}")
+  fi
+
+  if [ "${PROVIDER}" = "qemu" ]; then
+    pkr_opts+=("-only=qemu.vm")
+  elif [ "${PROVIDER}" = "virtualbox" ]; then
+    pkr_opts+=("-only=virtualbox-iso.vm")
+  fi
+
+  pkr_opts+=("-var" "headless=${HEADLESS}")
+  if [ "${DEBUG_MODE}" = "true" ]; then
+    pkr_opts+=("-debug")
+    export PACKER_LOG=1
+  fi
+
+  log_info "Running: packer build ${pkr_opts[*]} ${SCRIPT_DIR}/packer_templates"
+  packer build "${pkr_opts[@]}" "${SCRIPT_DIR}/packer_templates"
+
+  # 6. Apply post-build multi-stage size optimizations
+  cmd_box "${PROVIDER}"
+
+  log_success "Windows 11 build and box creation completed successfully!"
+}
+
+# Main Entrypoint
+case "${COMMAND}" in
+  build)  cmd_build ;;
+  box)    cmd_box "${PROVIDER}" ;;
+  run)    cmd_run ;;
+  serial) cmd_serial ;;
+  status) cmd_status ;;
+  clean)  cmd_clean ;;
+  *)
+    log_error "Unknown command: ${COMMAND}"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
- Add WINDOWS.md documentation covering disk minification, lifecycle operations, and shared folders
- Add windows-11-builder.sh for automated build, runner, box packaging, and real-time serial debugging
- Implement aggressive multi-layer disk minification (CompactOS, reserved storage disabled, hibernation disabled, WinRE purge, AppX debloat, WinSxS cleanup, zero-fill, and pigz-9 compression) reducing .box size from 16-20+ GB down to 9.0 GB
- Fix Windows 11 client serial port by disabling kernel EMS, enabling reliable COM1 logging
- Configure OpenSSH server and Vagrant insecure public key for passwordless vagrant ssh
- Add virtual_size metadata for seamless vagrant-libvirt integration

## Description
Windows support. I also have ARM support `./windows-11-builder.sh --arch aarch64`. Windows Server doesn't have an official ARM version so if you're running this on normal hypervisors on macOS you likely require this.

## Related Issue
N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
